### PR TITLE
fix: 修复 PyInstaller 打包后的多进程问题

### DIFF
--- a/parser-Python/uast/builder.py
+++ b/parser-Python/uast/builder.py
@@ -1,6 +1,7 @@
 import ast
 import argparse
 import os
+import sys
 import warnings
 import time
 import multiprocessing
@@ -35,6 +36,9 @@ def _parse_file_worker(args):
     
     Returns:
         tuple: (filepath, elapsed_time, success, error_msg)
+    
+    Note: This function must be importable at module level for multiprocessing
+    to work correctly in frozen (PyInstaller) environments.
     """
     filepath, target_file = args
     start_time = time.time()
@@ -243,7 +247,17 @@ def main():
 
 
 if __name__ == "__main__":
+    # PyInstaller support: Fix multiprocessing in frozen environments
+    if getattr(sys, 'frozen', False):
+        multiprocessing.freeze_support()
+        try:
+            multiprocessing.set_start_method('spawn', force=True)
+        except (RuntimeError, ValueError):
+            # Start method already set, ignore
+            pass
+   
     main()
+
 
 # ./dist/builder --rootDir="/Users/ariel/code/language-maturity-benchmark/xast-python/benchmark-python/case" --singleFileParse=False --output="/Users/ariel/code/uast/UAST4Python/output"
 # pyinstaller --onefile --paths .venv/lib/python3.13/site-packages ./uast/builder.py


### PR DESCRIPTION
## Summary by Sourcery

Fix multiprocessing compatibility when using PyInstaller by enabling freeze support and enforcing the spawn start method, and document import requirements for worker functions.

Bug Fixes:
- Enable multiprocessing.freeze_support and set the start method to spawn in frozen (PyInstaller) environments to prevent multi-process failures.

Enhancements:
- Add a docstring note that the worker function must be importable at module level for multiprocessing to work correctly in frozen builds.