### PR TITLE
fixbug: Differentiate VariableDeclaration and AssignmentExpression usage

### DIFF
--- a/parser-Python/uast/visitor.py
+++ b/parser-Python/uast/visitor.py
@@ -159,13 +159,11 @@ class UASTTransformer(ast.NodeTransformer):
                         id = self.packPos(node.targets[index].elts[i], self.visit(node.targets[index].elts[i]))
                         init = self.packPos(node.value.elts[i], self.visit(node.value.elts[i]))
                         exprs.append(
-                            UNode.VariableDeclaration(UNode.SourceLocation(), UNode.Meta(), id, init, False,
-                                                      UNode.DynamicType(UNode.SourceLocation(), UNode.Meta())))
+                            UNode.AssignmentExpression(UNode.SourceLocation(), UNode.Meta(), id, init, '='))
             else:  # a = b = 3
                 id = self.packPos(node.targets[index], self.visit(node.targets[index]))
                 init = self.packPos(node.value, self.visit(node.value))
-                exprs.append(UNode.VariableDeclaration(UNode.SourceLocation(), UNode.Meta(), id, init, False,
-                                                       UNode.DynamicType(UNode.SourceLocation(), UNode.Meta())))
+                exprs.append(UNode.AssignmentExpression(UNode.SourceLocation(), UNode.Meta(), id, init, '='))
         return exprs
 
     def visit_AsyncFunctionDef(self, node):


### PR DESCRIPTION
- Use VariableDeclaration only for function parameters
- Use AssignmentExpression for all assignment statements

## Summary by Sourcery

Bug Fixes:
- Replace UNode.VariableDeclaration with UNode.AssignmentExpression in visit_Assign for tuple unpacking and chained assignments