### PR TITLE
fix bug: add support for inf/nan

### DIFF
--- a/parser-Python/uast/visitor.py
+++ b/parser-Python/uast/visitor.py
@@ -1,6 +1,6 @@
 import ast
 import sys
-
+import math
 import uast.asttype as UNode
 
 
@@ -325,7 +325,14 @@ class UASTTransformer(ast.NodeTransformer):
         elif isinstance(node.value, bytes):
             literal_type = 'bytes'
         elif isinstance(node.value, float):
-            literal_type = 'float'
+            if math.isinf(node.value):
+                node.value = 'inf' if node.value > 0 else '-inf'
+                literal_type = 'string'
+            elif math.isnan(node.value):
+                node.value = 'nan'
+                literal_type = 'string'
+            else:
+                literal_type = 'float'
         if literal_type is not None:
             return self.packPos(node, UNode.Literal(UNode.SourceLocation(), UNode.Meta(), node.value, literal_type))
         else:


### PR DESCRIPTION
for testcase like below:
~~~python
def test_float():
    value_1 = float("3.14")
    value_2 = float(1e30000)
~~~
the current parser will output a invalid json format, which may casue error when using it for analysis.

## Summary by Sourcery

Bug Fixes:
- Handle infinite and NaN float constants by converting them to string literals