### PR TITLE
fix: add `IsDefaultImport` meta field to identify default import

### DIFF
--- a/parser-Go/uast/meta.go
+++ b/parser-Go/uast/meta.go
@@ -1,10 +1,11 @@
 package uast
 
 type Meta struct {
-	Type          Type   `json:"type,omitempty"`
-	Async         bool   `json:"async,omitempty"`
-	Defer         bool   `json:"defer,omitempty"`
-	IsRestElement bool   `json:"isRestElement,omitempty"`
-	ReceiveCls    string `json:"ReceiveCls"`
-	IsInterface   bool   `json:"isInterface,omitempty"`
+	Type            Type   `json:"type,omitempty"`
+	Async           bool   `json:"async,omitempty"`
+	Defer           bool   `json:"defer,omitempty"`
+	IsRestElement   bool   `json:"isRestElement,omitempty"`
+	ReceiveCls      string `json:"ReceiveCls"`
+	IsInterface     bool   `json:"isInterface,omitempty"`
+	IsDefaultImport bool   `json:"isDefaultImport,omitempty"`
 }

--- a/parser-Go/uast/visitor.go
+++ b/parser-Go/uast/visitor.go
@@ -33,6 +33,9 @@ func (u *Builder) VisitImportSpec(node *ast.ImportSpec) UNode {
 			Cloned:        false,
 			VarType:       &DynamicType{Type: "DynamicType"},
 			VariableParam: false,
+			Meta: Meta{
+				IsDefaultImport: true,
+			},
 		}
 	} else {
 		localName := node.Name.Name
@@ -61,7 +64,7 @@ func (u *Builder) VisitImportSpec(node *ast.ImportSpec) UNode {
 						LiteralType: "string",
 					},
 				}, node.Path),
-				Cloned:        true,
+				Cloned:        false,
 				VarType:       &DynamicType{Type: "DynamicType"},
 				VariableParam: false,
 			}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `Meta.IsDefaultImport` and marks default imports accordingly; sets `Cloned=false` for generated import variable declarations.
> 
> - **uast/meta**:
>   - Add `Meta.IsDefaultImport` field.
> - **uast/visitor**:
>   - In `VisitImportSpec` (default import), include `Meta{IsDefaultImport: true}` on the created `VariableDeclaration`.
>   - Set `Cloned: false` for generated `VariableDeclaration` in named import case (non-dot).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45c503ca2c7214f261c3045f8ff619d6336bd4fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Add metadata to identify default imports in the Go UAST builder and adjust import node cloning behavior.

New Features:
- Introduce an IsDefaultImport metadata flag on UAST nodes to mark default imports.

Bug Fixes:
- Ensure import nodes created for named imports are not incorrectly marked as cloned.