### PR TITLE
several features and bugfix

### DIFF
--- a/parser-Java-Js/src/frontend/java/ASTBuilder.ts
+++ b/parser-Java-Js/src/frontend/java/ASTBuilder.ts
@@ -1216,6 +1216,12 @@ export class ASTBuilder
     //     : variableModifier* typeType annotation* '...' variableDeclaratorId
     public visitLastFormalParameter(ctx: JP.LastFormalParameterContext): UAST.Instruction {
         const leftType = this.visit(ctx.typeType()) as UAST.Type;
+        if (ctx.children?.length === 3 && ctx.children[1].text === '...') {
+            if (!leftType._meta) {
+                leftType._meta = {}
+            }
+            leftType._meta.varargs = true
+        }
         this.typesState.push(leftType);
         const varId = this.visit(ctx.variableDeclaratorId()) as UAST.Identifier;
         const type = this.typesState.pop();


### PR DESCRIPTION
1. support array type
2. bugfix for negative number
3. bugfix for .class access
4. bugfix for VariableDeclaration loc
5. support varargs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds array type and varargs support, folds unary +/- correctly, fixes type `.class` access, and adjusts VariableDeclaration location metadata.
> 
> - **Parsing/Types**:
>   - Support array types in `visitTypeType` (wrap base type with `UAST.arrayType`).
>   - Mark varargs in `visitLastFormalParameter` via `leftType._meta.varargs = true`.
> - **Expressions**:
>   - Fold unary minus into negative numeric literals; pass-through unary plus; keep other prefixes as unary expressions.
> - **Member Access**:
>   - Use `class` (not `Class`) for type `.class` literals in `visitPrimary`.
> - **Source Locations**:
>   - Adjust `VariableDeclaration` end column when no initializer via `adJustNodeLoc`, invoked after node creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 875a4ec41e36208a0da3328be6c659a2a30ddb50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Support Java array type syntax in the AST builder and improve handling of unary expressions and member access for class literals.

New Features:
- Add support for array types in Java type parsing and representation.

Bug Fixes:
- Correct unary minus handling so negative numeric literals are represented with proper literal values instead of generic unary expressions.
- Handle unary plus by returning the underlying expression without wrapping it in a unary expression.
- Fix member access generation for Java class literals to use the correct `.class` access semantics.
- Adjust location metadata for variable declarations without initializers so their end column accounts for the identifier name.