### PR TITLE
bugfix for array init

### DIFF
--- a/parser-Java-Js/src/frontend/java/ASTBuilder.ts
+++ b/parser-Java-Js/src/frontend/java/ASTBuilder.ts
@@ -1660,6 +1660,9 @@ export class ASTBuilder
             const init = arrayCreatorRest.arrayInitializer()
             if (init) {
                 return this.visit(init) as UAST.Expression;
+            } else if (arrayCreatorRest.children?.length === 3 && arrayCreatorRest.children[0]?.text === '[' && /^[1-9]\d*$/.test(arrayCreatorRest.children[1]?.text) && arrayCreatorRest.children[2]?.text === ']') {
+                const memberAccess = UAST.memberAccess(callee, UAST.identifier(arrayCreatorRest.children[1].text))
+                return UAST.newExpression(memberAccess, [])
             } else {
                 return UAST.newExpression(callee, [])
             }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix Java AST building for array creations that specify a numeric size in brackets without an explicit initializer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds special-case handling in `visitCreator` to construct `newExpression(memberAccess(callee, size))` when `arrayCreatorRest` is `[<positive-int>]`, alongside existing initializer handling.
> 
> - **Parser (Java)**:
>   - Update `visitCreator` in `parser-Java-Js/src/frontend/java/ASTBuilder.ts` to handle array creation without initializer when `arrayCreatorRest` matches `[<positive-int>]`:
>     - Builds `memberAccess(callee, identifier(size))` and returns `UAST.newExpression(...)`.
>     - Keeps existing behavior for array initializers and default `new callee()` fallback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e15a10b521d5a7d4518b63f8d506f641fd87b11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->