### PR TITLE
check potential stackoverflow before parsing BinaryExpression

### DIFF
--- a/parser-Java-Js/src/frontend/java/ASTBuilder.ts
+++ b/parser-Java-Js/src/frontend/java/ASTBuilder.ts
@@ -1385,13 +1385,13 @@ export class ASTBuilder
             //       expression
             else if (['*', '/', '%', '+', '-', '<=', '>=', '>', '<', '>>', '<<', '==', '!=', '&', '|', '^', '&&', '||'].indexOf(bopText) !== -1) {
                 // e.g. a*b
-                try {
+                if (bopText === '+' && willExceedStackLimit(ctx.text)) {
+                    return UAST.noop()
+                } else {
                     const left = this.visit(ctx.expression()[0]) as UAST.Expression;
                     const right = this.visit(ctx.expression()[1]) as UAST.Expression;
                     // @ts-ignore
                     return UAST.binaryExpression(bopText, left, right);
-                } catch (e) {
-                    return UAST.noop()
                 }
             } else if (['=', '^=', '&=', '<<=', '>>=', '>>>=', '+=', '-=', '*=', '/=', '%=', ',=', '**=', '|='].indexOf(bopText) !== -1) {
                 // e.g. a=b
@@ -2507,6 +2507,12 @@ function addLoc(target, name, descriptor) {
     return descriptor;
 }
 
+function willExceedStackLimit(str) {
+    if (!str) {
+        return false
+    }
+    return str.split('+').length > 1000
+}
 
 function getUpperCase(str) {
     return str.charAt(0).toUpperCase() + str.slice(1);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Prevent potential stack overflows when parsing expressions**
> 
> - In `ASTBuilder.visitExpression`, short-circuits `bopText === '+'` to `UAST.noop()` if `willExceedStackLimit(ctx.text)` detects extremely long `+` chains
> - Introduces `willExceedStackLimit(str)` helper (counts `+` segments; threshold > 1000)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9c6ddc4ef1c9a371feef0faef010b15d649a279. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->