### PR TITLE
fixbug: add support for parsing classes with generic base types 

### DIFF
--- a/parser-Python/uast/visitor.py
+++ b/parser-Python/uast/visitor.py
@@ -134,10 +134,7 @@ class UASTTransformer(ast.NodeTransformer):
 
         super = []
         for base in node.bases:
-            if isinstance(base, ast.Subscript):  # 暂不处理泛型
-                unode = self.visit(base.value)
-            else:
-                unode = self.visit(base)
+            unode = self.visit(base)
             if isinstance(unode, list):
                 super.extend(unode)
             else:


### PR DESCRIPTION
e.g., Generic[T]
 
Previously, class bases as generics were ignored


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables parsing of classes with generic base types.
> 
> - In `visit_ClassDef`, remove the special-case that bypassed `ast.Subscript`; now always `visit(base)`, allowing generic bases to be included in `super`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e40822744418062f660baa1a60d765740ef8b0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->