### PR TITLE
chore(ci): 更新 macOS 构建矩阵配置

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -332,12 +332,14 @@ jobs:
   build_python_macos:
     name: Build Python Binary - macOS Universal
     needs: publish_parser_js
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        arch:
-          - amd64
-          - arm64
+        include:
+          - os: macos-15-intel
+            arch: amd64
+          - os: macos-latest
+            arch: arm64
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
- 将单 runner 改为矩阵配置
- 分别指定 intel 和 arm 架构的 runner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts macOS Python build in `/.github/workflows/release.yml` to use an OS+arch matrix with explicit runners.
> 
> - Switches `build_python_macos` from a single `macos-latest` runner to a matrix including `macos-15-intel` (amd64) and `macos-latest` (arm64), updating `runs-on` accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33ba444fd8a65156baebcc04f39eb04176d08efe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->