### PR TITLE
fixbug: use ScopedType instead of Identifier for user-defined types in VariableDeclaration

### DIFF
--- a/parser-Python/uast/asttype.py
+++ b/parser-Python/uast/asttype.py
@@ -382,6 +382,13 @@ class DynamicType(BaseNode):
     id: Identifier = None
     typeArguments: Optional[List['Type']] = None
 
+@dataclass_json
+@dataclass
+class ScopedType(BaseNode):
+    id: Identifier = None
+    scope: Optional['Type'] = None
+    typeArguments: Optional[List['Type']] = None
+
 
 # ========== Type Aliases ==========
 Instruction = Union[
@@ -402,7 +409,7 @@ Statement = Union[Sequence, SwitchStatement, BreakStatement, ContinueStatement, 
 LVal = Union[Identifier, MemberAccess, TupleExpression]
 
 Type = Union[
-    PrimitiveType, ArrayType, DynamicType, Identifier, MapType
+    PrimitiveType, ArrayType, DynamicType, ScopedType, MapType
 ]
 Conditional = Union[IfStatement , SwitchStatement , ConditionalExpression]
 
@@ -451,6 +458,7 @@ Node = Union[ArrayType
     , VariableDeclaration
     , WhileStatement
     , YieldExpression
+    , ScopedType
 ]
 
 # 其他类型别名类似定义...


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a new UAST `ScopedType` and uses it for user-defined type names in Python type annotations.
> 
> - Adds `ScopedType` node in `asttype.py`; updates `Type` and `Node` unions to include it
> - Updates `visitor._parse_type_annotation` to return `ScopedType` (wrapping an `Identifier`) for `ast.Name` that aren’t built-ins/`Any`
> - Minor whitespace/formatting adjustments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65afa38639b3f2a3436d9f6a383762e74d698dbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->