### PR TITLE
fix(python): support withitem __enter__ call

### DIFF
--- a/parser-Python/uast/visitor.py
+++ b/parser-Python/uast/visitor.py
@@ -909,11 +909,18 @@ class UASTTransformer(ast.NodeTransformer):
                                                                      UNode.Meta())))  # todo 缺少了nonlocal的标记
         return self.packPos(node, UNode.Sequence(UNode.SourceLocation(), UNode.Meta(), exprs))
 
-    def visit_withitem(self, node):  # 暂不处理
+    def visit_withitem(self, node):
         if node.optional_vars is not None:
+            enter = UNode.MemberAccess(UNode.SourceLocation(), UNode.Meta(),
+                                       self.packPos(node.context_expr, self.visit(node.context_expr)),
+                                       UNode.Identifier(UNode.SourceLocation(), UNode.Meta(), "__enter__"))
+
+            call = UNode.CallExpression(UNode.SourceLocation(), UNode.Meta(),
+                                        self.packPos(node.context_expr, enter), [])
+
             return UNode.VariableDeclaration(UNode.SourceLocation(), UNode.Meta(),
                                              self.packPos(node.optional_vars, self.visit(node.optional_vars)),
-                                             self.packPos(node.context_expr, self.visit(node.context_expr)), False,
+                                             self.packPos(node.context_expr, call), False,
                                              UNode.DynamicType(UNode.SourceLocation(), UNode.Meta()))
         else:
             return UNode.Noop(UNode.SourceLocation(), UNode.Meta())


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds proper handling for Python `with` items.
> 
> - Implements `visit_withitem` to call `__enter__()` on `context_expr` and initialize `optional_vars` via a `VariableDeclaration`
> - Replaces direct use of `context_expr` with a `CallExpression` to `__enter__()`; returns `Noop` when no `optional_vars`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f5ca17541ff0cff2a326cabcde3a0c75b691c65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->