### PR TITLE
Add ReturnStatement for __init__

### DIFF
--- a/parser-Python/uast/visitor.py
+++ b/parser-Python/uast/visitor.py
@@ -336,6 +336,10 @@ class UASTTransformer(ast.NodeTransformer):
         if node.name == '__init__':
             function_def._meta.isConstructor = True
             # function_def.body.body.append(UNode.ReturnStatement(UNode.SourceLocation(), UNode.Meta(), UNode.Identifier(UNode.SourceLocation(), UNode.Meta(), 'self')))
+            if len(body) > 0:
+                last_stmt = body[-1]
+                if not isinstance(last_stmt, UNode.ReturnStatement):
+                    function_def.body.body.append(UNode.ReturnStatement(UNode.SourceLocation(), UNode.Meta(), UNode.Identifier(UNode.SourceLocation(), UNode.Meta(), 'self')))
         decorator_list = []
         for decorator in node.decorator_list:
             decorator_list.append(self.packPos(decorator, self.visit(decorator)))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to UAST generation for `__init__` only; main risk is subtle downstream assumptions about constructors now having an explicit `return self`.
> 
> **Overview**
> Ensures Python `__init__` methods translated into UAST end with an explicit `ReturnStatement` returning `self` when they don’t already end with a return.
> 
> This is applied only for constructor functions (`visit_FunctionDef` when `node.name == '__init__'`) and avoids duplicating a return if the last emitted statement is already a `UNode.ReturnStatement`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afe3eb1a073fc152c4e0bc7e351dabe06218d087. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->