### PR TITLE
fix(php)：php parser使用treesitter重写

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,6 +224,115 @@ jobs:
 
           echo "✅ Published @ant-yasa/uast-parser-java-js@$VERSION"
 
+  # 3.5 发布 parser-PHP
+  publish_parser_php:
+    needs: [publish_spec, get_version]
+    runs-on: ubuntu-latest
+    environment: release
+    env:
+      VERSION: ${{ needs.get_version.outputs.version }}
+      NPM_TAG: ${{ needs.get_version.outputs.npm_tag }}
+    steps:
+      - name: Validate version
+        run: |
+          echo "🎯 VERSION: '$VERSION'"
+          echo "🎯 NPM_TAG: '$NPM_TAG'"
+          if [ -z "$VERSION" ]; then
+            echo "❌ ERROR: VERSION is empty!"
+            exit 1
+          fi
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+
+      - name: Upgrade npm
+        run: |
+          npm install -g npm@latest
+          echo "npm after upgrade:"
+          npm -v
+          echo "node after upgrade:"
+          node -v
+
+      - name: Check and Publish
+        working-directory: parser-PHP
+        run: |
+          echo "🔍 Publishing @ant-yasa/uast-parser-php"
+          echo "📦 Version: $VERSION"
+          echo "🏷  NPM Tag: $NPM_TAG"
+
+          if npm view @ant-yasa/uast-parser-php@$VERSION version > /dev/null 2>&1; then
+            echo "✅ Version $VERSION already published, skipping."
+            exit 0
+          fi
+
+          # 等待 uast-spec 发布完成
+          echo "⏳ Waiting for @ant-yasa/uast-spec@$VERSION to be available..."
+          for i in {1..30}; do
+            if npm view @ant-yasa/uast-spec@$VERSION version > /dev/null 2>&1; then
+              echo "✅ @ant-yasa/uast-spec@$VERSION is available."
+              break
+            else
+              echo "⏳ Attempt $i: @ant-yasa/uast-spec@$VERSION not found, retrying in 10s..."
+              sleep 10
+            fi
+          done
+
+          if ! npm view @ant-yasa/uast-spec@$VERSION version > /dev/null 2>&1; then
+            echo "❌ Failed to find @ant-yasa/uast-spec@$VERSION after waiting."
+            exit 1
+          fi
+          echo "📦 Installing dependencies for @ant-yasa/uast-parser-php..."
+          npm install
+
+          echo "📥 Installing @ant-yasa/uast-spec@$VERSION..."
+          npm install @ant-yasa/uast-spec@$VERSION --no-save
+
+          echo "🏗️  Running build..."
+          npm run build
+
+          # === 校验 dist/src/index.js 是否存在 ===
+          echo "🔍 Checking for dist/src/index.js..."
+          if [ ! -f dist/src/index.js ]; then
+            echo "❌ dist/src/index.js NOT found!"
+            echo "💡 Check your build script, output path, or tsconfig.json"
+            ls -R dist/ || echo "dist/ is empty or missing"
+            exit 1
+          else
+            echo "✅ dist/src/index.js exists"
+          fi
+
+          # === 校验 package.json 的 main 字段 ===
+          MAIN_FIELD=$(node -p "require('./package.json').main")
+          echo "🔗 package.json 'main' field: $MAIN_FIELD"
+          if [ "$MAIN_FIELD" != "dist/src/index.js" ]; then
+            echo "⚠️ Warning: 'main' field is not 'dist/src/index.js' — may cause runtime issues!"
+          fi
+
+          # === dry-run 打包，检查内容 ===
+          echo "📦 Running 'npm pack --dry-run' to verify package contents..."
+          DRY_RUN_OUTPUT=$(npm pack --dry-run 2>&1)
+          echo "$DRY_RUN_OUTPUT"
+
+          if echo "$DRY_RUN_OUTPUT" | grep -q "dist/src/index.js"; then
+            echo "✅ dist/src/index.js is included in the npm package."
+          else
+            echo "❌ dist/src/index.js is NOT included in the npm package!"
+            echo "💡 Check .npmignore, .gitignore, or files field in package.json"
+            exit 1
+          fi
+
+          # === 设置版本号 ===
+          echo "🔄 Setting version in package.json..."
+          npm version $VERSION --no-git-tag-version
+          npm publish --tag $NPM_TAG
+
+          echo "✅ Published @ant-yasa/uast-parser-php@$VERSION"
+
   # 4. 构建 Go 可执行文件（多平台）
   build_go:
     needs: publish_parser_js

--- a/parser-PHP/package-lock.json
+++ b/parser-PHP/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "@ant-yasa/uast-spec": "file:../specification",
         "php-parser": "^3.4.0",
-        "typescript": "^5.7.2"
+        "tree-sitter-php": "^0.24.2",
+        "typescript": "^5.7.2",
+        "web-tree-sitter": "^0.26.8"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.10",
@@ -1487,6 +1489,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -1902,6 +1924,25 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tree-sitter-php": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-php/-/tree-sitter-php-0.24.2.tgz",
+      "integrity": "sha512-zwgAePc/HozNaWOOfwRAA+3p8yhuehRw8Fb7vn5qd2XjiIc93uJPryDTMYTSjBRjVIUg/KY6pM3rRzs8dSwKfw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.4"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -2001,6 +2042,12 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.26.8",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.8.tgz",
+      "integrity": "sha512-4sUwi7ZyOrIk5KLgYLkc2A/F0LFMQnBhfb+2Cdl7ik4ePJ6JD+fk4ofI2sA5eGawBKBaK4Vntt7Ww5KcEsay4A==",
       "license": "MIT"
     },
     "node_modules/which": {

--- a/parser-PHP/package.json
+++ b/parser-PHP/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "for converting php to UAST",
   "dependencies": {
-    "@ant-yasa/uast-spec": "file:../specification",
+    "@ant-yasa/uast-spec": "^0.2.0",
     "php-parser": "^3.4.0",
     "tree-sitter-php": "^0.24.2",
     "typescript": "^5.7.2",

--- a/parser-PHP/package.json
+++ b/parser-PHP/package.json
@@ -5,7 +5,9 @@
   "dependencies": {
     "@ant-yasa/uast-spec": "file:../specification",
     "php-parser": "^3.4.0",
-    "typescript": "^5.7.2"
+    "tree-sitter-php": "^0.24.2",
+    "typescript": "^5.7.2",
+    "web-tree-sitter": "^0.26.8"
   },
   "scripts": {
     "test": "mocha --require tsx tests/index.ts",

--- a/parser-PHP/src/index.ts
+++ b/parser-PHP/src/index.ts
@@ -5,9 +5,17 @@ export { version } from '../package.json';
 
 export class Parser {
     private opts: Record<string, any>;
+    private initialized: boolean = false;
 
     constructor(opts: Record<string, any> | null = null) {
         this.opts = opts || {};
+    }
+
+    async init(): Promise<void> {
+        if (!this.initialized) {
+            await phpParser.init();
+            this.initialized = true;
+        }
     }
 
     parse(content: string, opts: Record<string, any> = {}): UAST.Node {

--- a/parser-PHP/src/parser.ts
+++ b/parser-PHP/src/parser.ts
@@ -102,7 +102,7 @@ function createVariableDeclaration(
     origin: PhpNode,
     opts: Record<string, any>
 ) {
-    const id = visit(idNode, opts) as UAST.LVal;
+    const id = (visit(idNode, opts) as UAST.LVal) || UAST.identifier('_');
     const init = visit(initNode, opts) as UAST.Expression | null;
     const varDecl = UAST.variableDeclaration(id, init, false, UAST.dynamicType());
     return appendNodeMeta(varDecl, origin, opts?.sourcefile);
@@ -204,10 +204,28 @@ function mapBinaryOperator(operator: string | undefined) {
     if (!operator) {
         return '+';
     }
-    if (operator === '.') {
-        return '+';
+    const mapping: Record<string, string> = {
+        '.': '+',
+        '??': '||',
+        '<=>': '-',
+        'or': '||',
+        'and': '&&',
+        'xor': '^',
+    };
+    return mapping[operator] || operator;
+}
+
+function mapAssignOperator(operator: string): string {
+    const mapping: Record<string, string> = {
+        '.=': '+=',
+        '??=': '=',
+        '**=': '*=',
+    };
+    const validOperators = new Set(['=', '^=', '&=', '<<=', '>>=', '>>>=', '+=', '-=', '*=', '/=', '%=', '|=', '**=']);
+    if (validOperators.has(operator)) {
+        return operator;
     }
-    return operator;
+    return mapping[operator] || '=';
 }
 
 function createFunctionBody(bodyNode: PhpNode | null | undefined, opts: Record<string, any>) {
@@ -223,7 +241,15 @@ function createFunctionBody(bodyNode: PhpNode | null | undefined, opts: Record<s
 }
 
 function createImportExpression(node: PhpNode, opts: Record<string, any>) {
-    const target = visit(node.target, opts) as UAST.Literal;
+    const targetNode = visit(node.target, opts);
+    let target: UAST.Literal;
+    if (UAST.isLiteral(targetNode)) {
+        target = targetNode;
+    } else {
+        // 动态 include（如 include $dir . '/file.php'），用空字符串占位
+        target = UAST.literal('', 'string');
+        target._meta.dynamicFrom = targetNode;
+    }
     const importExpr = UAST.importExpression(target);
     importExpr._meta.require = Boolean(node.require);
     importExpr._meta.once = Boolean(node.once);
@@ -344,7 +370,15 @@ function createLoopExpr(nodes: PhpNode[] | null | undefined, opts: Record<string
 }
 
 function createCatchClause(node: PhpNode, opts: Record<string, any>) {
-    const parameter = createVariableDeclaration(node.variable, null, node.variable || node, opts);
+    let parameter: UAST.VariableDeclaration;
+    if (node.variable) {
+        parameter = createVariableDeclaration(node.variable, null, node.variable, opts);
+    } else {
+        // PHP 8.0 non-capturing catch: catch (Exception) 无变量名
+        const placeholderId = UAST.identifier('_');
+        parameter = UAST.variableDeclaration(placeholderId, null, false, UAST.dynamicType());
+        appendNodeMeta(parameter, node, opts?.sourcefile);
+    }
     parameter._meta.catchTypes = visitList(node.what, opts);
     const clause = UAST.catchClause([parameter], visit(node.body, opts) as UAST.Instruction);
     return appendNodeMeta(clause, node, opts?.sourcefile);
@@ -486,7 +520,8 @@ function createEnumCase(node: PhpNode, opts: Record<string, any>) {
 function createNamespace(node: PhpNode, opts: Record<string, any>) {
     const instructions: Array<UAST.Instruction> = [];
     if (node.name) {
-        const pkg = UAST.packageDeclaration(UAST.identifier(node.name));
+        const nameStr = Array.isArray(node.name) ? node.name.join('\\') : String(node.name);
+        const pkg = UAST.packageDeclaration(UAST.identifier(nameStr));
         instructions.push(appendNodeMeta(pkg, node, opts?.sourcefile));
     }
     instructions.push(...flattenInstructions(visitList(node.children, opts)));
@@ -512,12 +547,17 @@ function visit(node: PhpNode | null | undefined, opts: Record<string, any>): any
             return appendNodeMeta(exprStmt, node, opts?.sourcefile);
         }
         case 'assign': {
+            const rawOp = node.operator || '=';
+            const mappedOp = mapAssignOperator(rawOp);
             const assign = UAST.assignmentExpression(
                 visit(node.left, opts) as UAST.LVal,
                 visit(node.right, opts) as UAST.Expression,
-                (node.operator || '=') as any,
+                mappedOp as any,
                 false
             );
+            if (rawOp !== mappedOp) {
+                assign._meta.rawOperator = rawOp;
+            }
             return appendNodeMeta(assign, node, opts?.sourcefile);
         }
         case 'assignref': {
@@ -532,9 +572,15 @@ function visit(node: PhpNode | null | undefined, opts: Record<string, any>): any
         }
         case 'variable':
         case 'identifier':
+            // 动态变量名 $$var: node.name 是对象而非字符串
+            if (typeof node.name === 'object' && node.name !== null) {
+                return visit(node.name, opts);
+            }
             return appendNodeMeta(UAST.identifier(node.name), node, opts?.sourcefile);
-        case 'name':
-            return appendNodeMeta(UAST.identifier(node.name), node, opts?.sourcefile);
+        case 'name': {
+            const nameStr = Array.isArray(node.name) ? node.name.join('\\') : String(node.name);
+            return appendNodeMeta(UAST.identifier(nameStr), node, opts?.sourcefile);
+        }
         case 'selfreference':
             return appendNodeMeta(UAST.identifier('self'), node, opts?.sourcefile);
         case 'parentreference':
@@ -579,9 +625,14 @@ function visit(node: PhpNode | null | undefined, opts: Record<string, any>): any
             return appendNodeMeta(binary, node, opts?.sourcefile);
         }
         case 'retif': {
+            const testExpr = visit(node.test, opts) as UAST.Expression;
+            // PHP Elvis 运算符 $a ?: $b 省略中间表达式，复用 test 作为 consequent
+            const consequent = node.trueExpr
+                ? visit(node.trueExpr, opts) as UAST.Expression
+                : visit(node.test, opts) as UAST.Expression;
             const conditional = UAST.conditionalExpression(
-                visit(node.test, opts) as UAST.Expression,
-                visit(node.trueExpr, opts) as UAST.Expression,
+                testExpr,
+                consequent,
                 visit(node.falseExpr, opts) as UAST.Expression
             );
             return appendNodeMeta(conditional, node, opts?.sourcefile);
@@ -654,9 +705,11 @@ function visit(node: PhpNode | null | undefined, opts: Record<string, any>): any
             return appendNodeMeta(member, node, opts?.sourcefile);
         }
         case 'offsetlookup': {
+            // $arr[] 数组追加时 node.offset 为 null，用 noop 占位
+            const offsetProperty = node.offset ? visit(node.offset, opts) as UAST.Expression : UAST.noop() as any;
             const member = UAST.memberAccess(
                 visit(node.what, opts) as UAST.Expression,
-                visit(node.offset, opts) as UAST.Expression,
+                offsetProperty,
                 true
             );
             return appendNodeMeta(member, node, opts?.sourcefile);
@@ -692,9 +745,10 @@ function visit(node: PhpNode | null | undefined, opts: Record<string, any>): any
             return appendNodeMeta(block, node, opts?.sourcefile);
         }
         case 'if': {
+            const ifBody = node.body ? visit(node.body, opts) as UAST.Instruction : UAST.scopedStatement([]);
             const ifStmt = UAST.ifStatement(
                 visit(node.test, opts) as UAST.Expression,
-                visit(node.body, opts) as UAST.Instruction,
+                ifBody,
                 visit(node.alternate, opts) as UAST.Instruction | null
             );
             return appendNodeMeta(ifStmt, node, opts?.sourcefile);
@@ -740,37 +794,41 @@ function visit(node: PhpNode | null | undefined, opts: Record<string, any>): any
             return appendNodeMeta(clause, node, opts?.sourcefile);
         }
         case 'for': {
+            const forBody = node.body ? visit(node.body, opts) as UAST.Instruction : UAST.scopedStatement([]);
             const stmt = UAST.forStatement(
                 createLoopInit(node.init, opts) as UAST.Expression | UAST.VariableDeclaration | null,
                 createLoopExpr(node.test, opts) as UAST.Expression | null,
                 createLoopExpr(node.increment, opts) as UAST.Expression | null,
-                visit(node.body, opts) as UAST.Instruction
+                forBody
             );
             return appendNodeMeta(stmt, node, opts?.sourcefile);
         }
         case 'foreach': {
             const key = node.key ? createVariableDeclaration(node.key, null, node.key, opts) : null;
             const value = node.value ? createVariableDeclaration(node.value, null, node.value, opts) : null;
+            const foreachBody = node.body ? visit(node.body, opts) as UAST.Instruction : UAST.scopedStatement([]);
             const stmt = UAST.rangeStatement(
                 key,
                 value,
                 visit(node.source, opts) as UAST.Expression,
-                visit(node.body, opts) as UAST.Instruction
+                foreachBody
             );
             return appendNodeMeta(stmt, node, opts?.sourcefile);
         }
         case 'while': {
+            const whileBody = node.body ? visit(node.body, opts) as UAST.Instruction : UAST.scopedStatement([]);
             const stmt = UAST.whileStatement(
                 visit(node.test, opts) as UAST.Expression,
-                visit(node.body, opts) as UAST.Instruction,
+                whileBody,
                 false
             );
             return appendNodeMeta(stmt, node, opts?.sourcefile);
         }
         case 'do': {
+            const doBody = node.body ? visit(node.body, opts) as UAST.Instruction : UAST.scopedStatement([]);
             const stmt = UAST.whileStatement(
                 visit(node.test, opts) as UAST.Expression,
-                visit(node.body, opts) as UAST.Instruction,
+                doBody,
                 true
             );
             return appendNodeMeta(stmt, node, opts?.sourcefile);

--- a/parser-PHP/src/parser.ts
+++ b/parser-PHP/src/parser.ts
@@ -1,73 +1,59 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-const PhpParserEngine = require('php-parser');
+import * as TreeSitter from 'web-tree-sitter';
 import * as UAST from '@ant-yasa/uast-spec';
 import { version } from '../package.json';
 
-type PhpNode = {
-    kind?: string;
-    loc?: {
-        source?: string | null;
-        start?: { line: number; column: number; offset?: number };
-        end?: { line: number; column: number; offset?: number };
-    };
-    [key: string]: any;
-};
+type SyntaxNode = TreeSitter.Node;
 
 export type ParseResult<Result> = Result;
 
-function createEngine() {
-    return new PhpParserEngine.Engine({
-        parser: {
-            php7: true,
-            suppressErrors: false,
-            extractDoc: true,
-        },
-        ast: {
-            withPositions: true,
-        },
-    });
+let parserInstance: TreeSitter.Parser | null = null;
+
+/** 初始化 tree-sitter parser，加载 PHP WASM */
+export async function init(): Promise<void> {
+    await TreeSitter.Parser.init();
+    const Lang = await TreeSitter.Language.load(
+        require.resolve('tree-sitter-php/tree-sitter-php.wasm')
+    );
+    parserInstance = new TreeSitter.Parser();
+    parserInstance.setLanguage(Lang);
 }
 
-function toSourceLocation(loc: PhpNode['loc'], sourcefile?: string) {
-    if (!loc?.start || !loc?.end) {
-        return null;
+function getParser(): TreeSitter.Parser {
+    if (!parserInstance) {
+        throw new Error('Parser not initialized. Call init() first.');
     }
+    return parserInstance;
+}
 
+function toSourceLocation(node: SyntaxNode, sourcefile?: string) {
     return {
         start: {
-            line: loc.start.line,
-            column: loc.start.column + 1,
+            line: node.startPosition.row + 1,
+            column: node.startPosition.column + 1,
         },
         end: {
-            line: loc.end.line,
-            column: loc.end.column + 1,
+            line: node.endPosition.row + 1,
+            column: node.endPosition.column + 1,
         },
         sourcefile,
     };
 }
 
-function appendNodeMeta(node: any, origin: PhpNode | null | undefined, sourcefile?: string) {
-    if (!node || !UAST.isNode(node)) {
-        return node;
+function appendNodeMeta(uastNode: any, tsNode: SyntaxNode | null | undefined, sourcefile?: string): any {
+    if (!uastNode || !UAST.isNode(uastNode)) {
+        return uastNode;
     }
 
-    const loc = toSourceLocation(origin?.loc, sourcefile);
-    if (loc) {
-        node.loc = loc;
-        node._meta.loc = loc;
+    if (tsNode) {
+        const loc = toSourceLocation(tsNode, sourcefile);
+        uastNode.loc = loc;
+        uastNode._meta.loc = loc;
     }
 
-    if (origin) {
-        node._meta.origin = origin;
-    }
-
-    return node;
+    return uastNode;
 }
 
-function visitList(nodes: PhpNode[] | null | undefined, opts: Record<string, any>): Array<any> {
-    if (!nodes) {
-        return [];
-    }
+function visitList(nodes: SyntaxNode[], opts: Record<string, any>): Array<any> {
     return nodes
         .map((node) => visit(node, opts))
         .filter((node) => node !== null && node !== undefined);
@@ -86,121 +72,7 @@ function flattenInstructions(nodes: Array<any>): Array<any> {
     return instructions;
 }
 
-function createParameter(parameter: PhpNode, opts: Record<string, any>) {
-    const id = visit(parameter.name, opts) as UAST.Identifier;
-    const init = visit(parameter.value, opts) as UAST.Expression | null;
-    const varDecl = UAST.variableDeclaration(id, init, false, UAST.dynamicType());
-    varDecl._meta.byref = Boolean(parameter.byref);
-    varDecl._meta.variadic = Boolean(parameter.variadic);
-    varDecl._meta.attributes = createAttrGroups(parameter.attrGroups, opts);
-    return appendNodeMeta(varDecl, parameter, opts?.sourcefile);
-}
-
-function createVariableDeclaration(
-    idNode: PhpNode | null | undefined,
-    initNode: PhpNode | null | undefined,
-    origin: PhpNode,
-    opts: Record<string, any>
-) {
-    const id = (visit(idNode, opts) as UAST.LVal) || UAST.identifier('_');
-    const init = visit(initNode, opts) as UAST.Expression | null;
-    const varDecl = UAST.variableDeclaration(id, init, false, UAST.dynamicType());
-    return appendNodeMeta(varDecl, origin, opts?.sourcefile);
-}
-
-function createFunctionLike(node: PhpNode, opts: Record<string, any>, extraModifiers: string[] = []) {
-    const id = visit(node.name, opts) as UAST.Identifier | null;
-    const parameters = (node.arguments || []).map((arg: PhpNode) => createParameter(arg, opts));
-    const body = node.body
-        ? (visit(node.body, opts) as UAST.Instruction)
-        : appendNodeMeta(UAST.scopedStatement([]), node, opts?.sourcefile);
-    const modifiers = [...extraModifiers];
-
-    if (typeof node.visibility === 'string') {
-        modifiers.push(node.visibility);
-    }
-    if (node.isStatic) {
-        modifiers.push('static');
-    }
-    if (node.isAbstract) {
-        modifiers.push('abstract');
-    }
-    if (node.isFinal) {
-        modifiers.push('final');
-    }
-
-    const fdef = UAST.functionDefinition(id, parameters, UAST.dynamicType(), body, modifiers);
-    fdef._meta.attributes = createAttrGroups(node.attrGroups, opts);
-    return appendNodeMeta(fdef, node, opts?.sourcefile);
-}
-
-function createClass(node: PhpNode, opts: Record<string, any>) {
-    const id = visit(node.name, opts) as UAST.Identifier | null;
-    const body = flattenInstructions(visitList(node.body, opts));
-    const supers = node.extends ? [visit(node.extends, opts)] : [];
-    const cdef = UAST.classDefinition(id, body, supers as Array<UAST.Expression>);
-    cdef._meta.implements = visitList(node.implements, opts);
-    cdef._meta.isAbstract = Boolean(node.isAbstract);
-    cdef._meta.isFinal = Boolean(node.isFinal);
-    cdef._meta.isReadonly = Boolean(node.isReadonly);
-    cdef._meta.attributes = createAttrGroups(node.attrGroups, opts);
-    return appendNodeMeta(cdef, node, opts?.sourcefile);
-}
-
-function createStructureLike(node: PhpNode, opts: Record<string, any>, kind: 'class' | 'interface' | 'trait') {
-    const id = visit(node.name, opts) as UAST.Identifier | null;
-    const body = flattenInstructions(visitList(node.body, opts));
-    const supers = visitList(node.extends, opts) as Array<UAST.Expression>;
-    const cdef = UAST.classDefinition(id, body, supers);
-    cdef._meta.structureKind = kind;
-    cdef._meta.attributes = createAttrGroups(node.attrGroups, opts);
-    return appendNodeMeta(cdef, node, opts?.sourcefile);
-}
-
-function createArrayExpression(node: PhpNode, opts: Record<string, any>) {
-    const properties = (node.items || []).map((item: PhpNode) => {
-        const key = item.key ? visit(item.key, opts) : UAST.literal(null, 'null');
-        const value = visit(item.value, opts) as UAST.Expression;
-        const prop = UAST.objectProperty(key, value);
-        return appendNodeMeta(prop, item, opts?.sourcefile);
-    });
-    const expr = UAST.objectExpression(properties);
-    expr._meta.isArray = true;
-    return appendNodeMeta(expr, node, opts?.sourcefile);
-}
-
-function createTupleExpression(node: PhpNode, opts: Record<string, any>) {
-    const elements = (node.items || []).map((item: PhpNode) => {
-        if (!item) {
-            return UAST.noop();
-        }
-        return visit(item.value || item, opts) as UAST.Expression | UAST.Instruction;
-    });
-    const tuple = UAST.tupleExpression(elements);
-    tuple._meta.shortForm = Boolean(node.shortForm);
-    return appendNodeMeta(tuple, node, opts?.sourcefile);
-}
-
-function createEncapsed(node: PhpNode, opts: Record<string, any>) {
-    const parts = (node.value || []).map((part: PhpNode) => visit(part.expression || part, opts) as UAST.Expression);
-    if (parts.length === 0) {
-        return appendNodeMeta(UAST.literal('', 'string'), node, opts?.sourcefile);
-    }
-    let expr = parts[0];
-    for (let index = 1; index < parts.length; index += 1) {
-        expr = appendNodeMeta(UAST.binaryExpression('+', expr, parts[index]), node, opts?.sourcefile);
-    }
-    expr._meta.encapsed = true;
-    return appendNodeMeta(expr, node, opts?.sourcefile);
-}
-
-function createProgram(node: PhpNode, opts: Record<string, any>) {
-    const body = flattenInstructions(visitList(node.children, opts));
-    const compileUnit = UAST.compileUnit(body, 'php', null, opts?.sourcefile || '', version);
-    return appendNodeMeta(compileUnit, node, opts?.sourcefile);
-}
-
-function mapBinaryOperator(operator: string | undefined) {
+function mapBinaryOperator(operator: string | undefined): string {
     if (!operator) {
         return '+';
     }
@@ -211,8 +83,11 @@ function mapBinaryOperator(operator: string | undefined) {
         'or': '||',
         'and': '&&',
         'xor': '^',
+        '<>': '!=',
     };
-    return mapping[operator] || operator;
+    // PHP 关键字大小写不敏感，统一转小写
+    const lower = operator.toLowerCase();
+    return mapping[lower] || lower;
 }
 
 function mapAssignOperator(operator: string): string {
@@ -228,701 +103,1092 @@ function mapAssignOperator(operator: string): string {
     return mapping[operator] || '=';
 }
 
-function createFunctionBody(bodyNode: PhpNode | null | undefined, opts: Record<string, any>) {
-    const body = visit(bodyNode, opts);
-    if (body && UAST.isNode(body) && !UAST.isExpr(body)) {
-        return body as UAST.Instruction;
-    }
-
-    const returnStmt = UAST.returnStatement(body as UAST.Expression | null);
-    appendNodeMeta(returnStmt, bodyNode, opts?.sourcefile);
-    const scoped = UAST.scopedStatement([returnStmt]);
-    return appendNodeMeta(scoped, bodyNode, opts?.sourcefile) as UAST.Instruction;
-}
-
-function createImportExpression(node: PhpNode, opts: Record<string, any>) {
-    const targetNode = visit(node.target, opts);
-    let target: UAST.Literal;
-    if (UAST.isLiteral(targetNode)) {
-        target = targetNode;
-    } else {
-        // 动态 include（如 include $dir . '/file.php'），用空字符串占位
-        target = UAST.literal('', 'string');
-        target._meta.dynamicFrom = targetNode;
-    }
-    const importExpr = UAST.importExpression(target);
-    importExpr._meta.require = Boolean(node.require);
-    importExpr._meta.once = Boolean(node.once);
-    return appendNodeMeta(importExpr, node, opts?.sourcefile);
-}
-
-function createUseGroup(node: PhpNode, opts: Record<string, any>) {
-    const imports = (node.items || []).map((item: PhpNode) => {
-        const from = UAST.literal(item.name, 'string');
-        const alias = item.alias ? visit(item.alias, opts) as UAST.Identifier : null;
-        const importExpr = UAST.importExpression(from, alias || undefined, undefined);
-        return appendNodeMeta(importExpr, item, opts?.sourcefile);
-    });
-
-    if (imports.length === 1) {
-        return UAST.expressionStatement(imports[0]);
-    }
-
-    const seq = UAST.sequence(imports);
-    return appendNodeMeta(seq, node, opts?.sourcefile);
-}
-
-function createPseudoCall(name: string, args: Array<UAST.Expression>, origin: PhpNode, opts: Record<string, any>) {
-    const call = UAST.callExpression(UAST.identifier(name), args);
-    call._meta.synthetic = true;
-    return appendNodeMeta(call, origin, opts?.sourcefile);
-}
-
-function createPseudoCallStatement(name: string, args: Array<UAST.Expression>, origin: PhpNode, opts: Record<string, any>) {
-    const call = createPseudoCall(name, args, origin, opts);
-    const stmt = UAST.expressionStatement(call);
-    return appendNodeMeta(stmt, origin, opts?.sourcefile);
-}
-
-function createAttrGroups(groups: PhpNode[] | null | undefined, opts: Record<string, any>) {
-    return (groups || []).map((group: PhpNode) => ({
-        type: 'AttributeGroup',
-        attributes: (group.attrs || []).map((attr: PhpNode) => ({
-            name: attr.name,
-            args: (attr.args || []).map((arg: PhpNode) => visit(arg, opts)),
-        })),
-    }));
-}
-
-function createPropertyStatement(node: PhpNode, opts: Record<string, any>) {
-    const declarations = (node.properties || []).map((property: PhpNode) => {
-        const decl = createVariableDeclaration(property.name, property.value, property, opts);
-        decl._meta.visibility = node.visibility || null;
-        decl._meta.isStatic = Boolean(node.isStatic);
-        decl._meta.readonly = Boolean(property.readonly);
-        decl._meta.attributes = createAttrGroups(property.attrGroups, opts);
-        return decl;
-    });
-
-    if (declarations.length === 1) {
-        return declarations[0];
-    }
-
-    const seq = UAST.sequence(declarations);
-    return appendNodeMeta(seq, node, opts?.sourcefile);
-}
-
-function createClassConstant(node: PhpNode, opts: Record<string, any>) {
-    const declarations = (node.constants || []).map((constant: PhpNode) => {
-        const decl = createVariableDeclaration(constant.name, constant.value, constant, opts);
-        decl._meta.constant = true;
-        decl._meta.visibility = node.visibility || null;
-        decl._meta.final = Boolean(node.final);
-        decl._meta.attributes = createAttrGroups(node.attrGroups, opts);
-        return decl;
-    });
-
-    if (declarations.length === 1) {
-        return declarations[0];
-    }
-
-    const seq = UAST.sequence(declarations);
-    return appendNodeMeta(seq, node, opts?.sourcefile);
-}
-
-function createConstantStatement(node: PhpNode, opts: Record<string, any>) {
-    const declarations = (node.constants || []).map((constant: PhpNode) => {
-        const decl = createVariableDeclaration(constant.name, constant.value, constant, opts);
-        decl._meta.constant = true;
-        return decl;
-    });
-
-    if (declarations.length === 1) {
-        return declarations[0];
-    }
-
-    const seq = UAST.sequence(declarations);
-    return appendNodeMeta(seq, node, opts?.sourcefile);
-}
-
-function createLoopInit(nodes: PhpNode[] | null | undefined, opts: Record<string, any>) {
-    const items = visitList(nodes, opts) as Array<UAST.Expression | UAST.VariableDeclaration>;
-    if (items.length === 0) {
-        return null;
-    }
-    if (items.length === 1) {
-        return items[0];
-    }
-    const seq = UAST.sequence(items as Array<UAST.Instruction>);
-    return appendNodeMeta(seq, nodes?.[0], opts?.sourcefile);
-}
-
-function createLoopExpr(nodes: PhpNode[] | null | undefined, opts: Record<string, any>) {
-    const items = visitList(nodes, opts) as Array<UAST.Expression>;
-    if (items.length === 0) {
-        return null;
-    }
-    if (items.length === 1) {
-        return items[0];
-    }
-    const seq = UAST.sequence(items as Array<UAST.Instruction>);
-    return appendNodeMeta(seq, nodes?.[0], opts?.sourcefile) as unknown as UAST.Expression;
-}
-
-function createCatchClause(node: PhpNode, opts: Record<string, any>) {
-    let parameter: UAST.VariableDeclaration;
-    if (node.variable) {
-        parameter = createVariableDeclaration(node.variable, null, node.variable, opts);
-    } else {
-        // PHP 8.0 non-capturing catch: catch (Exception) 无变量名
-        const placeholderId = UAST.identifier('_');
-        parameter = UAST.variableDeclaration(placeholderId, null, false, UAST.dynamicType());
-        appendNodeMeta(parameter, node, opts?.sourcefile);
-    }
-    parameter._meta.catchTypes = visitList(node.what, opts);
-    const clause = UAST.catchClause([parameter], visit(node.body, opts) as UAST.Instruction);
-    return appendNodeMeta(clause, node, opts?.sourcefile);
-}
-
-function createStaticStatement(node: PhpNode, opts: Record<string, any>) {
-    const declarations = (node.variables || []).map((item: PhpNode) => {
-        const decl = createVariableDeclaration(item.variable, item.defaultValue, item, opts);
-        decl._meta.storage = 'static';
-        return decl;
-    });
-
-    if (declarations.length === 1) {
-        return declarations[0];
-    }
-
-    const seq = UAST.sequence(declarations);
-    return appendNodeMeta(seq, node, opts?.sourcefile);
-}
-
-function createGlobalStatement(node: PhpNode, opts: Record<string, any>) {
-    const declarations = (node.items || []).map((item: PhpNode) => {
-        const decl = createVariableDeclaration(item, null, item, opts);
-        decl._meta.storage = 'global';
-        return decl;
-    });
-
-    if (declarations.length === 1) {
-        return declarations[0];
-    }
-
-    const seq = UAST.sequence(declarations);
-    return appendNodeMeta(seq, node, opts?.sourcefile);
-}
-
-function createDeclare(node: PhpNode, opts: Record<string, any>) {
-    const children = flattenInstructions(visitList(node.children, opts));
-    const stmt =
-        children.length === 0
-            ? appendNodeMeta(UAST.noop(), node, opts?.sourcefile)
-            : children.length === 1
-              ? children[0]
-              : appendNodeMeta(UAST.sequence(children), node, opts?.sourcefile);
-    if (stmt && UAST.isNode(stmt)) {
-        stmt._meta.declare = {
-            mode: node.mode,
-            directives: (node.directives || []).map((directive: PhpNode) => ({
-                key: visit(directive.key, opts),
-                value: visit(directive.value, opts),
-            })),
-        };
-    }
-    return stmt;
-}
-
-function createMatchExpression(node: PhpNode, opts: Record<string, any>) {
-    const condition = visit(node.cond, opts) as UAST.Expression;
-    const arms = (node.arms || []).map((arm: PhpNode) => {
-        const conds = (arm.conds || []).map((cond: PhpNode) => visit(cond, opts) as UAST.Expression);
-        const armObject = UAST.objectExpression([
-            appendNodeMeta(
-                UAST.objectProperty(
-                    UAST.identifier('conds'),
-                    UAST.tupleExpression(conds.length > 0 ? conds : [UAST.literal('default', 'string')])
-                ),
-                arm,
-                opts?.sourcefile
-            ),
-            appendNodeMeta(
-                UAST.objectProperty(UAST.identifier('body'), visit(arm.body, opts) as UAST.Expression),
-                arm,
-                opts?.sourcefile
-            ),
-        ]);
-        if (!arm.conds) {
-            armObject._meta.default = true;
+/** 去除字符串两端的引号 */
+function stripQuotes(text: string): string {
+    if (text.length >= 2) {
+        const first = text[0];
+        const last = text[text.length - 1];
+        if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+            return text.slice(1, -1);
         }
-        return appendNodeMeta(armObject, arm, opts?.sourcefile);
-    });
-    const args = [condition, UAST.tupleExpression(arms)];
-    const call = UAST.callExpression(UAST.identifier('match'), args);
-    call._meta.synthetic = true;
-    return appendNodeMeta(call, node, opts?.sourcefile);
-}
-
-function createCast(node: PhpNode, opts: Record<string, any>) {
-    const type = UAST.dynamicType(UAST.identifier(String(node.type || 'mixed')));
-    const expr = UAST.castExpression(visit(node.expr, opts) as UAST.Expression, type);
-    expr._meta.raw = node.raw;
-    return appendNodeMeta(expr, node, opts?.sourcefile);
-}
-
-function createTraitUse(node: PhpNode, opts: Record<string, any>) {
-    const stmt = createPseudoCallStatement(
-        'trait_use',
-        (node.traits || []).map((traitNode: PhpNode) => visit(traitNode, opts) as UAST.Expression),
-        node,
-        opts
-    );
-    stmt._meta.adaptations = (node.adaptations || []).map((adaptation: PhpNode) => {
-        if (adaptation.kind === 'traitprecedence') {
-            return {
-                kind: adaptation.kind,
-                trait: visit(adaptation.trait, opts),
-                method: visit(adaptation.method, opts),
-                instead: visitList(adaptation.instead, opts),
-            };
-        }
-        if (adaptation.kind === 'traitalias') {
-            return {
-                kind: adaptation.kind,
-                trait: visit(adaptation.trait, opts),
-                method: visit(adaptation.method, opts),
-                as: visit(adaptation.as, opts),
-                visibility: adaptation.visibility || '',
-            };
-        }
-        return adaptation;
-    });
-    return stmt;
-}
-
-function createEnum(node: PhpNode, opts: Record<string, any>) {
-    const body = flattenInstructions(visitList(node.body, opts));
-    const cdef = UAST.classDefinition(visit(node.name, opts) as UAST.Identifier, body, []);
-    cdef._meta.structureKind = 'enum';
-    cdef._meta.valueType = visit(node.valueType, opts);
-    cdef._meta.implements = visitList(node.implements, opts);
-    cdef._meta.attributes = createAttrGroups(node.attrGroups, opts);
-    return appendNodeMeta(cdef, node, opts?.sourcefile);
-}
-
-function createEnumCase(node: PhpNode, opts: Record<string, any>) {
-    const decl = createVariableDeclaration(node.name, node.value, node, opts);
-    decl._meta.enumCase = true;
-    return appendNodeMeta(decl, node, opts?.sourcefile);
-}
-
-function createNamespace(node: PhpNode, opts: Record<string, any>) {
-    const instructions: Array<UAST.Instruction> = [];
-    if (node.name) {
-        const nameStr = Array.isArray(node.name) ? node.name.join('\\') : String(node.name);
-        const pkg = UAST.packageDeclaration(UAST.identifier(nameStr));
-        instructions.push(appendNodeMeta(pkg, node, opts?.sourcefile));
     }
-    instructions.push(...flattenInstructions(visitList(node.children, opts)));
-
-    if (instructions.length === 1) {
-        return instructions[0];
-    }
-
-    const seq = UAST.sequence(instructions);
-    return appendNodeMeta(seq, node, opts?.sourcefile);
+    return text;
 }
 
-function visit(node: PhpNode | null | undefined, opts: Record<string, any>): any {
+/** 从 heredoc/nowdoc 中提取内容（去掉标签行和结束标签行） */
+function stripHeredoc(text: string): string {
+    const lines = text.split('\n');
+    // 第一行: <<<TAG 或 <<<'TAG'
+    // 最后一行: TAG;
+    if (lines.length >= 2) {
+        return lines.slice(1, -1).join('\n');
+    }
+    return text;
+}
+
+/** 从节点的匿名子节点中提取 operator 文本 */
+function getOperator(node: SyntaxNode): string {
+    for (let i = 0; i < node.childCount; i++) {
+        const child = node.child(i)!;
+        if (!child.isNamed && child.text !== '(' && child.text !== ')' && child.text !== ',' && child.text !== ';') {
+            return child.text;
+        }
+    }
+    return '=';
+}
+
+/** 处理函数参数（simple_parameter / variadic_parameter / property_promotion_parameter） */
+function createParameter(paramNode: SyntaxNode, opts: Record<string, any>): any {
+    const sourcefile = opts?.sourcefile as string | undefined;
+    const nameNode = paramNode.childForFieldName('name');
+    const id = nameNode ? visit(nameNode, opts) as UAST.Identifier : UAST.identifier('_');
+    const defaultValueNode = paramNode.childForFieldName('default_value');
+    const init = defaultValueNode ? visit(defaultValueNode, opts) as UAST.Expression : null;
+    const varDecl = UAST.variableDeclaration(id, init, false, UAST.dynamicType());
+    varDecl._meta.variadic = paramNode.type === 'variadic_parameter';
+    // property_promotion_parameter 的 visibility
+    if (paramNode.type === 'property_promotion_parameter') {
+        for (const child of paramNode.namedChildren) {
+            if (child.type === 'visibility_modifier') {
+                varDecl._meta.visibility = child.text;
+                break;
+            }
+        }
+    }
+    return appendNodeMeta(varDecl, paramNode, sourcefile);
+}
+
+/** 构建函数定义（function_definition / method_declaration / anonymous_function） */
+function createFunctionLike(node: SyntaxNode, opts: Record<string, any>): any {
+    const sourcefile = opts?.sourcefile as string | undefined;
+    const nameNode = node.childForFieldName('name');
+    const id = nameNode ? visit(nameNode, opts) as UAST.Identifier : null;
+    const paramsNode = node.childForFieldName('parameters');
+    const parameters = paramsNode
+        ? paramsNode.namedChildren.map((p) => createParameter(p, opts))
+        : [];
+    const bodyNode = node.childForFieldName('body');
+    const body = bodyNode
+        ? visit(bodyNode, opts) as UAST.Instruction
+        : appendNodeMeta(UAST.scopedStatement([]), node, sourcefile);
+    const modifiers: string[] = [];
+    for (const child of node.namedChildren) {
+        if (child.type === 'visibility_modifier' || child.type === 'static_modifier'
+            || child.type === 'abstract_modifier' || child.type === 'final_modifier'
+            || child.type === 'readonly_modifier') {
+            modifiers.push(child.text);
+        }
+    }
+    const fdef = UAST.functionDefinition(id, parameters, UAST.dynamicType(), body, modifiers);
+    return appendNodeMeta(fdef, node, sourcefile);
+}
+
+/** 构建类/接口/trait 定义 */
+function createClassLike(node: SyntaxNode, opts: Record<string, any>, kind?: string): any {
+    const sourcefile = opts?.sourcefile as string | undefined;
+    const nameNode = node.childForFieldName('name');
+    const id = nameNode ? visit(nameNode, opts) as UAST.Identifier : null;
+    const bodyNode = node.childForFieldName('body');
+    const body = bodyNode
+        ? flattenInstructions(visitList(bodyNode.namedChildren, opts))
+        : [];
+    // extends
+    const supers: Array<UAST.Expression> = [];
+    const baseClause = node.childForFieldName('base_clause');
+    if (baseClause) {
+        for (const child of baseClause.namedChildren) {
+            const superExpr = visit(child, opts);
+            if (superExpr) supers.push(superExpr);
+        }
+    }
+    const cdef = UAST.classDefinition(id, body, supers);
+    // implements
+    const implementsClause = node.childForFieldName('class_interface_clause');
+    if (implementsClause) {
+        cdef._meta.implements = visitList(implementsClause.namedChildren, opts);
+    }
+    if (kind) {
+        cdef._meta.kind = kind;
+    }
+    // modifiers
+    for (const child of node.namedChildren) {
+        if (child.type === 'abstract_modifier') cdef._meta.isAbstract = true;
+        if (child.type === 'final_modifier') cdef._meta.isFinal = true;
+        if (child.type === 'readonly_modifier') cdef._meta.isReadonly = true;
+    }
+    return appendNodeMeta(cdef, node, sourcefile);
+}
+
+function visit(node: SyntaxNode | null | undefined, opts: Record<string, any>): any {
     if (!node) {
         return null;
     }
 
-    switch (node.kind) {
-        case 'program':
-            return createProgram(node, opts);
-        case 'expressionstatement': {
-            const exprStmt = UAST.expressionStatement(visit(node.expression, opts) as UAST.Expression);
-            return appendNodeMeta(exprStmt, node, opts?.sourcefile);
+    const sourcefile = opts?.sourcefile as string | undefined;
+
+    switch (node.type) {
+        case 'program': {
+            const children = node.namedChildren.filter((child) => child.type !== 'php_tag');
+            const body = flattenInstructions(visitList(children, opts));
+            const compileUnit = UAST.compileUnit(body, 'php', null, sourcefile || '', version);
+            return appendNodeMeta(compileUnit, node, sourcefile);
         }
-        case 'assign': {
-            const rawOp = node.operator || '=';
-            const mappedOp = mapAssignOperator(rawOp);
-            const assign = UAST.assignmentExpression(
-                visit(node.left, opts) as UAST.LVal,
-                visit(node.right, opts) as UAST.Expression,
-                mappedOp as any,
-                false
+
+        case 'expression_statement': {
+            const child = node.namedChildren[0];
+            if (!child) {
+                return appendNodeMeta(UAST.noop(), node, sourcefile);
+            }
+            const result = visit(child, opts);
+            // throw_expression 等节点返回的是语句而非表达式，直接返回
+            if (UAST.isNode(result) && result.type.endsWith('Statement')) {
+                return appendNodeMeta(result, node, sourcefile);
+            }
+            const exprStmt = UAST.expressionStatement(result as UAST.Expression);
+            return appendNodeMeta(exprStmt, node, sourcefile);
+        }
+
+        case 'variable_name': {
+            // $variable -> 'variable'（variable_name 的 namedChild(0) 是 name 节点）
+            const nameNode = node.namedChildren[0];
+            const name = nameNode ? nameNode.text : node.text.replace(/^\$/, '');
+            return appendNodeMeta(UAST.identifier(name), node, sourcefile);
+        }
+
+        case 'dynamic_variable_name': {
+            // $$var -> 变量变量，递归访问内部节点
+            const inner = node.namedChildren[0];
+            if (inner) {
+                return visit(inner, opts);
+            }
+            return appendNodeMeta(UAST.identifier(node.text.replace(/^\$+/, '')), node, sourcefile);
+        }
+
+        case 'by_ref': {
+            // &$var -> 引用传递，直接访问内部变量
+            const inner = node.namedChildren[0];
+            if (inner) {
+                const result = visit(inner, opts);
+                if (UAST.isNode(result)) {
+                    result._meta.byref = true;
+                }
+                return result;
+            }
+            return appendNodeMeta(UAST.noop(), node, sourcefile);
+        }
+
+        case 'name':
+            return appendNodeMeta(UAST.identifier(node.text), node, sourcefile);
+
+        case 'qualified_name':
+            return appendNodeMeta(UAST.identifier(node.text), node, sourcefile);
+
+        case 'namespace_name':
+            return appendNodeMeta(UAST.identifier(node.text), node, sourcefile);
+
+        case 'relative_scope':
+            // self / parent / static
+            return appendNodeMeta(UAST.identifier(node.text), node, sourcefile);
+
+        case 'integer':
+            return appendNodeMeta(UAST.literal(Number(node.text), 'number'), node, sourcefile);
+
+        case 'float':
+            return appendNodeMeta(UAST.literal(Number(node.text), 'number'), node, sourcefile);
+
+        case 'string':
+            return appendNodeMeta(UAST.literal(stripQuotes(node.text), 'string'), node, sourcefile);
+
+        case 'encapsed_string': {
+            // 含变量插值的双引号字符串，拆成 binary concat
+            const parts = node.namedChildren.map((child) => {
+                if (child.type === 'string_content') {
+                    return appendNodeMeta(UAST.literal(child.text, 'string'), child, sourcefile);
+                }
+                return visit(child, opts);
+            });
+            if (parts.length === 0) {
+                return appendNodeMeta(UAST.literal('', 'string'), node, sourcefile);
+            }
+            let expr = parts[0];
+            for (let i = 1; i < parts.length; i++) {
+                expr = appendNodeMeta(UAST.binaryExpression('+' as any, expr, parts[i]), node, sourcefile);
+            }
+            if (expr && UAST.isNode(expr)) {
+                expr._meta.encapsed = true;
+            }
+            return appendNodeMeta(expr, node, sourcefile);
+        }
+
+        case 'heredoc': {
+            const content = stripHeredoc(node.text);
+            const literal = UAST.literal(content, 'string');
+            literal._meta.heredoc = true;
+            return appendNodeMeta(literal, node, sourcefile);
+        }
+
+        case 'nowdoc': {
+            const content = stripHeredoc(node.text);
+            const literal = UAST.literal(content, 'string');
+            literal._meta.nowdoc = true;
+            return appendNodeMeta(literal, node, sourcefile);
+        }
+
+        case 'boolean':
+            return appendNodeMeta(
+                UAST.literal(node.text.toLowerCase() === 'true', 'boolean'),
+                node,
+                sourcefile
             );
+
+        case 'null':
+            return appendNodeMeta(UAST.literal(null, 'null'), node, sourcefile);
+
+        case 'argument': {
+            // argument 节点包装了一个表达式 child
+            const child = node.namedChildren[0];
+            return child ? visit(child, opts) : appendNodeMeta(UAST.noop(), node, sourcefile);
+        }
+
+        case 'parenthesized_expression': {
+            const child = node.namedChildren[0];
+            return child ? visit(child, opts) : appendNodeMeta(UAST.noop(), node, sourcefile);
+        }
+
+        case 'text_interpolation':
+            // HTML 文本片段，跳过
+            return null;
+
+        // ─── 赋值 ───
+
+        case 'assignment_expression': {
+            const left = visit(node.childForFieldName('left'), opts) as UAST.LVal;
+            const right = visit(node.childForFieldName('right'), opts) as UAST.Expression;
+            const op = mapAssignOperator(getOperator(node));
+            const assign = UAST.assignmentExpression(left, right, op as any, false);
+            return appendNodeMeta(assign, node, sourcefile);
+        }
+
+        case 'augmented_assignment_expression': {
+            const left = visit(node.childForFieldName('left'), opts) as UAST.LVal;
+            const right = visit(node.childForFieldName('right'), opts) as UAST.Expression;
+            const rawOp = getOperator(node);
+            const mappedOp = mapAssignOperator(rawOp);
+            const assign = UAST.assignmentExpression(left, right, mappedOp as any, false);
             if (rawOp !== mappedOp) {
                 assign._meta.rawOperator = rawOp;
             }
-            return appendNodeMeta(assign, node, opts?.sourcefile);
+            return appendNodeMeta(assign, node, sourcefile);
         }
-        case 'assignref': {
-            const assign = UAST.assignmentExpression(
-                visit(node.left, opts) as UAST.LVal,
-                visit(node.right, opts) as UAST.Expression,
-                '=',
-                true
-            );
+
+        case 'reference_assignment_expression': {
+            const left = visit(node.childForFieldName('left'), opts) as UAST.LVal;
+            const right = visit(node.childForFieldName('right'), opts) as UAST.Expression;
+            const assign = UAST.assignmentExpression(left, right, '=', true);
             assign._meta.byref = true;
-            return appendNodeMeta(assign, node, opts?.sourcefile);
+            return appendNodeMeta(assign, node, sourcefile);
         }
-        case 'variable':
-        case 'identifier':
-            // 动态变量名 $$var: node.name 是对象而非字符串
-            if (typeof node.name === 'object' && node.name !== null) {
-                return visit(node.name, opts);
+
+        // ─── 二元 / 条件 / 一元 ───
+
+        case 'binary_expression': {
+            const left = visit(node.childForFieldName('left'), opts) as UAST.Expression;
+            const right = visit(node.childForFieldName('right'), opts) as UAST.Expression;
+            const op = getOperator(node);
+            const binary = UAST.binaryExpression(mapBinaryOperator(op) as any, left, right);
+            return appendNodeMeta(binary, node, sourcefile);
+        }
+
+        case 'conditional_expression': {
+            const named = node.namedChildren;
+            if (named.length >= 3) {
+                // 完整三元：condition ? consequent : alternative
+                const cond = visit(named[0], opts) as UAST.Expression;
+                const consequent = visit(named[1], opts) as UAST.Expression;
+                const alternative = visit(named[2], opts) as UAST.Expression;
+                return appendNodeMeta(UAST.conditionalExpression(cond, consequent, alternative), node, sourcefile);
             }
-            return appendNodeMeta(UAST.identifier(node.name), node, opts?.sourcefile);
-        case 'name': {
-            const nameStr = Array.isArray(node.name) ? node.name.join('\\') : String(node.name);
-            return appendNodeMeta(UAST.identifier(nameStr), node, opts?.sourcefile);
+            // PHP Elvis ?:（省略 consequent），只有 2 个 namedChildren
+            const cond = visit(named[0], opts) as UAST.Expression;
+            const alternative = visit(named[1], opts) as UAST.Expression;
+            // 复用 condition 作为 consequent
+            const condDup = visit(named[0], opts) as UAST.Expression;
+            return appendNodeMeta(UAST.conditionalExpression(cond, condDup, alternative), node, sourcefile);
         }
-        case 'selfreference':
-            return appendNodeMeta(UAST.identifier('self'), node, opts?.sourcefile);
-        case 'parentreference':
-            return appendNodeMeta(UAST.identifier('parent'), node, opts?.sourcefile);
-        case 'staticreference':
-            return appendNodeMeta(UAST.identifier('static'), node, opts?.sourcefile);
-        case 'number':
-            return appendNodeMeta(UAST.literal(Number(node.value), 'number'), node, opts?.sourcefile);
-        case 'string':
-            return appendNodeMeta(UAST.literal(node.value, 'string'), node, opts?.sourcefile);
-        case 'nowdoc': {
-            const literal = UAST.literal(node.value, 'string');
-            literal._meta.label = node.label;
-            literal._meta.nowdoc = true;
-            return appendNodeMeta(literal, node, opts?.sourcefile);
+
+        case 'unary_op_expression': {
+            const op = getOperator(node);
+            const operand = visit(node.namedChildren[0], opts) as UAST.Expression;
+            const unary = UAST.unaryExpression(op as any, operand, false);
+            return appendNodeMeta(unary, node, sourcefile);
         }
-        case 'magic': {
-            const literal = UAST.literal(node.value, 'string');
-            literal._meta.magic = true;
-            literal._meta.raw = node.raw;
-            return appendNodeMeta(literal, node, opts?.sourcefile);
+
+        case 'update_expression': {
+            // 判断 prefix/postfix：第一个子节点是匿名（operator）则 prefix，否则 postfix
+            const firstChild = node.child(0)!;
+            const isPostfix = firstChild.isNamed;
+            const op = getOperator(node);
+            const operand = visit(node.namedChildren[0], opts) as UAST.Expression;
+            const unary = UAST.unaryExpression(op as any, operand, isPostfix);
+            return appendNodeMeta(unary, node, sourcefile);
         }
-        case 'boolean':
-            return appendNodeMeta(UAST.literal(Boolean(node.value), 'boolean'), node, opts?.sourcefile);
-        case 'nullkeyword':
-            return appendNodeMeta(UAST.literal(null, 'null'), node, opts?.sourcefile);
-        case 'namedargument': {
-            const expr = visit(node.value, opts) as UAST.Expression;
-            if (expr && UAST.isNode(expr)) {
-                expr._meta.argName = node.name;
-            }
-            return expr;
+
+        // ─── 调用 ───
+
+        case 'function_call_expression': {
+            const callee = visit(node.childForFieldName('function'), opts) as UAST.Expression;
+            const argsNode = node.childForFieldName('arguments');
+            const args = argsNode ? visitList(argsNode.namedChildren, opts) as Array<UAST.Expression> : [];
+            const call = UAST.callExpression(callee, args);
+            return appendNodeMeta(call, node, sourcefile);
         }
-        case 'encapsed':
-            return createEncapsed(node, opts);
-        case 'bin': {
-            const binary = UAST.binaryExpression(
-                mapBinaryOperator(node.type || node.operator) as any,
-                visit(node.left, opts) as UAST.Expression,
-                visit(node.right, opts) as UAST.Expression
-            );
-            return appendNodeMeta(binary, node, opts?.sourcefile);
+
+        case 'member_call_expression': {
+            const object = visit(node.childForFieldName('object'), opts) as UAST.Expression;
+            const name = visit(node.childForFieldName('name'), opts) as UAST.Expression;
+            const memberCallee = UAST.memberAccess(object, name, false);
+            appendNodeMeta(memberCallee, node, sourcefile);
+            const argsNode = node.childForFieldName('arguments');
+            const args = argsNode ? visitList(argsNode.namedChildren, opts) as Array<UAST.Expression> : [];
+            const call = UAST.callExpression(memberCallee, args);
+            return appendNodeMeta(call, node, sourcefile);
         }
-        case 'retif': {
-            const testExpr = visit(node.test, opts) as UAST.Expression;
-            // PHP Elvis 运算符 $a ?: $b 省略中间表达式，复用 test 作为 consequent
-            const consequent = node.trueExpr
-                ? visit(node.trueExpr, opts) as UAST.Expression
-                : visit(node.test, opts) as UAST.Expression;
-            const conditional = UAST.conditionalExpression(
-                testExpr,
-                consequent,
-                visit(node.falseExpr, opts) as UAST.Expression
-            );
-            return appendNodeMeta(conditional, node, opts?.sourcefile);
+
+        case 'scoped_call_expression': {
+            const scope = visit(node.childForFieldName('scope'), opts) as UAST.Expression;
+            const name = visit(node.childForFieldName('name'), opts) as UAST.Expression;
+            const memberCallee = UAST.memberAccess(scope, name, false);
+            memberCallee._meta.isStatic = true;
+            appendNodeMeta(memberCallee, node, sourcefile);
+            const argsNode = node.childForFieldName('arguments');
+            const args = argsNode ? visitList(argsNode.namedChildren, opts) as Array<UAST.Expression> : [];
+            const call = UAST.callExpression(memberCallee, args);
+            return appendNodeMeta(call, node, sourcefile);
         }
-        case 'unary': {
-            const unary = UAST.unaryExpression(
-                (node.type || '!') as any,
-                visit(node.what, opts) as UAST.Expression,
-                false
-            );
-            return appendNodeMeta(unary, node, opts?.sourcefile);
+
+        // ─── new / cast ───
+
+        case 'object_creation_expression': {
+            const className = visit(node.namedChildren[0], opts) as UAST.Expression;
+            const argsNode = node.childForFieldName('arguments');
+            const args = argsNode ? visitList(argsNode.namedChildren, opts) as Array<UAST.Expression> : [];
+            const expr = UAST.newExpression(className, args);
+            return appendNodeMeta(expr, node, sourcefile);
         }
-        case 'pre': {
-            const operator = node.type === '-' ? '--' : '++';
-            const unary = UAST.unaryExpression(
-                operator as any,
-                visit(node.what, opts) as UAST.Expression,
-                false
-            );
-            return appendNodeMeta(unary, node, opts?.sourcefile);
+
+        case 'cast_expression': {
+            const typeNode = node.childForFieldName('type');
+            const castType = typeNode ? typeNode.text.replace(/[()]/g, '').trim() : 'mixed';
+            const value = visit(node.childForFieldName('value'), opts) as UAST.Expression;
+            const call = UAST.callExpression(UAST.identifier(castType), [value]);
+            call._meta.isCast = true;
+            return appendNodeMeta(call, node, sourcefile);
         }
-        case 'post': {
-            const operator = node.type === '-' ? '--' : '++';
-            const unary = UAST.unaryExpression(
-                operator as any,
-                visit(node.what, opts) as UAST.Expression,
-                true
-            );
-            return appendNodeMeta(unary, node, opts?.sourcefile);
+
+        // ─── 成员访问 ───
+
+        case 'member_access_expression': {
+            const object = visit(node.childForFieldName('object'), opts) as UAST.Expression;
+            const name = visit(node.childForFieldName('name'), opts) as UAST.Expression;
+            const member = UAST.memberAccess(object, name, false);
+            return appendNodeMeta(member, node, sourcefile);
         }
-        case 'call': {
-            const call = UAST.callExpression(
-                visit(node.what, opts) as UAST.Expression,
-                (node.arguments || []).map((arg: PhpNode) => visit(arg, opts) as UAST.Expression)
-            );
-            return appendNodeMeta(call, node, opts?.sourcefile);
-        }
-        case 'new': {
-            const expr = UAST.newExpression(
-                visit(node.what, opts) as UAST.Expression,
-                (node.arguments || []).map((arg: PhpNode) => visit(arg, opts) as UAST.Expression)
-            );
-            return appendNodeMeta(expr, node, opts?.sourcefile);
-        }
-        case 'cast':
-            return createCast(node, opts);
-        case 'propertylookup': {
-            const member = UAST.memberAccess(
-                visit(node.what, opts) as UAST.Expression,
-                visit(node.offset, opts) as UAST.Expression,
-                false
-            );
-            return appendNodeMeta(member, node, opts?.sourcefile);
-        }
-        case 'nullsafepropertylookup': {
-            const object = visit(node.what, opts) as UAST.Expression;
-            const access = UAST.memberAccess(object, visit(node.offset, opts) as UAST.Expression, false);
-            appendNodeMeta(access, node, opts?.sourcefile);
+
+        case 'nullsafe_member_access_expression': {
+            const object = visit(node.childForFieldName('object'), opts) as UAST.Expression;
+            const name = visit(node.childForFieldName('name'), opts) as UAST.Expression;
+            const access = UAST.memberAccess(object, name, false);
+            appendNodeMeta(access, node, sourcefile);
             access._meta.nullsafe = true;
             const expr = UAST.conditionalExpression(object, access, UAST.literal(null, 'null'));
-            return appendNodeMeta(expr, node, opts?.sourcefile);
+            return appendNodeMeta(expr, node, sourcefile);
         }
-        case 'staticlookup': {
-            const member = UAST.memberAccess(
-                visit(node.what, opts) as UAST.Expression,
-                visit(node.offset, opts) as UAST.Expression,
-                false
-            );
+
+        case 'scoped_property_access_expression': {
+            const scope = visit(node.childForFieldName('scope'), opts) as UAST.Expression;
+            const name = visit(node.childForFieldName('name'), opts) as UAST.Expression;
+            const member = UAST.memberAccess(scope, name, false);
             member._meta.isStatic = true;
-            return appendNodeMeta(member, node, opts?.sourcefile);
+            return appendNodeMeta(member, node, sourcefile);
         }
-        case 'offsetlookup': {
-            // $arr[] 数组追加时 node.offset 为 null，用 noop 占位
-            const offsetProperty = node.offset ? visit(node.offset, opts) as UAST.Expression : UAST.noop() as any;
-            const member = UAST.memberAccess(
-                visit(node.what, opts) as UAST.Expression,
-                offsetProperty,
-                true
-            );
-            return appendNodeMeta(member, node, opts?.sourcefile);
+
+        case 'class_constant_access_expression': {
+            // class_constant_access_expression 没有字段名，按位置取 namedChildren
+            const scope = visit(node.namedChildren[0], opts) as UAST.Expression;
+            const name = visit(node.namedChildren[1], opts) as UAST.Expression;
+            const member = UAST.memberAccess(scope, name, false);
+            member._meta.isStatic = true;
+            return appendNodeMeta(member, node, sourcefile);
         }
-        case 'array':
-            return createArrayExpression(node, opts);
-        case 'list':
-            return createTupleExpression(node, opts);
-        case 'match':
-            return createMatchExpression(node, opts);
-        case 'include':
-            return createImportExpression(node, opts);
-        case 'isset':
-            return createPseudoCall(
-                'isset',
-                (node.variables || []).map((variable: PhpNode) => visit(variable, opts) as UAST.Expression),
-                node,
-                opts
-            );
-        case 'empty':
-            return createPseudoCall('empty', [visit(node.expression, opts) as UAST.Expression], node, opts);
-        case 'clone':
-            return createPseudoCall('clone', [visit(node.what, opts) as UAST.Expression], node, opts);
-        case 'unset':
-            return createPseudoCall(
-                'unset',
-                (node.variables || []).map((variable: PhpNode) => visit(variable, opts) as UAST.Expression),
-                node,
-                opts
-            );
-        case 'block': {
-            const block = UAST.scopedStatement(flattenInstructions(visitList(node.children, opts)));
-            return appendNodeMeta(block, node, opts?.sourcefile);
+
+        case 'subscript_expression': {
+            const named = node.namedChildren;
+            const object = visit(named[0], opts) as UAST.Expression;
+            // $arr[] 数组追加时 index 为空，用 noop 占位
+            const index = named.length > 1 ? visit(named[1], opts) as UAST.Expression : UAST.noop() as any;
+            const member = UAST.memberAccess(object, index, true);
+            return appendNodeMeta(member, node, sourcefile);
         }
-        case 'if': {
-            const ifBody = node.body ? visit(node.body, opts) as UAST.Instruction : UAST.scopedStatement([]);
-            const ifStmt = UAST.ifStatement(
-                visit(node.test, opts) as UAST.Expression,
-                ifBody,
-                visit(node.alternate, opts) as UAST.Instruction | null
-            );
-            return appendNodeMeta(ifStmt, node, opts?.sourcefile);
+
+        // ─── 数组 / 列表 / match ───
+
+        case 'array_creation_expression': {
+            const properties = node.namedChildren.map((element) => {
+                const elementChildren = element.namedChildren;
+                if (elementChildren.length >= 2) {
+                    // key => value
+                    const key = visit(elementChildren[0], opts) as UAST.Expression;
+                    const value = visit(elementChildren[1], opts) as UAST.Expression;
+                    const prop = UAST.objectProperty(key, value);
+                    return appendNodeMeta(prop, element, sourcefile);
+                }
+                // value only
+                const value = visit(elementChildren[0], opts) as UAST.Expression;
+                const prop = UAST.objectProperty(UAST.literal(null, 'null'), value);
+                return appendNodeMeta(prop, element, sourcefile);
+            });
+            const expr = UAST.objectExpression(properties);
+            expr._meta.isArray = true;
+            return appendNodeMeta(expr, node, sourcefile);
         }
-        case 'return': {
-            const ret = UAST.returnStatement(visit(node.expr, opts) as UAST.Expression | null);
-            return appendNodeMeta(ret, node, opts?.sourcefile);
+
+        case 'list_literal': {
+            const elements = node.namedChildren.map((child) => visit(child, opts) as UAST.Expression);
+            const tuple = UAST.tupleExpression(elements);
+            return appendNodeMeta(tuple, node, sourcefile);
         }
-        case 'break': {
-            const stmt = UAST.breakStatement();
-            stmt._meta.level = node.level;
-            return appendNodeMeta(stmt, node, opts?.sourcefile);
+
+        case 'match_expression': {
+            const condition = visit(node.childForFieldName('condition_list') || node.childForFieldName('condition'), opts) as UAST.Expression;
+            const bodyNode = node.childForFieldName('body');
+            const arms = bodyNode ? bodyNode.namedChildren.map((arm) => {
+                if (arm.type === 'match_default_expression') {
+                    // default arm
+                    const body = visit(arm.childForFieldName('return_expression') || arm.namedChildren[0], opts) as UAST.Expression;
+                    const armObject = UAST.objectExpression([
+                        appendNodeMeta(
+                            UAST.objectProperty(UAST.identifier('conds'), UAST.tupleExpression([UAST.literal('default', 'string')])),
+                            arm, sourcefile
+                        ),
+                        appendNodeMeta(UAST.objectProperty(UAST.identifier('body'), body), arm, sourcefile),
+                    ]);
+                    armObject._meta.default = true;
+                    return appendNodeMeta(armObject, arm, sourcefile);
+                }
+                // match_conditional_expression
+                const condListNode = arm.childForFieldName('conditional_expressions');
+                const conds = condListNode
+                    ? visitList(condListNode.namedChildren, opts) as Array<UAST.Expression>
+                    : visitList(arm.namedChildren.slice(0, -1), opts) as Array<UAST.Expression>;
+                const returnExpr = arm.childForFieldName('return_expression') || arm.namedChildren[arm.namedChildren.length - 1];
+                const body = visit(returnExpr, opts) as UAST.Expression;
+                const armObject = UAST.objectExpression([
+                    appendNodeMeta(
+                        UAST.objectProperty(UAST.identifier('conds'), UAST.tupleExpression(conds.length > 0 ? conds : [UAST.literal('default', 'string')])),
+                        arm, sourcefile
+                    ),
+                    appendNodeMeta(UAST.objectProperty(UAST.identifier('body'), body), arm, sourcefile),
+                ]);
+                return appendNodeMeta(armObject, arm, sourcefile);
+            }) : [];
+            const matchArgs = [condition, UAST.tupleExpression(arms)];
+            const call = UAST.callExpression(UAST.identifier('match'), matchArgs);
+            call._meta.synthetic = true;
+            return appendNodeMeta(call, node, sourcefile);
         }
-        case 'continue': {
-            const stmt = UAST.continueStatement();
-            stmt._meta.level = node.level;
-            return appendNodeMeta(stmt, node, opts?.sourcefile);
+
+        // ─── import ───
+
+        case 'include_expression':
+        case 'include_once_expression':
+        case 'require_expression':
+        case 'require_once_expression': {
+            const targetNode = visit(node.namedChildren[0], opts);
+            let target: UAST.Literal;
+            if (UAST.isLiteral(targetNode)) {
+                target = targetNode;
+            } else {
+                // 动态 include，用空字符串占位
+                target = UAST.literal('', 'string');
+                target._meta.dynamicFrom = targetNode;
+            }
+            const importExpr = UAST.importExpression(target);
+            importExpr._meta.require = node.type.startsWith('require');
+            importExpr._meta.once = node.type.endsWith('once_expression');
+            return appendNodeMeta(importExpr, node, sourcefile);
         }
-        case 'throw': {
-            const stmt = UAST.throwStatement(visit(node.what, opts) as UAST.Expression);
-            return appendNodeMeta(stmt, node, opts?.sourcefile);
-        }
-        case 'try': {
-            const stmt = UAST.tryStatement(
-                visit(node.body, opts) as UAST.Statement,
-                (node.catches || []).map((catchNode: PhpNode) => createCatchClause(catchNode, opts)),
-                visit(node.always, opts) as UAST.Instruction | null
-            );
-            return appendNodeMeta(stmt, node, opts?.sourcefile);
-        }
-        case 'switch': {
-            const stmt = UAST.switchStatement(
-                visit(node.test, opts) as UAST.Expression,
-                flattenInstructions(visitList(node.body?.children, opts)) as Array<UAST.CaseClause>
-            );
-            return appendNodeMeta(stmt, node, opts?.sourcefile);
-        }
-        case 'case': {
-            const clause = UAST.caseClause(
-                visit(node.test, opts) as UAST.Expression | null,
-                visit(node.body, opts) as UAST.Instruction
-            );
-            return appendNodeMeta(clause, node, opts?.sourcefile);
-        }
-        case 'for': {
-            const forBody = node.body ? visit(node.body, opts) as UAST.Instruction : UAST.scopedStatement([]);
-            const stmt = UAST.forStatement(
-                createLoopInit(node.init, opts) as UAST.Expression | UAST.VariableDeclaration | null,
-                createLoopExpr(node.test, opts) as UAST.Expression | null,
-                createLoopExpr(node.increment, opts) as UAST.Expression | null,
-                forBody
-            );
-            return appendNodeMeta(stmt, node, opts?.sourcefile);
-        }
-        case 'foreach': {
-            const key = node.key ? createVariableDeclaration(node.key, null, node.key, opts) : null;
-            const value = node.value ? createVariableDeclaration(node.value, null, node.value, opts) : null;
-            const foreachBody = node.body ? visit(node.body, opts) as UAST.Instruction : UAST.scopedStatement([]);
-            const stmt = UAST.rangeStatement(
-                key,
-                value,
-                visit(node.source, opts) as UAST.Expression,
-                foreachBody
-            );
-            return appendNodeMeta(stmt, node, opts?.sourcefile);
-        }
-        case 'while': {
-            const whileBody = node.body ? visit(node.body, opts) as UAST.Instruction : UAST.scopedStatement([]);
-            const stmt = UAST.whileStatement(
-                visit(node.test, opts) as UAST.Expression,
-                whileBody,
-                false
-            );
-            return appendNodeMeta(stmt, node, opts?.sourcefile);
-        }
-        case 'do': {
-            const doBody = node.body ? visit(node.body, opts) as UAST.Instruction : UAST.scopedStatement([]);
-            const stmt = UAST.whileStatement(
-                visit(node.test, opts) as UAST.Expression,
-                doBody,
-                true
-            );
-            return appendNodeMeta(stmt, node, opts?.sourcefile);
-        }
-        case 'echo': {
-            const echoCall = UAST.callExpression(
-                UAST.identifier('echo'),
-                (node.expressions || []).map((expr: PhpNode) => visit(expr, opts) as UAST.Expression)
-            );
-            appendNodeMeta(echoCall, node, opts?.sourcefile);
+
+        // ─── 其他表达式 ───
+
+        case 'echo_statement': {
+            const args = visitList(node.namedChildren, opts) as Array<UAST.Expression>;
+            const echoCall = UAST.callExpression(UAST.identifier('echo'), args);
+            appendNodeMeta(echoCall, node, sourcefile);
             const exprStmt = UAST.expressionStatement(echoCall);
-            return appendNodeMeta(exprStmt, node, opts?.sourcefile);
+            return appendNodeMeta(exprStmt, node, sourcefile);
         }
-        case 'print':
-            return createPseudoCall('print', [visit(node.expression, opts) as UAST.Expression], node, opts);
-        case 'exit': {
-            const args = node.expression ? [visit(node.expression, opts) as UAST.Expression] : [];
-            const call = createPseudoCall('exit', args, node, opts);
-            call._meta.useDie = Boolean(node.useDie);
-            return call;
+
+        case 'yield_expression': {
+            const valueNode = node.namedChildren[0] || null;
+            const expr = UAST.yieldExpression(valueNode ? visit(valueNode, opts) as UAST.Expression : null);
+            return appendNodeMeta(expr, node, sourcefile);
         }
-        case 'eval':
-            return createPseudoCall('eval', [visit(node.source, opts) as UAST.Expression], node, opts);
-        case 'silent': {
-            const expr = visit(node.expr, opts) as UAST.Expression;
+
+        case 'error_suppression_expression': {
+            const expr = visit(node.namedChildren[0], opts);
             if (expr && UAST.isNode(expr)) {
                 expr._meta.silent = true;
             }
             return expr;
         }
-        case 'yield': {
-            const expr = UAST.yieldExpression(visit(node.value, opts) as UAST.Expression | null);
-            expr._meta.key = visit(node.key, opts);
-            return appendNodeMeta(expr, node, opts?.sourcefile);
+
+        case 'clone_expression': {
+            const expr = visit(node.namedChildren[0], opts) as UAST.Expression;
+            const call = UAST.callExpression(UAST.identifier('clone'), [expr]);
+            return appendNodeMeta(call, node, sourcefile);
         }
-        case 'yieldfrom': {
-            const expr = UAST.yieldExpression(visit(node.value, opts) as UAST.Expression | null);
-            expr._meta.isYieldFrom = true;
-            return appendNodeMeta(expr, node, opts?.sourcefile);
+
+        case 'print_intrinsic': {
+            const expr = visit(node.namedChildren[0], opts) as UAST.Expression;
+            const call = UAST.callExpression(UAST.identifier('print'), [expr]);
+            return appendNodeMeta(call, node, sourcefile);
         }
-        case 'function':
-            return createFunctionLike(node, opts);
-        case 'method':
-            return createFunctionLike(node, opts);
-        case 'closure': {
-            const fdef = createFunctionLike(node, opts, node.isStatic ? ['static'] : []);
-            fdef._meta.uses = (node.uses || []).map((item: PhpNode) => {
-                const value = visit(item, opts);
-                if (value && UAST.isNode(value)) {
-                    value._meta.byref = Boolean(item.byref);
+
+        case 'exit_statement': {
+            const args = node.namedChildren.length > 0
+                ? [visit(node.namedChildren[0], opts) as UAST.Expression]
+                : [];
+            const call = UAST.callExpression(UAST.identifier('exit'), args);
+            return appendNodeMeta(call, node, sourcefile);
+        }
+
+        case 'sequence_expression': {
+            const items = visitList(node.namedChildren, opts);
+            const seq = UAST.sequence(items);
+            return appendNodeMeta(seq, node, sourcefile);
+        }
+
+        // ─── 语句 ───
+
+        case 'compound_statement': {
+            const body = flattenInstructions(visitList(node.namedChildren, opts));
+            const scoped = UAST.scopedStatement(body);
+            return appendNodeMeta(scoped, node, sourcefile);
+        }
+
+        case 'if_statement': {
+            const condNode = node.childForFieldName('condition');
+            // parenthesized_expression → 取内层
+            const test = condNode && condNode.type === 'parenthesized_expression'
+                ? visit(condNode.namedChildren[0], opts) as UAST.Expression
+                : visit(condNode, opts) as UAST.Expression;
+            const bodyNode = node.childForFieldName('body');
+            const consequent = bodyNode
+                ? visit(bodyNode, opts) as UAST.Instruction
+                : UAST.scopedStatement([]);
+            // alternative: else_clause 或 else_if_clause
+            const altNode = node.childForFieldName('alternative');
+            let alternate: UAST.Instruction | null = null;
+            if (altNode) {
+                if (altNode.type === 'else_if_clause') {
+                    // 递归构建嵌套 if
+                    const elseIfCond = altNode.childForFieldName('condition');
+                    const elseIfTest = elseIfCond && elseIfCond.type === 'parenthesized_expression'
+                        ? visit(elseIfCond.namedChildren[0], opts) as UAST.Expression
+                        : visit(elseIfCond, opts) as UAST.Expression;
+                    const elseIfBody = altNode.childForFieldName('body');
+                    const elseIfConsequent = elseIfBody
+                        ? visit(elseIfBody, opts) as UAST.Instruction
+                        : UAST.scopedStatement([]);
+                    const elseIfAlt = altNode.childForFieldName('alternative');
+                    const nestedAlt = elseIfAlt ? visit(elseIfAlt, opts) as UAST.Instruction : null;
+                    alternate = UAST.ifStatement(elseIfTest, elseIfConsequent, nestedAlt);
+                    appendNodeMeta(alternate, altNode, sourcefile);
+                } else if (altNode.type === 'else_clause') {
+                    const elseBody = altNode.namedChildren[0];
+                    alternate = elseBody ? visit(elseBody, opts) as UAST.Instruction : UAST.scopedStatement([]);
+                } else {
+                    alternate = visit(altNode, opts) as UAST.Instruction;
                 }
-                return value;
-            });
-            fdef._meta.byref = Boolean(node.byref);
+            }
+            const ifStmt = UAST.ifStatement(test, consequent, alternate);
+            return appendNodeMeta(ifStmt, node, sourcefile);
+        }
+
+        case 'else_if_clause': {
+            const condNode = node.childForFieldName('condition');
+            const test = condNode && condNode.type === 'parenthesized_expression'
+                ? visit(condNode.namedChildren[0], opts) as UAST.Expression
+                : visit(condNode, opts) as UAST.Expression;
+            const bodyNode = node.childForFieldName('body');
+            const consequent = bodyNode
+                ? visit(bodyNode, opts) as UAST.Instruction
+                : UAST.scopedStatement([]);
+            const altNode = node.childForFieldName('alternative');
+            const alternate = altNode ? visit(altNode, opts) as UAST.Instruction : null;
+            const ifStmt = UAST.ifStatement(test, consequent, alternate);
+            return appendNodeMeta(ifStmt, node, sourcefile);
+        }
+
+        case 'else_clause': {
+            const child = node.namedChildren[0];
+            return child ? visit(child, opts) : appendNodeMeta(UAST.scopedStatement([]), node, sourcefile);
+        }
+
+        case 'return_statement': {
+            const child = node.namedChildren[0] || null;
+            const ret = UAST.returnStatement(child ? visit(child, opts) as UAST.Expression : null);
+            return appendNodeMeta(ret, node, sourcefile);
+        }
+
+        case 'break_statement': {
+            const stmt = UAST.breakStatement();
+            const levelNode = node.namedChildren[0];
+            if (levelNode && levelNode.type === 'integer') {
+                stmt._meta.level = Number(levelNode.text);
+            }
+            return appendNodeMeta(stmt, node, sourcefile);
+        }
+
+        case 'continue_statement': {
+            const stmt = UAST.continueStatement();
+            const levelNode = node.namedChildren[0];
+            if (levelNode && levelNode.type === 'integer') {
+                stmt._meta.level = Number(levelNode.text);
+            }
+            return appendNodeMeta(stmt, node, sourcefile);
+        }
+
+        case 'throw_expression': {
+            const expr = visit(node.namedChildren[0], opts) as UAST.Expression;
+            const stmt = UAST.throwStatement(expr);
+            return appendNodeMeta(stmt, node, sourcefile);
+        }
+
+        case 'try_statement': {
+            const bodyNode = node.childForFieldName('body');
+            const body = bodyNode ? visit(bodyNode, opts) as UAST.Statement : UAST.scopedStatement([]) as any;
+            const catches: Array<UAST.CatchClause> = [];
+            let finalizer: UAST.Instruction | null = null;
+            for (const child of node.namedChildren) {
+                if (child.type === 'catch_clause') {
+                    catches.push(visit(child, opts) as UAST.CatchClause);
+                } else if (child.type === 'finally_clause') {
+                    const finallyBody = child.namedChildren[0];
+                    finalizer = finallyBody ? visit(finallyBody, opts) as UAST.Instruction : UAST.scopedStatement([]);
+                }
+            }
+            const tryStmt = UAST.tryStatement(body, catches.length > 0 ? catches : null, finalizer);
+            return appendNodeMeta(tryStmt, node, sourcefile);
+        }
+
+        case 'catch_clause': {
+            let paramId: UAST.Identifier = UAST.identifier('_');
+            const catchTypes: Array<any> = [];
+            let catchBody: UAST.Instruction = UAST.scopedStatement([]);
+            for (const child of node.namedChildren) {
+                if (child.type === 'type_list') {
+                    for (const typeChild of child.namedChildren) {
+                        catchTypes.push(visit(typeChild, opts));
+                    }
+                } else if (child.type === 'named_type' || child.type === 'qualified_name' || child.type === 'name') {
+                    catchTypes.push(visit(child, opts));
+                } else if (child.type === 'variable_name') {
+                    paramId = visit(child, opts) as UAST.Identifier;
+                } else if (child.type === 'compound_statement') {
+                    catchBody = visit(child, opts) as UAST.Instruction;
+                }
+            }
+            const param = UAST.variableDeclaration(paramId, null, false, UAST.dynamicType());
+            param._meta.catchTypes = catchTypes;
+            appendNodeMeta(param, node, sourcefile);
+            const clause = UAST.catchClause([param], catchBody);
+            return appendNodeMeta(clause, node, sourcefile);
+        }
+
+        case 'switch_statement': {
+            const condNode = node.childForFieldName('condition');
+            const discriminant = condNode && condNode.type === 'parenthesized_expression'
+                ? visit(condNode.namedChildren[0], opts) as UAST.Expression
+                : visit(condNode, opts) as UAST.Expression;
+            const bodyNode = node.childForFieldName('body');
+            // 只取 case_statement / default_statement，过滤 comment 等
+            const caseNodes = bodyNode
+                ? bodyNode.namedChildren.filter((c) => c.type === 'case_statement' || c.type === 'default_statement')
+                : [];
+            const cases = visitList(caseNodes, opts) as Array<UAST.CaseClause>;
+            const switchStmt = UAST.switchStatement(discriminant, cases);
+            return appendNodeMeta(switchStmt, node, sourcefile);
+        }
+
+        case 'case_statement': {
+            const children = node.namedChildren;
+            const test = children.length > 0 ? visit(children[0], opts) as UAST.Expression : null;
+            const bodyStatements = children.length > 1
+                ? flattenInstructions(visitList(children.slice(1), opts))
+                : [];
+            const body = UAST.scopedStatement(bodyStatements);
+            appendNodeMeta(body, node, sourcefile);
+            const clause = UAST.caseClause(test, body);
+            return appendNodeMeta(clause, node, sourcefile);
+        }
+
+        case 'default_statement': {
+            const bodyStatements = flattenInstructions(visitList(node.namedChildren, opts));
+            const body = UAST.scopedStatement(bodyStatements);
+            appendNodeMeta(body, node, sourcefile);
+            const clause = UAST.caseClause(null, body);
+            return appendNodeMeta(clause, node, sourcefile);
+        }
+
+        case 'for_statement': {
+            const children = node.namedChildren;
+            let init: UAST.Expression | null = null;
+            let test: UAST.Expression | null = null;
+            let update: UAST.Expression | null = null;
+            let forBody: UAST.Instruction = UAST.scopedStatement([]);
+            const bodyIdx = children.findIndex((c) => c.type === 'compound_statement' || c.type === 'colon_block');
+            if (bodyIdx >= 0) {
+                forBody = visit(children[bodyIdx], opts) as UAST.Instruction;
+            }
+            const exprs = children.filter((c) => c.type !== 'compound_statement' && c.type !== 'colon_block');
+            if (exprs.length >= 1) init = visit(exprs[0], opts) as UAST.Expression;
+            if (exprs.length >= 2) test = visit(exprs[1], opts) as UAST.Expression;
+            if (exprs.length >= 3) update = visit(exprs[2], opts) as UAST.Expression;
+            const forStmt = UAST.forStatement(init, test, update, forBody);
+            return appendNodeMeta(forStmt, node, sourcefile);
+        }
+
+        case 'foreach_statement': {
+            const children = node.namedChildren;
+            let source: UAST.Expression = UAST.noop() as any;
+            let key: UAST.VariableDeclaration | null = null;
+            let value: UAST.VariableDeclaration | null = null;
+            let foreachBody: UAST.Instruction = UAST.scopedStatement([]);
+            const bodyIdx = children.findIndex((c) => c.type === 'compound_statement' || c.type === 'colon_block');
+            if (bodyIdx >= 0) {
+                foreachBody = visit(children[bodyIdx], opts) as UAST.Instruction;
+            }
+            const nonBody = children.filter((c) => c.type !== 'compound_statement' && c.type !== 'colon_block');
+            if (nonBody.length >= 1) {
+                source = visit(nonBody[0], opts) as UAST.Expression;
+            }
+            if (nonBody.length >= 2) {
+                const second = nonBody[1];
+                if (second.type === 'pair') {
+                    const pairChildren = second.namedChildren;
+                    if (pairChildren.length >= 2) {
+                        const keyExpr = visit(pairChildren[0], opts) as UAST.LVal;
+                        key = UAST.variableDeclaration(keyExpr, null, false, UAST.dynamicType());
+                        appendNodeMeta(key, pairChildren[0], sourcefile);
+                        const valExpr = visit(pairChildren[1], opts) as UAST.LVal;
+                        value = UAST.variableDeclaration(valExpr, null, false, UAST.dynamicType());
+                        appendNodeMeta(value, pairChildren[1], sourcefile);
+                    }
+                } else {
+                    const valExpr = visit(second, opts) as UAST.LVal;
+                    value = UAST.variableDeclaration(valExpr, null, false, UAST.dynamicType());
+                    appendNodeMeta(value, second, sourcefile);
+                }
+            }
+            const rangeStmt = UAST.rangeStatement(key, value, source, foreachBody);
+            return appendNodeMeta(rangeStmt, node, sourcefile);
+        }
+
+        case 'while_statement': {
+            const condNode = node.childForFieldName('condition');
+            const test = condNode && condNode.type === 'parenthesized_expression'
+                ? visit(condNode.namedChildren[0], opts) as UAST.Expression
+                : visit(condNode, opts) as UAST.Expression;
+            const bodyNode = node.childForFieldName('body');
+            const whileBody = bodyNode ? visit(bodyNode, opts) as UAST.Instruction : UAST.scopedStatement([]);
+            const stmt = UAST.whileStatement(test, whileBody, false);
+            return appendNodeMeta(stmt, node, sourcefile);
+        }
+
+        case 'do_statement': {
+            const bodyNode = node.childForFieldName('body');
+            const doBody = bodyNode ? visit(bodyNode, opts) as UAST.Instruction : UAST.scopedStatement([]);
+            const condNode = node.childForFieldName('condition');
+            const test = condNode && condNode.type === 'parenthesized_expression'
+                ? visit(condNode.namedChildren[0], opts) as UAST.Expression
+                : visit(condNode, opts) as UAST.Expression;
+            const stmt = UAST.whileStatement(test, doBody, true);
+            return appendNodeMeta(stmt, node, sourcefile);
+        }
+
+        case 'empty_statement':
+            return appendNodeMeta(UAST.noop(), node, sourcefile);
+
+        case 'goto_statement': {
+            const noop = UAST.noop();
+            noop._meta.goto = node.namedChildren[0] ? node.namedChildren[0].text : null;
+            return appendNodeMeta(noop, node, sourcefile);
+        }
+
+        case 'named_label_statement': {
+            const noop = UAST.noop();
+            noop._meta.label = node.namedChildren[0] ? node.namedChildren[0].text : null;
+            return appendNodeMeta(noop, node, sourcefile);
+        }
+
+        case 'unset_statement': {
+            const args = visitList(node.namedChildren, opts) as Array<UAST.Expression>;
+            const call = UAST.callExpression(UAST.identifier('unset'), args);
+            appendNodeMeta(call, node, sourcefile);
+            const exprStmt = UAST.expressionStatement(call);
+            return appendNodeMeta(exprStmt, node, sourcefile);
+        }
+
+        // ─── 声明 ───
+
+        case 'function_definition':
+        case 'method_declaration':
+            return createFunctionLike(node, opts);
+
+        case 'anonymous_function': {
+            const fdef = createFunctionLike(node, opts);
+            for (const child of node.namedChildren) {
+                if (child.type === 'anonymous_function_use_clause') {
+                    fdef._meta.uses = visitList(child.namedChildren, opts);
+                    break;
+                }
+            }
             return fdef;
         }
-        case 'arrowfunc': {
-            const id = null;
-            const parameters = (node.arguments || []).map((arg: PhpNode) => createParameter(arg, opts));
-            const body = createFunctionBody(node.body, opts);
-            const fdef = UAST.functionDefinition(id, parameters, UAST.dynamicType(), body, []);
-            return appendNodeMeta(fdef, node, opts?.sourcefile);
+
+        case 'arrow_function': {
+            const paramsNode = node.childForFieldName('parameters');
+            const parameters = paramsNode
+                ? paramsNode.namedChildren.map((p) => createParameter(p, opts))
+                : [];
+            const bodyNode = node.childForFieldName('body');
+            let body: UAST.Instruction;
+            if (bodyNode) {
+                const bodyExpr = visit(bodyNode, opts);
+                if (bodyExpr && UAST.isNode(bodyExpr) && !UAST.isExpr(bodyExpr)) {
+                    body = bodyExpr as UAST.Instruction;
+                } else {
+                    const ret = UAST.returnStatement(bodyExpr as UAST.Expression);
+                    appendNodeMeta(ret, bodyNode, sourcefile);
+                    body = UAST.scopedStatement([ret]);
+                    appendNodeMeta(body, bodyNode, sourcefile);
+                }
+            } else {
+                body = UAST.scopedStatement([]);
+            }
+            const fdef = UAST.functionDefinition(null, parameters, UAST.dynamicType(), body, []);
+            return appendNodeMeta(fdef, node, sourcefile);
         }
-        case 'class':
-            return createClass(node, opts);
-        case 'constantstatement':
-            return createConstantStatement(node, opts);
-        case 'interface':
-            return createStructureLike(node, opts, 'interface');
-        case 'trait':
-            return createStructureLike(node, opts, 'trait');
-        case 'traituse':
-            return createTraitUse(node, opts);
-        case 'enum':
-            return createEnum(node, opts);
-        case 'enumcase':
-            return createEnumCase(node, opts);
-        case 'propertystatement':
-            return createPropertyStatement(node, opts);
-        case 'classconstant':
-            return createClassConstant(node, opts);
-        case 'global':
-            return createGlobalStatement(node, opts);
-        case 'static':
-            return createStaticStatement(node, opts);
-        case 'declare':
-            return createDeclare(node, opts);
-        case 'namespace':
-            return createNamespace(node, opts);
-        case 'usegroup':
-            return createUseGroup(node, opts);
+
+        case 'simple_parameter':
+        case 'variadic_parameter':
+        case 'property_promotion_parameter':
+            return createParameter(node, opts);
+
+        case 'class_declaration':
+            return createClassLike(node, opts);
+
+        case 'interface_declaration':
+            return createClassLike(node, opts, 'interface');
+
+        case 'trait_declaration':
+            return createClassLike(node, opts, 'trait');
+
+        case 'enum_declaration': {
+            const nameNode = node.childForFieldName('name');
+            const id = nameNode ? visit(nameNode, opts) as UAST.Identifier : null;
+            const bodyNode = node.childForFieldName('body');
+            const body = bodyNode
+                ? flattenInstructions(visitList(bodyNode.namedChildren, opts))
+                : [];
+            const cdef = UAST.classDefinition(id, body, []);
+            cdef._meta.kind = 'enum';
+            return appendNodeMeta(cdef, node, sourcefile);
+        }
+
+        case 'enum_case': {
+            const nameNode = node.childForFieldName('name');
+            const id = nameNode ? visit(nameNode, opts) as UAST.Identifier : UAST.identifier('_');
+            let init: UAST.Expression | null = null;
+            for (const child of node.namedChildren) {
+                if (child !== nameNode && child.type !== 'name') {
+                    init = visit(child, opts) as UAST.Expression;
+                    break;
+                }
+            }
+            const decl = UAST.variableDeclaration(id, init, false, UAST.dynamicType());
+            decl._meta.enumCase = true;
+            return appendNodeMeta(decl, node, sourcefile);
+        }
+
+        case 'property_declaration': {
+            const declarations: Array<any> = [];
+            let visibility: string | null = null;
+            let isStatic = false;
+            let isReadonly = false;
+            for (const child of node.namedChildren) {
+                if (child.type === 'visibility_modifier') {
+                    visibility = child.text;
+                } else if (child.type === 'static_modifier') {
+                    isStatic = true;
+                } else if (child.type === 'readonly_modifier') {
+                    isReadonly = true;
+                } else if (child.type === 'property_element') {
+                    const propName = child.childForFieldName('name') || child.namedChildren[0];
+                    const propValue = child.namedChildren.length > 1 ? child.namedChildren[1] : null;
+                    const id = propName ? visit(propName, opts) as UAST.LVal : UAST.identifier('_');
+                    const init = propValue ? visit(propValue, opts) as UAST.Expression : null;
+                    const decl = UAST.variableDeclaration(id, init, false, UAST.dynamicType());
+                    decl._meta.visibility = visibility;
+                    decl._meta.isStatic = isStatic;
+                    decl._meta.readonly = isReadonly;
+                    declarations.push(appendNodeMeta(decl, child, sourcefile));
+                }
+            }
+            if (declarations.length === 1) return declarations[0];
+            if (declarations.length === 0) return appendNodeMeta(UAST.noop(), node, sourcefile);
+            return appendNodeMeta(UAST.sequence(declarations), node, sourcefile);
+        }
+
+        case 'const_declaration': {
+            const declarations: Array<any> = [];
+            for (const child of node.namedChildren) {
+                if (child.type === 'const_element') {
+                    const nameChild = child.childForFieldName('name') || child.namedChildren[0];
+                    const valueChild = child.childForFieldName('value') || child.namedChildren[1];
+                    const id = nameChild ? visit(nameChild, opts) as UAST.LVal : UAST.identifier('_');
+                    const init = valueChild ? visit(valueChild, opts) as UAST.Expression : null;
+                    const decl = UAST.variableDeclaration(id, init, false, UAST.dynamicType());
+                    decl._meta.constant = true;
+                    declarations.push(appendNodeMeta(decl, child, sourcefile));
+                }
+            }
+            if (declarations.length === 1) return declarations[0];
+            if (declarations.length === 0) return appendNodeMeta(UAST.noop(), node, sourcefile);
+            return appendNodeMeta(UAST.sequence(declarations), node, sourcefile);
+        }
+
+        case 'use_declaration': {
+            // trait use 语句
+            const traitNames = visitList(node.namedChildren, opts) as Array<UAST.Expression>;
+            const call = UAST.callExpression(UAST.identifier('trait_use'), traitNames);
+            call._meta.synthetic = true;
+            appendNodeMeta(call, node, sourcefile);
+            const exprStmt = UAST.expressionStatement(call);
+            return appendNodeMeta(exprStmt, node, sourcefile);
+        }
+
+        case 'namespace_definition': {
+            const nameNode = node.childForFieldName('name');
+            const bodyNode = node.childForFieldName('body');
+            const instructions: Array<UAST.Instruction> = [];
+            if (nameNode) {
+                const pkg = UAST.packageDeclaration(UAST.identifier(nameNode.text));
+                instructions.push(appendNodeMeta(pkg, nameNode, sourcefile));
+            }
+            if (bodyNode) {
+                instructions.push(...flattenInstructions(visitList(bodyNode.namedChildren, opts)));
+            }
+            if (instructions.length === 1) return instructions[0];
+            if (instructions.length === 0) return appendNodeMeta(UAST.noop(), node, sourcefile);
+            return appendNodeMeta(UAST.sequence(instructions), node, sourcefile);
+        }
+
+        case 'namespace_use_declaration': {
+            const imports: Array<any> = [];
+            for (const child of node.namedChildren) {
+                if (child.type === 'namespace_use_clause') {
+                    const nameChild = child.namedChildren[0];
+                    const from = UAST.literal(nameChild ? nameChild.text : '', 'string');
+                    const aliasChild = child.namedChildren.length > 1 ? child.namedChildren[1] : null;
+                    const alias = aliasChild ? visit(aliasChild, opts) as UAST.Identifier : undefined;
+                    const importExpr = UAST.importExpression(from, alias);
+                    imports.push(appendNodeMeta(importExpr, child, sourcefile));
+                } else if (child.type === 'namespace_use_group') {
+                    for (const groupChild of child.namedChildren) {
+                        if (groupChild.type === 'namespace_use_group_clause') {
+                            const gcName = groupChild.namedChildren[0];
+                            const from = UAST.literal(gcName ? gcName.text : '', 'string');
+                            const gcAlias = groupChild.namedChildren.length > 1 ? groupChild.namedChildren[1] : null;
+                            const alias = gcAlias ? visit(gcAlias, opts) as UAST.Identifier : undefined;
+                            const importExpr = UAST.importExpression(from, alias);
+                            imports.push(appendNodeMeta(importExpr, groupChild, sourcefile));
+                        }
+                    }
+                }
+            }
+            if (imports.length === 1) {
+                return UAST.expressionStatement(imports[0]);
+            }
+            if (imports.length === 0) return appendNodeMeta(UAST.noop(), node, sourcefile);
+            return appendNodeMeta(UAST.sequence(imports.map((i: any) => UAST.expressionStatement(i))), node, sourcefile);
+        }
+
+        case 'global_declaration': {
+            const declarations = node.namedChildren.map((child) => {
+                const id = visit(child, opts) as UAST.LVal;
+                const decl = UAST.variableDeclaration(id, null, false, UAST.dynamicType());
+                decl._meta.storage = 'global';
+                return appendNodeMeta(decl, child, sourcefile);
+            });
+            if (declarations.length === 1) return declarations[0];
+            if (declarations.length === 0) return appendNodeMeta(UAST.noop(), node, sourcefile);
+            return appendNodeMeta(UAST.sequence(declarations), node, sourcefile);
+        }
+
+        case 'function_static_declaration': {
+            const declarations: Array<any> = [];
+            for (const child of node.namedChildren) {
+                if (child.type === 'static_variable_declaration') {
+                    const varName = child.namedChildren[0];
+                    const varInit = child.namedChildren.length > 1 ? child.namedChildren[1] : null;
+                    const id = varName ? visit(varName, opts) as UAST.LVal : UAST.identifier('_');
+                    const init = varInit ? visit(varInit, opts) as UAST.Expression : null;
+                    const decl = UAST.variableDeclaration(id, init, false, UAST.dynamicType());
+                    decl._meta.storage = 'static';
+                    declarations.push(appendNodeMeta(decl, child, sourcefile));
+                }
+            }
+            if (declarations.length === 1) return declarations[0];
+            if (declarations.length === 0) return appendNodeMeta(UAST.noop(), node, sourcefile);
+            return appendNodeMeta(UAST.sequence(declarations), node, sourcefile);
+        }
+
+        case 'declare_statement': {
+            const directives: Array<{ key: any; value: any }> = [];
+            let declareBody: UAST.Instruction | null = null;
+            for (const child of node.namedChildren) {
+                if (child.type === 'declare_directive') {
+                    const key = child.namedChildren[0] ? visit(child.namedChildren[0], opts) : null;
+                    const value = child.namedChildren[1] ? visit(child.namedChildren[1], opts) : null;
+                    directives.push({ key, value });
+                } else if (child.type === 'compound_statement' || child.type === 'colon_block') {
+                    declareBody = visit(child, opts) as UAST.Instruction;
+                }
+            }
+            const result = declareBody || appendNodeMeta(UAST.noop(), node, sourcefile);
+            if (result && UAST.isNode(result)) {
+                result._meta.declare = { directives };
+            }
+            return appendNodeMeta(result, node, sourcefile);
+        }
+
+        // ─── 辅助节点类型 ───
+
+        case 'named_type': {
+            const child = node.namedChildren[0];
+            return child ? visit(child, opts) : appendNodeMeta(UAST.identifier(node.text), node, sourcefile);
+        }
+
+        case 'colon_block': {
+            const body = flattenInstructions(visitList(node.namedChildren, opts));
+            return appendNodeMeta(UAST.scopedStatement(body), node, sourcefile);
+        }
+
         default: {
             const noop = UAST.noop();
-            return appendNodeMeta(noop, node, opts?.sourcefile);
+            return appendNodeMeta(noop, node, sourcefile);
         }
     }
 }
@@ -933,7 +1199,7 @@ function sanitize(node: any) {
     }
 
     if (Array.isArray(node)) {
-        node.forEach((item) => sanitize(item));
+        node.forEach((item: any) => sanitize(item));
         return;
     }
 
@@ -942,20 +1208,27 @@ function sanitize(node: any) {
     }
 
     if (node.loc) {
-        Object.keys(node.loc).forEach((key) => {
+        Object.keys(node.loc).forEach((key: string) => {
             if (!['start', 'end', 'sourcefile'].includes(key)) {
                 delete node.loc[key];
             }
         });
     }
 
-    Object.keys(node).forEach((key) => sanitize(node[key]));
+    Object.keys(node).forEach((key: string) => sanitize(node[key]));
 }
 
 export function parse(content: string, opts: Record<string, any> = {}): ParseResult<UAST.Node> {
-    const engine = createEngine();
-    const ast = engine.parseCode(content, opts?.sourcefile);
-    const node = visit(ast, opts);
-    sanitize(node);
-    return node;
+    const parser = getParser();
+    const tree = parser.parse(content);
+    if (!tree) {
+        throw new Error('Failed to parse PHP code');
+    }
+    try {
+        const node = visit(tree.rootNode, opts);
+        sanitize(node);
+        return node;
+    } finally {
+        tree.delete();
+    }
 }

--- a/parser-PHP/tests/benchmark/base/advanced.php.json
+++ b/parser-PHP/tests/benchmark/base/advanced.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 10
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+            "sourcefile": "advanced.php"
           }
         },
         "loc": {
@@ -28,7 +28,7 @@
             "line": 3,
             "column": 10
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "advanced.php"
         }
       },
       "init": {
@@ -45,7 +45,7 @@
               "line": 3,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+            "sourcefile": "advanced.php"
           }
         },
         "loc": {
@@ -57,7 +57,7 @@
             "line": 3,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "advanced.php"
         }
       },
       "cloned": false,
@@ -77,7 +77,7 @@
             "line": 3,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "advanced.php"
         }
       },
       "loc": {
@@ -89,7 +89,7 @@
           "line": 3,
           "column": 14
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+        "sourcefile": "advanced.php"
       }
     },
     {
@@ -104,7 +104,7 @@
             "line": 5,
             "column": 25
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "advanced.php"
         },
         "declare": {
           "directives": [
@@ -123,7 +123,7 @@
                       "line": 5,
                       "column": 23
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                    "sourcefile": "advanced.php"
                   }
                 },
                 "loc": {
@@ -135,7 +135,7 @@
                     "line": 5,
                     "column": 23
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "advanced.php"
                 }
               },
               "value": null
@@ -152,7 +152,7 @@
           "line": 5,
           "column": 25
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+        "sourcefile": "advanced.php"
       }
     },
     {
@@ -170,7 +170,7 @@
               "line": 7,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+            "sourcefile": "advanced.php"
           }
         },
         "loc": {
@@ -182,7 +182,7 @@
             "line": 7,
             "column": 16
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "advanced.php"
         }
       },
       "parameters": [
@@ -201,7 +201,7 @@
                   "line": 7,
                   "column": 19
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                "sourcefile": "advanced.php"
               }
             },
             "loc": {
@@ -213,7 +213,7 @@
                 "line": 7,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "advanced.php"
             }
           },
           "init": null,
@@ -234,7 +234,7 @@
                 "line": 7,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "advanced.php"
             }
           },
           "loc": {
@@ -246,7 +246,7 @@
               "line": 7,
               "column": 19
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+            "sourcefile": "advanced.php"
           }
         }
       ],
@@ -275,7 +275,7 @@
                       "line": 9,
                       "column": 11
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                    "sourcefile": "advanced.php"
                   }
                 },
                 "loc": {
@@ -287,7 +287,7 @@
                     "line": 9,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "advanced.php"
                 }
               },
               "right": {
@@ -311,7 +311,7 @@
                           "line": 9,
                           "column": 23
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                        "sourcefile": "advanced.php"
                       }
                     },
                     "loc": {
@@ -323,7 +323,7 @@
                         "line": 9,
                         "column": 23
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                      "sourcefile": "advanced.php"
                     }
                   },
                   {
@@ -356,7 +356,7 @@
                                         "line": 10,
                                         "column": 10
                                       },
-                                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                      "sourcefile": "advanced.php"
                                     }
                                   },
                                   "loc": {
@@ -368,7 +368,7 @@
                                       "line": 10,
                                       "column": 10
                                     },
-                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "advanced.php"
                                   }
                                 }
                               ],
@@ -384,7 +384,7 @@
                                   "line": 10,
                                   "column": 19
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "advanced.php"
                               }
                             },
                             "loc": {
@@ -396,7 +396,7 @@
                                 "line": 10,
                                 "column": 19
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "advanced.php"
                             }
                           },
                           {
@@ -421,7 +421,7 @@
                                       "line": 10,
                                       "column": 17
                                     },
-                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "advanced.php"
                                   }
                                 },
                                 "loc": {
@@ -433,7 +433,7 @@
                                     "line": 10,
                                     "column": 17
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "advanced.php"
                                 }
                               },
                               "arguments": [],
@@ -447,7 +447,7 @@
                                     "line": 10,
                                     "column": 19
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "advanced.php"
                                 }
                               },
                               "loc": {
@@ -459,7 +459,7 @@
                                   "line": 10,
                                   "column": 19
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "advanced.php"
                               }
                             },
                             "_meta": {
@@ -472,7 +472,7 @@
                                   "line": 10,
                                   "column": 19
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "advanced.php"
                               }
                             },
                             "loc": {
@@ -484,7 +484,7 @@
                                 "line": 10,
                                 "column": 19
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "advanced.php"
                             }
                           }
                         ],
@@ -499,7 +499,7 @@
                               "line": 10,
                               "column": 19
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                            "sourcefile": "advanced.php"
                           }
                         },
                         "loc": {
@@ -511,7 +511,7 @@
                             "line": 10,
                             "column": 19
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                          "sourcefile": "advanced.php"
                         }
                       },
                       {
@@ -541,7 +541,7 @@
                                         "line": 11,
                                         "column": 10
                                       },
-                                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                      "sourcefile": "advanced.php"
                                     }
                                   },
                                   "loc": {
@@ -553,7 +553,7 @@
                                       "line": 11,
                                       "column": 10
                                     },
-                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "advanced.php"
                                   }
                                 },
                                 {
@@ -570,7 +570,7 @@
                                         "line": 11,
                                         "column": 13
                                       },
-                                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                      "sourcefile": "advanced.php"
                                     }
                                   },
                                   "loc": {
@@ -582,7 +582,7 @@
                                       "line": 11,
                                       "column": 13
                                     },
-                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "advanced.php"
                                   }
                                 }
                               ],
@@ -598,7 +598,7 @@
                                   "line": 11,
                                   "column": 22
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "advanced.php"
                               }
                             },
                             "loc": {
@@ -610,7 +610,7 @@
                                 "line": 11,
                                 "column": 22
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "advanced.php"
                             }
                           },
                           {
@@ -635,7 +635,7 @@
                                       "line": 11,
                                       "column": 20
                                     },
-                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "advanced.php"
                                   }
                                 },
                                 "loc": {
@@ -647,7 +647,7 @@
                                     "line": 11,
                                     "column": 20
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "advanced.php"
                                 }
                               },
                               "arguments": [],
@@ -661,7 +661,7 @@
                                     "line": 11,
                                     "column": 22
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "advanced.php"
                                 }
                               },
                               "loc": {
@@ -673,7 +673,7 @@
                                   "line": 11,
                                   "column": 22
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "advanced.php"
                               }
                             },
                             "_meta": {
@@ -686,7 +686,7 @@
                                   "line": 11,
                                   "column": 22
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "advanced.php"
                               }
                             },
                             "loc": {
@@ -698,7 +698,7 @@
                                 "line": 11,
                                 "column": 22
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "advanced.php"
                             }
                           }
                         ],
@@ -713,7 +713,7 @@
                               "line": 11,
                               "column": 22
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                            "sourcefile": "advanced.php"
                           }
                         },
                         "loc": {
@@ -725,7 +725,7 @@
                             "line": 11,
                             "column": 22
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                          "sourcefile": "advanced.php"
                         }
                       },
                       {
@@ -760,7 +760,7 @@
                                   "line": 12,
                                   "column": 25
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "advanced.php"
                               }
                             },
                             "loc": {
@@ -772,7 +772,7 @@
                                 "line": 12,
                                 "column": 25
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "advanced.php"
                             }
                           },
                           {
@@ -797,7 +797,7 @@
                                       "line": 12,
                                       "column": 23
                                     },
-                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "advanced.php"
                                   }
                                 },
                                 "loc": {
@@ -809,7 +809,7 @@
                                     "line": 12,
                                     "column": 23
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "advanced.php"
                                 }
                               },
                               "arguments": [],
@@ -823,7 +823,7 @@
                                     "line": 12,
                                     "column": 25
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "advanced.php"
                                 }
                               },
                               "loc": {
@@ -835,7 +835,7 @@
                                   "line": 12,
                                   "column": 25
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "advanced.php"
                               }
                             },
                             "_meta": {
@@ -848,7 +848,7 @@
                                   "line": 12,
                                   "column": 25
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "advanced.php"
                               }
                             },
                             "loc": {
@@ -860,7 +860,7 @@
                                 "line": 12,
                                 "column": 25
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "advanced.php"
                             }
                           }
                         ],
@@ -876,7 +876,7 @@
                               "line": 12,
                               "column": 25
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                            "sourcefile": "advanced.php"
                           }
                         },
                         "loc": {
@@ -888,7 +888,7 @@
                             "line": 12,
                             "column": 25
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                          "sourcefile": "advanced.php"
                         }
                       }
                     ],
@@ -906,7 +906,7 @@
                       "line": 13,
                       "column": 6
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                    "sourcefile": "advanced.php"
                   }
                 },
                 "loc": {
@@ -918,7 +918,7 @@
                     "line": 13,
                     "column": 6
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "advanced.php"
                 }
               },
               "operator": "=",
@@ -933,7 +933,7 @@
                     "line": 13,
                     "column": 6
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "advanced.php"
                 }
               },
               "loc": {
@@ -945,7 +945,7 @@
                   "line": 13,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                "sourcefile": "advanced.php"
               }
             },
             "_meta": {
@@ -958,7 +958,7 @@
                   "line": 13,
                   "column": 7
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                "sourcefile": "advanced.php"
               }
             },
             "loc": {
@@ -970,7 +970,7 @@
                 "line": 13,
                 "column": 7
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "advanced.php"
             }
           },
           {
@@ -988,7 +988,7 @@
                     "line": 15,
                     "column": 18
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "advanced.php"
                 }
               },
               "loc": {
@@ -1000,7 +1000,7 @@
                   "line": 15,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                "sourcefile": "advanced.php"
               }
             },
             "isYield": false,
@@ -1014,7 +1014,7 @@
                   "line": 15,
                   "column": 19
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                "sourcefile": "advanced.php"
               }
             },
             "loc": {
@@ -1026,7 +1026,7 @@
                 "line": 15,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "advanced.php"
             }
           }
         ],
@@ -1041,7 +1041,7 @@
               "line": 16,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+            "sourcefile": "advanced.php"
           }
         },
         "loc": {
@@ -1053,7 +1053,7 @@
             "line": 16,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "advanced.php"
         }
       },
       "modifiers": [],
@@ -1067,7 +1067,7 @@
             "line": 16,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "advanced.php"
         }
       },
       "loc": {
@@ -1079,7 +1079,7 @@
           "line": 16,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+        "sourcefile": "advanced.php"
       }
     },
     {
@@ -1108,7 +1108,7 @@
                       "line": 19,
                       "column": 13
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                    "sourcefile": "advanced.php"
                   }
                 },
                 "loc": {
@@ -1120,7 +1120,7 @@
                     "line": 19,
                     "column": 13
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "advanced.php"
                 }
               }
             ],
@@ -1134,7 +1134,7 @@
                   "line": 19,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                "sourcefile": "advanced.php"
               }
             },
             "loc": {
@@ -1146,7 +1146,7 @@
                 "line": 19,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "advanced.php"
             }
           },
           "_meta": {
@@ -1159,7 +1159,7 @@
                 "line": 19,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "advanced.php"
             }
           },
           "loc": {
@@ -1171,7 +1171,7 @@
               "line": 19,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+            "sourcefile": "advanced.php"
           }
         }
       ],
@@ -1186,7 +1186,7 @@
             "line": 20,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "advanced.php"
         },
         "declare": {
           "directives": [
@@ -1205,7 +1205,7 @@
                       "line": 18,
                       "column": 16
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                    "sourcefile": "advanced.php"
                   }
                 },
                 "loc": {
@@ -1217,7 +1217,7 @@
                     "line": 18,
                     "column": 16
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "advanced.php"
                 }
               },
               "value": null
@@ -1234,13 +1234,13 @@
           "line": 20,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+        "sourcefile": "advanced.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php",
+  "uri": "advanced.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -1252,7 +1252,7 @@
         "line": 21,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+      "sourcefile": "advanced.php"
     }
   },
   "loc": {
@@ -1264,6 +1264,6 @@
       "line": 21,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+    "sourcefile": "advanced.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/advanced.php.json
+++ b/parser-PHP/tests/benchmark/base/advanced.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 10
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
           }
         },
         "loc": {
@@ -28,7 +28,7 @@
             "line": 3,
             "column": 10
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
         }
       },
       "init": {
@@ -45,7 +45,7 @@
               "line": 3,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
           }
         },
         "loc": {
@@ -57,7 +57,7 @@
             "line": 3,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
         }
       },
       "cloned": false,
@@ -77,7 +77,7 @@
             "line": 3,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
         }
       },
       "loc": {
@@ -89,7 +89,7 @@
           "line": 3,
           "column": 14
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
       }
     },
     {
@@ -104,7 +104,7 @@
             "line": 5,
             "column": 25
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
         },
         "declare": {
           "directives": [
@@ -123,7 +123,7 @@
                       "line": 5,
                       "column": 23
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                   }
                 },
                 "loc": {
@@ -135,7 +135,7 @@
                     "line": 5,
                     "column": 23
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                 }
               },
               "value": null
@@ -152,7 +152,7 @@
           "line": 5,
           "column": 25
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
       }
     },
     {
@@ -170,7 +170,7 @@
               "line": 7,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
           }
         },
         "loc": {
@@ -182,7 +182,7 @@
             "line": 7,
             "column": 16
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
         }
       },
       "parameters": [
@@ -201,7 +201,7 @@
                   "line": 7,
                   "column": 19
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
               }
             },
             "loc": {
@@ -213,7 +213,7 @@
                 "line": 7,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
             }
           },
           "init": null,
@@ -234,7 +234,7 @@
                 "line": 7,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
             }
           },
           "loc": {
@@ -246,7 +246,7 @@
               "line": 7,
               "column": 19
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
           }
         }
       ],
@@ -275,7 +275,7 @@
                       "line": 9,
                       "column": 11
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                   }
                 },
                 "loc": {
@@ -287,7 +287,7 @@
                     "line": 9,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                 }
               },
               "right": {
@@ -311,7 +311,7 @@
                           "line": 9,
                           "column": 23
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                       }
                     },
                     "loc": {
@@ -323,7 +323,7 @@
                         "line": 9,
                         "column": 23
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                     }
                   },
                   {
@@ -356,7 +356,7 @@
                                         "line": 10,
                                         "column": 10
                                       },
-                                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                     }
                                   },
                                   "loc": {
@@ -368,7 +368,7 @@
                                       "line": 10,
                                       "column": 10
                                     },
-                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                   }
                                 }
                               ],
@@ -384,7 +384,7 @@
                                   "line": 10,
                                   "column": 19
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "loc": {
@@ -396,7 +396,7 @@
                                 "line": 10,
                                 "column": 19
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                             }
                           },
                           {
@@ -421,7 +421,7 @@
                                       "line": 10,
                                       "column": 17
                                     },
-                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                   }
                                 },
                                 "loc": {
@@ -433,7 +433,7 @@
                                     "line": 10,
                                     "column": 17
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                 }
                               },
                               "arguments": [],
@@ -447,7 +447,7 @@
                                     "line": 10,
                                     "column": 19
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                 }
                               },
                               "loc": {
@@ -459,7 +459,7 @@
                                   "line": 10,
                                   "column": 19
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "_meta": {
@@ -472,7 +472,7 @@
                                   "line": 10,
                                   "column": 19
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "loc": {
@@ -484,7 +484,7 @@
                                 "line": 10,
                                 "column": 19
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                             }
                           }
                         ],
@@ -499,7 +499,7 @@
                               "line": 10,
                               "column": 19
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                           }
                         },
                         "loc": {
@@ -511,7 +511,7 @@
                             "line": 10,
                             "column": 19
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                         }
                       },
                       {
@@ -541,7 +541,7 @@
                                         "line": 11,
                                         "column": 10
                                       },
-                                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                     }
                                   },
                                   "loc": {
@@ -553,7 +553,7 @@
                                       "line": 11,
                                       "column": 10
                                     },
-                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                   }
                                 },
                                 {
@@ -570,7 +570,7 @@
                                         "line": 11,
                                         "column": 13
                                       },
-                                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                     }
                                   },
                                   "loc": {
@@ -582,7 +582,7 @@
                                       "line": 11,
                                       "column": 13
                                     },
-                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                   }
                                 }
                               ],
@@ -598,7 +598,7 @@
                                   "line": 11,
                                   "column": 22
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "loc": {
@@ -610,7 +610,7 @@
                                 "line": 11,
                                 "column": 22
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                             }
                           },
                           {
@@ -635,7 +635,7 @@
                                       "line": 11,
                                       "column": 20
                                     },
-                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                   }
                                 },
                                 "loc": {
@@ -647,7 +647,7 @@
                                     "line": 11,
                                     "column": 20
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                 }
                               },
                               "arguments": [],
@@ -661,7 +661,7 @@
                                     "line": 11,
                                     "column": 22
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                 }
                               },
                               "loc": {
@@ -673,7 +673,7 @@
                                   "line": 11,
                                   "column": 22
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "_meta": {
@@ -686,7 +686,7 @@
                                   "line": 11,
                                   "column": 22
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "loc": {
@@ -698,7 +698,7 @@
                                 "line": 11,
                                 "column": 22
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                             }
                           }
                         ],
@@ -713,7 +713,7 @@
                               "line": 11,
                               "column": 22
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                           }
                         },
                         "loc": {
@@ -725,7 +725,7 @@
                             "line": 11,
                             "column": 22
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                         }
                       },
                       {
@@ -760,7 +760,7 @@
                                   "line": 12,
                                   "column": 25
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "loc": {
@@ -772,7 +772,7 @@
                                 "line": 12,
                                 "column": 25
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                             }
                           },
                           {
@@ -797,7 +797,7 @@
                                       "line": 12,
                                       "column": 23
                                     },
-                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                   }
                                 },
                                 "loc": {
@@ -809,7 +809,7 @@
                                     "line": 12,
                                     "column": 23
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                 }
                               },
                               "arguments": [],
@@ -823,7 +823,7 @@
                                     "line": 12,
                                     "column": 25
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                 }
                               },
                               "loc": {
@@ -835,7 +835,7 @@
                                   "line": 12,
                                   "column": 25
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "_meta": {
@@ -848,7 +848,7 @@
                                   "line": 12,
                                   "column": 25
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "loc": {
@@ -860,7 +860,7 @@
                                 "line": 12,
                                 "column": 25
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                             }
                           }
                         ],
@@ -876,7 +876,7 @@
                               "line": 12,
                               "column": 25
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                           }
                         },
                         "loc": {
@@ -888,7 +888,7 @@
                             "line": 12,
                             "column": 25
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                         }
                       }
                     ],
@@ -906,7 +906,7 @@
                       "line": 13,
                       "column": 6
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                   }
                 },
                 "loc": {
@@ -918,7 +918,7 @@
                     "line": 13,
                     "column": 6
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                 }
               },
               "operator": "=",
@@ -933,7 +933,7 @@
                     "line": 13,
                     "column": 6
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                 }
               },
               "loc": {
@@ -945,7 +945,7 @@
                   "line": 13,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
               }
             },
             "_meta": {
@@ -958,7 +958,7 @@
                   "line": 13,
                   "column": 7
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
               }
             },
             "loc": {
@@ -970,7 +970,7 @@
                 "line": 13,
                 "column": 7
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
             }
           },
           {
@@ -988,7 +988,7 @@
                     "line": 15,
                     "column": 18
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                 }
               },
               "loc": {
@@ -1000,7 +1000,7 @@
                   "line": 15,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
               }
             },
             "isYield": false,
@@ -1014,7 +1014,7 @@
                   "line": 15,
                   "column": 19
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
               }
             },
             "loc": {
@@ -1026,7 +1026,7 @@
                 "line": 15,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
             }
           }
         ],
@@ -1041,7 +1041,7 @@
               "line": 16,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
           }
         },
         "loc": {
@@ -1053,7 +1053,7 @@
             "line": 16,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
         }
       },
       "modifiers": [],
@@ -1067,7 +1067,7 @@
             "line": 16,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
         }
       },
       "loc": {
@@ -1079,7 +1079,7 @@
           "line": 16,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
       }
     },
     {
@@ -1108,7 +1108,7 @@
                       "line": 19,
                       "column": 13
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                   }
                 },
                 "loc": {
@@ -1120,7 +1120,7 @@
                     "line": 19,
                     "column": 13
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                 }
               }
             ],
@@ -1134,7 +1134,7 @@
                   "line": 19,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
               }
             },
             "loc": {
@@ -1146,7 +1146,7 @@
                 "line": 19,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
             }
           },
           "_meta": {
@@ -1159,7 +1159,7 @@
                 "line": 19,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
             }
           },
           "loc": {
@@ -1171,7 +1171,7 @@
               "line": 19,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
           }
         }
       ],
@@ -1186,7 +1186,7 @@
             "line": 20,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
         },
         "declare": {
           "directives": [
@@ -1205,7 +1205,7 @@
                       "line": 18,
                       "column": 16
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                   }
                 },
                 "loc": {
@@ -1217,7 +1217,7 @@
                     "line": 18,
                     "column": 16
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                 }
               },
               "value": null
@@ -1234,13 +1234,13 @@
           "line": 20,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -1252,7 +1252,7 @@
         "line": 21,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
     }
   },
   "loc": {
@@ -1264,6 +1264,6 @@
       "line": 21,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/advanced.php.json
+++ b/parser-PHP/tests/benchmark/base/advanced.php.json
@@ -16,24 +16,7 @@
               "line": 3,
               "column": 10
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-          },
-          "origin": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 6,
-                "offset": 13
-              },
-              "end": {
-                "line": 3,
-                "column": 9,
-                "offset": 16
-              }
-            },
-            "name": "APP"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
           }
         },
         "loc": {
@@ -45,7 +28,7 @@
             "line": 3,
             "column": 10
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
         }
       },
       "init": {
@@ -62,24 +45,7 @@
               "line": 3,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-          },
-          "origin": {
-            "kind": "number",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 12,
-                "offset": 19
-              },
-              "end": {
-                "line": 3,
-                "column": 13,
-                "offset": 20
-              }
-            },
-            "value": "1"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
           }
         },
         "loc": {
@@ -91,7 +57,7 @@
             "line": 3,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
         }
       },
       "cloned": false,
@@ -101,6 +67,7 @@
         "_meta": {}
       },
       "_meta": {
+        "constant": true,
         "loc": {
           "start": {
             "line": 3,
@@ -110,59 +77,8 @@
             "line": 3,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-        },
-        "origin": {
-          "kind": "constant",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 6,
-              "offset": 13
-            },
-            "end": {
-              "line": 3,
-              "column": 13,
-              "offset": 20
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 6,
-                "offset": 13
-              },
-              "end": {
-                "line": 3,
-                "column": 9,
-                "offset": 16
-              }
-            },
-            "name": "APP"
-          },
-          "value": {
-            "kind": "number",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 12,
-                "offset": 19
-              },
-              "end": {
-                "line": 3,
-                "column": 13,
-                "offset": 20
-              }
-            },
-            "value": "1"
-          }
-        },
-        "constant": true
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+        }
       },
       "loc": {
         "start": {
@@ -173,7 +89,7 @@
           "line": 3,
           "column": 14
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
       }
     },
     {
@@ -188,128 +104,12 @@
             "line": 5,
             "column": 25
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-        },
-        "origin": {
-          "kind": "declare",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 5,
-              "column": 0,
-              "offset": 23
-            },
-            "end": {
-              "line": 5,
-              "column": 24,
-              "offset": 47
-            }
-          },
-          "children": [],
-          "directives": [
-            {
-              "kind": "declaredirective",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 5,
-                  "column": 8,
-                  "offset": 31
-                },
-                "end": {
-                  "line": 5,
-                  "column": 22,
-                  "offset": 45
-                }
-              },
-              "key": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 8,
-                    "offset": 31
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 20,
-                    "offset": 43
-                  }
-                },
-                "name": "strict_types"
-              },
-              "value": {
-                "kind": "number",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 21,
-                    "offset": 44
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 22,
-                    "offset": 45
-                  }
-                },
-                "value": "1"
-              }
-            }
-          ],
-          "mode": "none"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
         },
         "declare": {
-          "mode": "none",
           "directives": [
             {
               "key": {
-                "type": "Identifier",
-                "name": "strict_types",
-                "_meta": {
-                  "loc": {
-                    "start": {
-                      "line": 5,
-                      "column": 9
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 21
-                    },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                  },
-                  "origin": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 8,
-                        "offset": 31
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 20,
-                        "offset": 43
-                      }
-                    },
-                    "name": "strict_types"
-                  }
-                },
-                "loc": {
-                  "start": {
-                    "line": 5,
-                    "column": 9
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 21
-                  },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                }
-              },
-              "value": {
                 "type": "Literal",
                 "value": 1,
                 "literalType": "number",
@@ -323,24 +123,7 @@
                       "line": 5,
                       "column": 23
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                  },
-                  "origin": {
-                    "kind": "number",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 21,
-                        "offset": 44
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 22,
-                        "offset": 45
-                      }
-                    },
-                    "value": "1"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                   }
                 },
                 "loc": {
@@ -352,9 +135,10 @@
                     "line": 5,
                     "column": 23
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                 }
-              }
+              },
+              "value": null
             }
           ]
         }
@@ -368,7 +152,7 @@
           "line": 5,
           "column": 25
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
       }
     },
     {
@@ -386,24 +170,7 @@
               "line": 7,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-          },
-          "origin": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 7,
-                "column": 9,
-                "offset": 58
-              },
-              "end": {
-                "line": 7,
-                "column": 15,
-                "offset": 64
-              }
-            },
-            "name": "choose"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
           }
         },
         "loc": {
@@ -415,7 +182,7 @@
             "line": 7,
             "column": 16
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
         }
       },
       "parameters": [
@@ -434,24 +201,7 @@
                   "line": 7,
                   "column": 19
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 7,
-                    "column": 16,
-                    "offset": 65
-                  },
-                  "end": {
-                    "line": 7,
-                    "column": 18,
-                    "offset": 67
-                  }
-                },
-                "name": "v"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
               }
             },
             "loc": {
@@ -463,7 +213,7 @@
                 "line": 7,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
             }
           },
           "init": null,
@@ -474,9 +224,7 @@
             "_meta": {}
           },
           "_meta": {
-            "byref": false,
             "variadic": false,
-            "attributes": [],
             "loc": {
               "start": {
                 "line": 7,
@@ -486,48 +234,7 @@
                 "line": 7,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-            },
-            "origin": {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 7,
-                  "column": 16,
-                  "offset": 65
-                },
-                "end": {
-                  "line": 7,
-                  "column": 18,
-                  "offset": 67
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 7,
-                    "column": 16,
-                    "offset": 65
-                  },
-                  "end": {
-                    "line": 7,
-                    "column": 18,
-                    "offset": 67
-                  }
-                },
-                "name": "v"
-              },
-              "value": null,
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
             }
           },
           "loc": {
@@ -539,7 +246,7 @@
               "line": 7,
               "column": 19
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
           }
         }
       ],
@@ -568,25 +275,7 @@
                       "line": 9,
                       "column": 11
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                  },
-                  "origin": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 4,
-                        "offset": 75
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 10,
-                        "offset": 81
-                      }
-                    },
-                    "name": "value",
-                    "curly": false
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                   }
                 },
                 "loc": {
@@ -598,7 +287,7 @@
                     "line": 9,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                 }
               },
               "right": {
@@ -622,25 +311,7 @@
                           "line": 9,
                           "column": 23
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                      },
-                      "origin": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 9,
-                            "column": 20,
-                            "offset": 91
-                          },
-                          "end": {
-                            "line": 9,
-                            "column": 22,
-                            "offset": 93
-                          }
-                        },
-                        "name": "v",
-                        "curly": false
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                       }
                     },
                     "loc": {
@@ -652,7 +323,7 @@
                         "line": 9,
                         "column": 23
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                     }
                   },
                   {
@@ -685,24 +356,7 @@
                                         "line": 10,
                                         "column": 10
                                       },
-                                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                                    },
-                                    "origin": {
-                                      "kind": "number",
-                                      "loc": {
-                                        "source": null,
-                                        "start": {
-                                          "line": 10,
-                                          "column": 8,
-                                          "offset": 105
-                                        },
-                                        "end": {
-                                          "line": 10,
-                                          "column": 9,
-                                          "offset": 106
-                                        }
-                                      },
-                                      "value": "1"
+                                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                                     }
                                   },
                                   "loc": {
@@ -714,7 +368,7 @@
                                       "line": 10,
                                       "column": 10
                                     },
-                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                                   }
                                 }
                               ],
@@ -730,77 +384,7 @@
                                   "line": 10,
                                   "column": 19
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                              },
-                              "origin": {
-                                "kind": "matcharm",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 10,
-                                    "column": 8,
-                                    "offset": 105
-                                  },
-                                  "end": {
-                                    "line": 10,
-                                    "column": 18,
-                                    "offset": 115
-                                  }
-                                },
-                                "conds": [
-                                  {
-                                    "kind": "number",
-                                    "loc": {
-                                      "source": null,
-                                      "start": {
-                                        "line": 10,
-                                        "column": 8,
-                                        "offset": 105
-                                      },
-                                      "end": {
-                                        "line": 10,
-                                        "column": 9,
-                                        "offset": 106
-                                      }
-                                    },
-                                    "value": "1"
-                                  }
-                                ],
-                                "body": {
-                                  "kind": "call",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 10,
-                                      "column": 13,
-                                      "offset": 110
-                                    },
-                                    "end": {
-                                      "line": 10,
-                                      "column": 18,
-                                      "offset": 115
-                                    }
-                                  },
-                                  "what": {
-                                    "kind": "name",
-                                    "loc": {
-                                      "source": null,
-                                      "start": {
-                                        "line": 10,
-                                        "column": 13,
-                                        "offset": 110
-                                      },
-                                      "end": {
-                                        "line": 10,
-                                        "column": 16,
-                                        "offset": 113
-                                      }
-                                    },
-                                    "name": "foo",
-                                    "resolution": "uqn"
-                                  },
-                                  "arguments": []
-                                }
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "loc": {
@@ -812,7 +396,7 @@
                                 "line": 10,
                                 "column": 19
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                             }
                           },
                           {
@@ -837,25 +421,7 @@
                                       "line": 10,
                                       "column": 17
                                     },
-                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                                  },
-                                  "origin": {
-                                    "kind": "name",
-                                    "loc": {
-                                      "source": null,
-                                      "start": {
-                                        "line": 10,
-                                        "column": 13,
-                                        "offset": 110
-                                      },
-                                      "end": {
-                                        "line": 10,
-                                        "column": 16,
-                                        "offset": 113
-                                      }
-                                    },
-                                    "name": "foo",
-                                    "resolution": "uqn"
+                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                                   }
                                 },
                                 "loc": {
@@ -867,7 +433,7 @@
                                     "line": 10,
                                     "column": 17
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                                 }
                               },
                               "arguments": [],
@@ -881,42 +447,7 @@
                                     "line": 10,
                                     "column": 19
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                                },
-                                "origin": {
-                                  "kind": "call",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 10,
-                                      "column": 13,
-                                      "offset": 110
-                                    },
-                                    "end": {
-                                      "line": 10,
-                                      "column": 18,
-                                      "offset": 115
-                                    }
-                                  },
-                                  "what": {
-                                    "kind": "name",
-                                    "loc": {
-                                      "source": null,
-                                      "start": {
-                                        "line": 10,
-                                        "column": 13,
-                                        "offset": 110
-                                      },
-                                      "end": {
-                                        "line": 10,
-                                        "column": 16,
-                                        "offset": 113
-                                      }
-                                    },
-                                    "name": "foo",
-                                    "resolution": "uqn"
-                                  },
-                                  "arguments": []
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                                 }
                               },
                               "loc": {
@@ -928,7 +459,7 @@
                                   "line": 10,
                                   "column": 19
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "_meta": {
@@ -941,77 +472,7 @@
                                   "line": 10,
                                   "column": 19
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                              },
-                              "origin": {
-                                "kind": "matcharm",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 10,
-                                    "column": 8,
-                                    "offset": 105
-                                  },
-                                  "end": {
-                                    "line": 10,
-                                    "column": 18,
-                                    "offset": 115
-                                  }
-                                },
-                                "conds": [
-                                  {
-                                    "kind": "number",
-                                    "loc": {
-                                      "source": null,
-                                      "start": {
-                                        "line": 10,
-                                        "column": 8,
-                                        "offset": 105
-                                      },
-                                      "end": {
-                                        "line": 10,
-                                        "column": 9,
-                                        "offset": 106
-                                      }
-                                    },
-                                    "value": "1"
-                                  }
-                                ],
-                                "body": {
-                                  "kind": "call",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 10,
-                                      "column": 13,
-                                      "offset": 110
-                                    },
-                                    "end": {
-                                      "line": 10,
-                                      "column": 18,
-                                      "offset": 115
-                                    }
-                                  },
-                                  "what": {
-                                    "kind": "name",
-                                    "loc": {
-                                      "source": null,
-                                      "start": {
-                                        "line": 10,
-                                        "column": 13,
-                                        "offset": 110
-                                      },
-                                      "end": {
-                                        "line": 10,
-                                        "column": 16,
-                                        "offset": 113
-                                      }
-                                    },
-                                    "name": "foo",
-                                    "resolution": "uqn"
-                                  },
-                                  "arguments": []
-                                }
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "loc": {
@@ -1023,7 +484,7 @@
                                 "line": 10,
                                 "column": 19
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                             }
                           }
                         ],
@@ -1038,77 +499,7 @@
                               "line": 10,
                               "column": 19
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                          },
-                          "origin": {
-                            "kind": "matcharm",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 10,
-                                "column": 8,
-                                "offset": 105
-                              },
-                              "end": {
-                                "line": 10,
-                                "column": 18,
-                                "offset": 115
-                              }
-                            },
-                            "conds": [
-                              {
-                                "kind": "number",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 10,
-                                    "column": 8,
-                                    "offset": 105
-                                  },
-                                  "end": {
-                                    "line": 10,
-                                    "column": 9,
-                                    "offset": 106
-                                  }
-                                },
-                                "value": "1"
-                              }
-                            ],
-                            "body": {
-                              "kind": "call",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 10,
-                                  "column": 13,
-                                  "offset": 110
-                                },
-                                "end": {
-                                  "line": 10,
-                                  "column": 18,
-                                  "offset": 115
-                                }
-                              },
-                              "what": {
-                                "kind": "name",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 10,
-                                    "column": 13,
-                                    "offset": 110
-                                  },
-                                  "end": {
-                                    "line": 10,
-                                    "column": 16,
-                                    "offset": 113
-                                  }
-                                },
-                                "name": "foo",
-                                "resolution": "uqn"
-                              },
-                              "arguments": []
-                            }
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                           }
                         },
                         "loc": {
@@ -1120,7 +511,7 @@
                             "line": 10,
                             "column": 19
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                         }
                       },
                       {
@@ -1150,24 +541,7 @@
                                         "line": 11,
                                         "column": 10
                                       },
-                                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                                    },
-                                    "origin": {
-                                      "kind": "number",
-                                      "loc": {
-                                        "source": null,
-                                        "start": {
-                                          "line": 11,
-                                          "column": 8,
-                                          "offset": 125
-                                        },
-                                        "end": {
-                                          "line": 11,
-                                          "column": 9,
-                                          "offset": 126
-                                        }
-                                      },
-                                      "value": "2"
+                                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                                     }
                                   },
                                   "loc": {
@@ -1179,7 +553,7 @@
                                       "line": 11,
                                       "column": 10
                                     },
-                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                                   }
                                 },
                                 {
@@ -1196,24 +570,7 @@
                                         "line": 11,
                                         "column": 13
                                       },
-                                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                                    },
-                                    "origin": {
-                                      "kind": "number",
-                                      "loc": {
-                                        "source": null,
-                                        "start": {
-                                          "line": 11,
-                                          "column": 11,
-                                          "offset": 128
-                                        },
-                                        "end": {
-                                          "line": 11,
-                                          "column": 12,
-                                          "offset": 129
-                                        }
-                                      },
-                                      "value": "3"
+                                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                                     }
                                   },
                                   "loc": {
@@ -1225,7 +582,7 @@
                                       "line": 11,
                                       "column": 13
                                     },
-                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                                   }
                                 }
                               ],
@@ -1241,94 +598,7 @@
                                   "line": 11,
                                   "column": 22
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                              },
-                              "origin": {
-                                "kind": "matcharm",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 11,
-                                    "column": 8,
-                                    "offset": 125
-                                  },
-                                  "end": {
-                                    "line": 11,
-                                    "column": 21,
-                                    "offset": 138
-                                  }
-                                },
-                                "conds": [
-                                  {
-                                    "kind": "number",
-                                    "loc": {
-                                      "source": null,
-                                      "start": {
-                                        "line": 11,
-                                        "column": 8,
-                                        "offset": 125
-                                      },
-                                      "end": {
-                                        "line": 11,
-                                        "column": 9,
-                                        "offset": 126
-                                      }
-                                    },
-                                    "value": "2"
-                                  },
-                                  {
-                                    "kind": "number",
-                                    "loc": {
-                                      "source": null,
-                                      "start": {
-                                        "line": 11,
-                                        "column": 11,
-                                        "offset": 128
-                                      },
-                                      "end": {
-                                        "line": 11,
-                                        "column": 12,
-                                        "offset": 129
-                                      }
-                                    },
-                                    "value": "3"
-                                  }
-                                ],
-                                "body": {
-                                  "kind": "call",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 11,
-                                      "column": 16,
-                                      "offset": 133
-                                    },
-                                    "end": {
-                                      "line": 11,
-                                      "column": 21,
-                                      "offset": 138
-                                    }
-                                  },
-                                  "what": {
-                                    "kind": "name",
-                                    "loc": {
-                                      "source": null,
-                                      "start": {
-                                        "line": 11,
-                                        "column": 16,
-                                        "offset": 133
-                                      },
-                                      "end": {
-                                        "line": 11,
-                                        "column": 19,
-                                        "offset": 136
-                                      }
-                                    },
-                                    "name": "bar",
-                                    "resolution": "uqn"
-                                  },
-                                  "arguments": []
-                                }
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "loc": {
@@ -1340,7 +610,7 @@
                                 "line": 11,
                                 "column": 22
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                             }
                           },
                           {
@@ -1365,25 +635,7 @@
                                       "line": 11,
                                       "column": 20
                                     },
-                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                                  },
-                                  "origin": {
-                                    "kind": "name",
-                                    "loc": {
-                                      "source": null,
-                                      "start": {
-                                        "line": 11,
-                                        "column": 16,
-                                        "offset": 133
-                                      },
-                                      "end": {
-                                        "line": 11,
-                                        "column": 19,
-                                        "offset": 136
-                                      }
-                                    },
-                                    "name": "bar",
-                                    "resolution": "uqn"
+                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                                   }
                                 },
                                 "loc": {
@@ -1395,7 +647,7 @@
                                     "line": 11,
                                     "column": 20
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                                 }
                               },
                               "arguments": [],
@@ -1409,42 +661,7 @@
                                     "line": 11,
                                     "column": 22
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                                },
-                                "origin": {
-                                  "kind": "call",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 11,
-                                      "column": 16,
-                                      "offset": 133
-                                    },
-                                    "end": {
-                                      "line": 11,
-                                      "column": 21,
-                                      "offset": 138
-                                    }
-                                  },
-                                  "what": {
-                                    "kind": "name",
-                                    "loc": {
-                                      "source": null,
-                                      "start": {
-                                        "line": 11,
-                                        "column": 16,
-                                        "offset": 133
-                                      },
-                                      "end": {
-                                        "line": 11,
-                                        "column": 19,
-                                        "offset": 136
-                                      }
-                                    },
-                                    "name": "bar",
-                                    "resolution": "uqn"
-                                  },
-                                  "arguments": []
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                                 }
                               },
                               "loc": {
@@ -1456,7 +673,7 @@
                                   "line": 11,
                                   "column": 22
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "_meta": {
@@ -1469,94 +686,7 @@
                                   "line": 11,
                                   "column": 22
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                              },
-                              "origin": {
-                                "kind": "matcharm",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 11,
-                                    "column": 8,
-                                    "offset": 125
-                                  },
-                                  "end": {
-                                    "line": 11,
-                                    "column": 21,
-                                    "offset": 138
-                                  }
-                                },
-                                "conds": [
-                                  {
-                                    "kind": "number",
-                                    "loc": {
-                                      "source": null,
-                                      "start": {
-                                        "line": 11,
-                                        "column": 8,
-                                        "offset": 125
-                                      },
-                                      "end": {
-                                        "line": 11,
-                                        "column": 9,
-                                        "offset": 126
-                                      }
-                                    },
-                                    "value": "2"
-                                  },
-                                  {
-                                    "kind": "number",
-                                    "loc": {
-                                      "source": null,
-                                      "start": {
-                                        "line": 11,
-                                        "column": 11,
-                                        "offset": 128
-                                      },
-                                      "end": {
-                                        "line": 11,
-                                        "column": 12,
-                                        "offset": 129
-                                      }
-                                    },
-                                    "value": "3"
-                                  }
-                                ],
-                                "body": {
-                                  "kind": "call",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 11,
-                                      "column": 16,
-                                      "offset": 133
-                                    },
-                                    "end": {
-                                      "line": 11,
-                                      "column": 21,
-                                      "offset": 138
-                                    }
-                                  },
-                                  "what": {
-                                    "kind": "name",
-                                    "loc": {
-                                      "source": null,
-                                      "start": {
-                                        "line": 11,
-                                        "column": 16,
-                                        "offset": 133
-                                      },
-                                      "end": {
-                                        "line": 11,
-                                        "column": 19,
-                                        "offset": 136
-                                      }
-                                    },
-                                    "name": "bar",
-                                    "resolution": "uqn"
-                                  },
-                                  "arguments": []
-                                }
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "loc": {
@@ -1568,7 +698,7 @@
                                 "line": 11,
                                 "column": 22
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                             }
                           }
                         ],
@@ -1583,94 +713,7 @@
                               "line": 11,
                               "column": 22
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                          },
-                          "origin": {
-                            "kind": "matcharm",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 8,
-                                "offset": 125
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 21,
-                                "offset": 138
-                              }
-                            },
-                            "conds": [
-                              {
-                                "kind": "number",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 11,
-                                    "column": 8,
-                                    "offset": 125
-                                  },
-                                  "end": {
-                                    "line": 11,
-                                    "column": 9,
-                                    "offset": 126
-                                  }
-                                },
-                                "value": "2"
-                              },
-                              {
-                                "kind": "number",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 11,
-                                    "column": 11,
-                                    "offset": 128
-                                  },
-                                  "end": {
-                                    "line": 11,
-                                    "column": 12,
-                                    "offset": 129
-                                  }
-                                },
-                                "value": "3"
-                              }
-                            ],
-                            "body": {
-                              "kind": "call",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 11,
-                                  "column": 16,
-                                  "offset": 133
-                                },
-                                "end": {
-                                  "line": 11,
-                                  "column": 21,
-                                  "offset": 138
-                                }
-                              },
-                              "what": {
-                                "kind": "name",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 11,
-                                    "column": 16,
-                                    "offset": 133
-                                  },
-                                  "end": {
-                                    "line": 11,
-                                    "column": 19,
-                                    "offset": 136
-                                  }
-                                },
-                                "name": "bar",
-                                "resolution": "uqn"
-                              },
-                              "arguments": []
-                            }
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                           }
                         },
                         "loc": {
@@ -1682,7 +725,7 @@
                             "line": 11,
                             "column": 22
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                         }
                       },
                       {
@@ -1717,59 +760,7 @@
                                   "line": 12,
                                   "column": 25
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                              },
-                              "origin": {
-                                "kind": "matcharm",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 12,
-                                    "column": 8,
-                                    "offset": 148
-                                  },
-                                  "end": {
-                                    "line": 12,
-                                    "column": 24,
-                                    "offset": 164
-                                  }
-                                },
-                                "conds": null,
-                                "body": {
-                                  "kind": "call",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 19,
-                                      "offset": 159
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 24,
-                                      "offset": 164
-                                    }
-                                  },
-                                  "what": {
-                                    "kind": "name",
-                                    "loc": {
-                                      "source": null,
-                                      "start": {
-                                        "line": 12,
-                                        "column": 19,
-                                        "offset": 159
-                                      },
-                                      "end": {
-                                        "line": 12,
-                                        "column": 22,
-                                        "offset": 162
-                                      }
-                                    },
-                                    "name": "baz",
-                                    "resolution": "uqn"
-                                  },
-                                  "arguments": []
-                                }
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "loc": {
@@ -1781,7 +772,7 @@
                                 "line": 12,
                                 "column": 25
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                             }
                           },
                           {
@@ -1806,25 +797,7 @@
                                       "line": 12,
                                       "column": 23
                                     },
-                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                                  },
-                                  "origin": {
-                                    "kind": "name",
-                                    "loc": {
-                                      "source": null,
-                                      "start": {
-                                        "line": 12,
-                                        "column": 19,
-                                        "offset": 159
-                                      },
-                                      "end": {
-                                        "line": 12,
-                                        "column": 22,
-                                        "offset": 162
-                                      }
-                                    },
-                                    "name": "baz",
-                                    "resolution": "uqn"
+                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                                   }
                                 },
                                 "loc": {
@@ -1836,7 +809,7 @@
                                     "line": 12,
                                     "column": 23
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                                 }
                               },
                               "arguments": [],
@@ -1850,42 +823,7 @@
                                     "line": 12,
                                     "column": 25
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                                },
-                                "origin": {
-                                  "kind": "call",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 19,
-                                      "offset": 159
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 24,
-                                      "offset": 164
-                                    }
-                                  },
-                                  "what": {
-                                    "kind": "name",
-                                    "loc": {
-                                      "source": null,
-                                      "start": {
-                                        "line": 12,
-                                        "column": 19,
-                                        "offset": 159
-                                      },
-                                      "end": {
-                                        "line": 12,
-                                        "column": 22,
-                                        "offset": 162
-                                      }
-                                    },
-                                    "name": "baz",
-                                    "resolution": "uqn"
-                                  },
-                                  "arguments": []
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                                 }
                               },
                               "loc": {
@@ -1897,7 +835,7 @@
                                   "line": 12,
                                   "column": 25
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "_meta": {
@@ -1910,59 +848,7 @@
                                   "line": 12,
                                   "column": 25
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                              },
-                              "origin": {
-                                "kind": "matcharm",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 12,
-                                    "column": 8,
-                                    "offset": 148
-                                  },
-                                  "end": {
-                                    "line": 12,
-                                    "column": 24,
-                                    "offset": 164
-                                  }
-                                },
-                                "conds": null,
-                                "body": {
-                                  "kind": "call",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 19,
-                                      "offset": 159
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 24,
-                                      "offset": 164
-                                    }
-                                  },
-                                  "what": {
-                                    "kind": "name",
-                                    "loc": {
-                                      "source": null,
-                                      "start": {
-                                        "line": 12,
-                                        "column": 19,
-                                        "offset": 159
-                                      },
-                                      "end": {
-                                        "line": 12,
-                                        "column": 22,
-                                        "offset": 162
-                                      }
-                                    },
-                                    "name": "baz",
-                                    "resolution": "uqn"
-                                  },
-                                  "arguments": []
-                                }
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "loc": {
@@ -1974,7 +860,7 @@
                                 "line": 12,
                                 "column": 25
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                             }
                           }
                         ],
@@ -1990,59 +876,7 @@
                               "line": 12,
                               "column": 25
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                          },
-                          "origin": {
-                            "kind": "matcharm",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 12,
-                                "column": 8,
-                                "offset": 148
-                              },
-                              "end": {
-                                "line": 12,
-                                "column": 24,
-                                "offset": 164
-                              }
-                            },
-                            "conds": null,
-                            "body": {
-                              "kind": "call",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 12,
-                                  "column": 19,
-                                  "offset": 159
-                                },
-                                "end": {
-                                  "line": 12,
-                                  "column": 24,
-                                  "offset": 164
-                                }
-                              },
-                              "what": {
-                                "kind": "name",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 12,
-                                    "column": 19,
-                                    "offset": 159
-                                  },
-                                  "end": {
-                                    "line": 12,
-                                    "column": 22,
-                                    "offset": 162
-                                  }
-                                },
-                                "name": "baz",
-                                "resolution": "uqn"
-                              },
-                              "arguments": []
-                            }
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                           }
                         },
                         "loc": {
@@ -2054,7 +888,7 @@
                             "line": 12,
                             "column": 25
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                         }
                       }
                     ],
@@ -2072,252 +906,7 @@
                       "line": 13,
                       "column": 6
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                  },
-                  "origin": {
-                    "kind": "match",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 13,
-                        "offset": 84
-                      },
-                      "end": {
-                        "line": 13,
-                        "column": 5,
-                        "offset": 171
-                      }
-                    },
-                    "cond": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 20,
-                          "offset": 91
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 22,
-                          "offset": 93
-                        }
-                      },
-                      "name": "v",
-                      "curly": false
-                    },
-                    "arms": [
-                      {
-                        "kind": "matcharm",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 10,
-                            "column": 8,
-                            "offset": 105
-                          },
-                          "end": {
-                            "line": 10,
-                            "column": 18,
-                            "offset": 115
-                          }
-                        },
-                        "conds": [
-                          {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 10,
-                                "column": 8,
-                                "offset": 105
-                              },
-                              "end": {
-                                "line": 10,
-                                "column": 9,
-                                "offset": 106
-                              }
-                            },
-                            "value": "1"
-                          }
-                        ],
-                        "body": {
-                          "kind": "call",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 10,
-                              "column": 13,
-                              "offset": 110
-                            },
-                            "end": {
-                              "line": 10,
-                              "column": 18,
-                              "offset": 115
-                            }
-                          },
-                          "what": {
-                            "kind": "name",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 10,
-                                "column": 13,
-                                "offset": 110
-                              },
-                              "end": {
-                                "line": 10,
-                                "column": 16,
-                                "offset": 113
-                              }
-                            },
-                            "name": "foo",
-                            "resolution": "uqn"
-                          },
-                          "arguments": []
-                        }
-                      },
-                      {
-                        "kind": "matcharm",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 8,
-                            "offset": 125
-                          },
-                          "end": {
-                            "line": 11,
-                            "column": 21,
-                            "offset": 138
-                          }
-                        },
-                        "conds": [
-                          {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 8,
-                                "offset": 125
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 9,
-                                "offset": 126
-                              }
-                            },
-                            "value": "2"
-                          },
-                          {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 11,
-                                "offset": 128
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 12,
-                                "offset": 129
-                              }
-                            },
-                            "value": "3"
-                          }
-                        ],
-                        "body": {
-                          "kind": "call",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 16,
-                              "offset": 133
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 21,
-                              "offset": 138
-                            }
-                          },
-                          "what": {
-                            "kind": "name",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 16,
-                                "offset": 133
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 19,
-                                "offset": 136
-                              }
-                            },
-                            "name": "bar",
-                            "resolution": "uqn"
-                          },
-                          "arguments": []
-                        }
-                      },
-                      {
-                        "kind": "matcharm",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 8,
-                            "offset": 148
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 24,
-                            "offset": 164
-                          }
-                        },
-                        "conds": null,
-                        "body": {
-                          "kind": "call",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 19,
-                              "offset": 159
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 24,
-                              "offset": 164
-                            }
-                          },
-                          "what": {
-                            "kind": "name",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 12,
-                                "column": 19,
-                                "offset": 159
-                              },
-                              "end": {
-                                "line": 12,
-                                "column": 22,
-                                "offset": 162
-                              }
-                            },
-                            "name": "baz",
-                            "resolution": "uqn"
-                          },
-                          "arguments": []
-                        }
-                      }
-                    ]
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                   }
                 },
                 "loc": {
@@ -2329,7 +918,7 @@
                     "line": 13,
                     "column": 6
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                 }
               },
               "operator": "=",
@@ -2342,289 +931,9 @@
                   },
                   "end": {
                     "line": 13,
-                    "column": 7
+                    "column": 6
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                },
-                "origin": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 9,
-                      "column": 4,
-                      "offset": 75
-                    },
-                    "end": {
-                      "line": 13,
-                      "column": 6,
-                      "offset": 172
-                    }
-                  },
-                  "left": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 4,
-                        "offset": 75
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 10,
-                        "offset": 81
-                      }
-                    },
-                    "name": "value",
-                    "curly": false
-                  },
-                  "right": {
-                    "kind": "match",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 13,
-                        "offset": 84
-                      },
-                      "end": {
-                        "line": 13,
-                        "column": 5,
-                        "offset": 171
-                      }
-                    },
-                    "cond": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 20,
-                          "offset": 91
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 22,
-                          "offset": 93
-                        }
-                      },
-                      "name": "v",
-                      "curly": false
-                    },
-                    "arms": [
-                      {
-                        "kind": "matcharm",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 10,
-                            "column": 8,
-                            "offset": 105
-                          },
-                          "end": {
-                            "line": 10,
-                            "column": 18,
-                            "offset": 115
-                          }
-                        },
-                        "conds": [
-                          {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 10,
-                                "column": 8,
-                                "offset": 105
-                              },
-                              "end": {
-                                "line": 10,
-                                "column": 9,
-                                "offset": 106
-                              }
-                            },
-                            "value": "1"
-                          }
-                        ],
-                        "body": {
-                          "kind": "call",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 10,
-                              "column": 13,
-                              "offset": 110
-                            },
-                            "end": {
-                              "line": 10,
-                              "column": 18,
-                              "offset": 115
-                            }
-                          },
-                          "what": {
-                            "kind": "name",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 10,
-                                "column": 13,
-                                "offset": 110
-                              },
-                              "end": {
-                                "line": 10,
-                                "column": 16,
-                                "offset": 113
-                              }
-                            },
-                            "name": "foo",
-                            "resolution": "uqn"
-                          },
-                          "arguments": []
-                        }
-                      },
-                      {
-                        "kind": "matcharm",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 8,
-                            "offset": 125
-                          },
-                          "end": {
-                            "line": 11,
-                            "column": 21,
-                            "offset": 138
-                          }
-                        },
-                        "conds": [
-                          {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 8,
-                                "offset": 125
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 9,
-                                "offset": 126
-                              }
-                            },
-                            "value": "2"
-                          },
-                          {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 11,
-                                "offset": 128
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 12,
-                                "offset": 129
-                              }
-                            },
-                            "value": "3"
-                          }
-                        ],
-                        "body": {
-                          "kind": "call",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 16,
-                              "offset": 133
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 21,
-                              "offset": 138
-                            }
-                          },
-                          "what": {
-                            "kind": "name",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 16,
-                                "offset": 133
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 19,
-                                "offset": 136
-                              }
-                            },
-                            "name": "bar",
-                            "resolution": "uqn"
-                          },
-                          "arguments": []
-                        }
-                      },
-                      {
-                        "kind": "matcharm",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 8,
-                            "offset": 148
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 24,
-                            "offset": 164
-                          }
-                        },
-                        "conds": null,
-                        "body": {
-                          "kind": "call",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 19,
-                              "offset": 159
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 24,
-                              "offset": 164
-                            }
-                          },
-                          "what": {
-                            "kind": "name",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 12,
-                                "column": 19,
-                                "offset": 159
-                              },
-                              "end": {
-                                "line": 12,
-                                "column": 22,
-                                "offset": 162
-                              }
-                            },
-                            "name": "baz",
-                            "resolution": "uqn"
-                          },
-                          "arguments": []
-                        }
-                      }
-                    ]
-                  },
-                  "operator": "="
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                 }
               },
               "loc": {
@@ -2634,9 +943,9 @@
                 },
                 "end": {
                   "line": 13,
-                  "column": 7
+                  "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
               }
             },
             "_meta": {
@@ -2649,303 +958,7 @@
                   "line": 13,
                   "column": 7
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-              },
-              "origin": {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 9,
-                    "column": 4,
-                    "offset": 75
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 6,
-                    "offset": 172
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 9,
-                      "column": 4,
-                      "offset": 75
-                    },
-                    "end": {
-                      "line": 13,
-                      "column": 6,
-                      "offset": 172
-                    }
-                  },
-                  "left": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 4,
-                        "offset": 75
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 10,
-                        "offset": 81
-                      }
-                    },
-                    "name": "value",
-                    "curly": false
-                  },
-                  "right": {
-                    "kind": "match",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 13,
-                        "offset": 84
-                      },
-                      "end": {
-                        "line": 13,
-                        "column": 5,
-                        "offset": 171
-                      }
-                    },
-                    "cond": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 20,
-                          "offset": 91
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 22,
-                          "offset": 93
-                        }
-                      },
-                      "name": "v",
-                      "curly": false
-                    },
-                    "arms": [
-                      {
-                        "kind": "matcharm",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 10,
-                            "column": 8,
-                            "offset": 105
-                          },
-                          "end": {
-                            "line": 10,
-                            "column": 18,
-                            "offset": 115
-                          }
-                        },
-                        "conds": [
-                          {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 10,
-                                "column": 8,
-                                "offset": 105
-                              },
-                              "end": {
-                                "line": 10,
-                                "column": 9,
-                                "offset": 106
-                              }
-                            },
-                            "value": "1"
-                          }
-                        ],
-                        "body": {
-                          "kind": "call",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 10,
-                              "column": 13,
-                              "offset": 110
-                            },
-                            "end": {
-                              "line": 10,
-                              "column": 18,
-                              "offset": 115
-                            }
-                          },
-                          "what": {
-                            "kind": "name",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 10,
-                                "column": 13,
-                                "offset": 110
-                              },
-                              "end": {
-                                "line": 10,
-                                "column": 16,
-                                "offset": 113
-                              }
-                            },
-                            "name": "foo",
-                            "resolution": "uqn"
-                          },
-                          "arguments": []
-                        }
-                      },
-                      {
-                        "kind": "matcharm",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 8,
-                            "offset": 125
-                          },
-                          "end": {
-                            "line": 11,
-                            "column": 21,
-                            "offset": 138
-                          }
-                        },
-                        "conds": [
-                          {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 8,
-                                "offset": 125
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 9,
-                                "offset": 126
-                              }
-                            },
-                            "value": "2"
-                          },
-                          {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 11,
-                                "offset": 128
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 12,
-                                "offset": 129
-                              }
-                            },
-                            "value": "3"
-                          }
-                        ],
-                        "body": {
-                          "kind": "call",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 16,
-                              "offset": 133
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 21,
-                              "offset": 138
-                            }
-                          },
-                          "what": {
-                            "kind": "name",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 16,
-                                "offset": 133
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 19,
-                                "offset": 136
-                              }
-                            },
-                            "name": "bar",
-                            "resolution": "uqn"
-                          },
-                          "arguments": []
-                        }
-                      },
-                      {
-                        "kind": "matcharm",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 8,
-                            "offset": 148
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 24,
-                            "offset": 164
-                          }
-                        },
-                        "conds": null,
-                        "body": {
-                          "kind": "call",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 19,
-                              "offset": 159
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 24,
-                              "offset": 164
-                            }
-                          },
-                          "what": {
-                            "kind": "name",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 12,
-                                "column": 19,
-                                "offset": 159
-                              },
-                              "end": {
-                                "line": 12,
-                                "column": 22,
-                                "offset": 162
-                              }
-                            },
-                            "name": "baz",
-                            "resolution": "uqn"
-                          },
-                          "arguments": []
-                        }
-                      }
-                    ]
-                  },
-                  "operator": "="
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
               }
             },
             "loc": {
@@ -2957,7 +970,7 @@
                 "line": 13,
                 "column": 7
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
             }
           },
           {
@@ -2975,25 +988,7 @@
                     "line": 15,
                     "column": 18
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                },
-                "origin": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 15,
-                      "column": 11,
-                      "offset": 185
-                    },
-                    "end": {
-                      "line": 15,
-                      "column": 17,
-                      "offset": 191
-                    }
-                  },
-                  "name": "value",
-                  "curly": false
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                 }
               },
               "loc": {
@@ -3005,7 +1000,7 @@
                   "line": 15,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
               }
             },
             "isYield": false,
@@ -3019,41 +1014,7 @@
                   "line": 15,
                   "column": 19
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-              },
-              "origin": {
-                "kind": "return",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 15,
-                    "column": 4,
-                    "offset": 178
-                  },
-                  "end": {
-                    "line": 15,
-                    "column": 18,
-                    "offset": 192
-                  }
-                },
-                "expr": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 15,
-                      "column": 11,
-                      "offset": 185
-                    },
-                    "end": {
-                      "line": 15,
-                      "column": 17,
-                      "offset": 191
-                    }
-                  },
-                  "name": "value",
-                  "curly": false
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
               }
             },
             "loc": {
@@ -3065,7 +1026,7 @@
                 "line": 15,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
             }
           }
         ],
@@ -3080,355 +1041,7 @@
               "line": 16,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-          },
-          "origin": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 8,
-                "column": 0,
-                "offset": 69
-              },
-              "end": {
-                "line": 16,
-                "column": 1,
-                "offset": 194
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 9,
-                    "column": 4,
-                    "offset": 75
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 6,
-                    "offset": 172
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 9,
-                      "column": 4,
-                      "offset": 75
-                    },
-                    "end": {
-                      "line": 13,
-                      "column": 6,
-                      "offset": 172
-                    }
-                  },
-                  "left": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 4,
-                        "offset": 75
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 10,
-                        "offset": 81
-                      }
-                    },
-                    "name": "value",
-                    "curly": false
-                  },
-                  "right": {
-                    "kind": "match",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 13,
-                        "offset": 84
-                      },
-                      "end": {
-                        "line": 13,
-                        "column": 5,
-                        "offset": 171
-                      }
-                    },
-                    "cond": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 20,
-                          "offset": 91
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 22,
-                          "offset": 93
-                        }
-                      },
-                      "name": "v",
-                      "curly": false
-                    },
-                    "arms": [
-                      {
-                        "kind": "matcharm",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 10,
-                            "column": 8,
-                            "offset": 105
-                          },
-                          "end": {
-                            "line": 10,
-                            "column": 18,
-                            "offset": 115
-                          }
-                        },
-                        "conds": [
-                          {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 10,
-                                "column": 8,
-                                "offset": 105
-                              },
-                              "end": {
-                                "line": 10,
-                                "column": 9,
-                                "offset": 106
-                              }
-                            },
-                            "value": "1"
-                          }
-                        ],
-                        "body": {
-                          "kind": "call",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 10,
-                              "column": 13,
-                              "offset": 110
-                            },
-                            "end": {
-                              "line": 10,
-                              "column": 18,
-                              "offset": 115
-                            }
-                          },
-                          "what": {
-                            "kind": "name",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 10,
-                                "column": 13,
-                                "offset": 110
-                              },
-                              "end": {
-                                "line": 10,
-                                "column": 16,
-                                "offset": 113
-                              }
-                            },
-                            "name": "foo",
-                            "resolution": "uqn"
-                          },
-                          "arguments": []
-                        }
-                      },
-                      {
-                        "kind": "matcharm",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 8,
-                            "offset": 125
-                          },
-                          "end": {
-                            "line": 11,
-                            "column": 21,
-                            "offset": 138
-                          }
-                        },
-                        "conds": [
-                          {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 8,
-                                "offset": 125
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 9,
-                                "offset": 126
-                              }
-                            },
-                            "value": "2"
-                          },
-                          {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 11,
-                                "offset": 128
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 12,
-                                "offset": 129
-                              }
-                            },
-                            "value": "3"
-                          }
-                        ],
-                        "body": {
-                          "kind": "call",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 16,
-                              "offset": 133
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 21,
-                              "offset": 138
-                            }
-                          },
-                          "what": {
-                            "kind": "name",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 16,
-                                "offset": 133
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 19,
-                                "offset": 136
-                              }
-                            },
-                            "name": "bar",
-                            "resolution": "uqn"
-                          },
-                          "arguments": []
-                        }
-                      },
-                      {
-                        "kind": "matcharm",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 8,
-                            "offset": 148
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 24,
-                            "offset": 164
-                          }
-                        },
-                        "conds": null,
-                        "body": {
-                          "kind": "call",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 19,
-                              "offset": 159
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 24,
-                              "offset": 164
-                            }
-                          },
-                          "what": {
-                            "kind": "name",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 12,
-                                "column": 19,
-                                "offset": 159
-                              },
-                              "end": {
-                                "line": 12,
-                                "column": 22,
-                                "offset": 162
-                              }
-                            },
-                            "name": "baz",
-                            "resolution": "uqn"
-                          },
-                          "arguments": []
-                        }
-                      }
-                    ]
-                  },
-                  "operator": "="
-                }
-              },
-              {
-                "kind": "return",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 15,
-                    "column": 4,
-                    "offset": 178
-                  },
-                  "end": {
-                    "line": 15,
-                    "column": 18,
-                    "offset": 192
-                  }
-                },
-                "expr": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 15,
-                      "column": 11,
-                      "offset": 185
-                    },
-                    "end": {
-                      "line": 15,
-                      "column": 17,
-                      "offset": 191
-                    }
-                  },
-                  "name": "value",
-                  "curly": false
-                }
-              }
-            ]
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
           }
         },
         "loc": {
@@ -3440,12 +1053,11 @@
             "line": 16,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
         }
       },
       "modifiers": [],
       "_meta": {
-        "attributes": [],
         "loc": {
           "start": {
             "line": 7,
@@ -3455,435 +1067,7 @@
             "line": 16,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-        },
-        "origin": {
-          "kind": "function",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 7,
-              "column": 0,
-              "offset": 49
-            },
-            "end": {
-              "line": 16,
-              "column": 1,
-              "offset": 194
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 7,
-                "column": 9,
-                "offset": 58
-              },
-              "end": {
-                "line": 7,
-                "column": 15,
-                "offset": 64
-              }
-            },
-            "name": "choose"
-          },
-          "arguments": [
-            {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 7,
-                  "column": 16,
-                  "offset": 65
-                },
-                "end": {
-                  "line": 7,
-                  "column": 18,
-                  "offset": 67
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 7,
-                    "column": 16,
-                    "offset": 65
-                  },
-                  "end": {
-                    "line": 7,
-                    "column": 18,
-                    "offset": 67
-                  }
-                },
-                "name": "v"
-              },
-              "value": null,
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
-            }
-          ],
-          "byref": false,
-          "type": null,
-          "nullable": false,
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 8,
-                "column": 0,
-                "offset": 69
-              },
-              "end": {
-                "line": 16,
-                "column": 1,
-                "offset": 194
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 9,
-                    "column": 4,
-                    "offset": 75
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 6,
-                    "offset": 172
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 9,
-                      "column": 4,
-                      "offset": 75
-                    },
-                    "end": {
-                      "line": 13,
-                      "column": 6,
-                      "offset": 172
-                    }
-                  },
-                  "left": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 4,
-                        "offset": 75
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 10,
-                        "offset": 81
-                      }
-                    },
-                    "name": "value",
-                    "curly": false
-                  },
-                  "right": {
-                    "kind": "match",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 13,
-                        "offset": 84
-                      },
-                      "end": {
-                        "line": 13,
-                        "column": 5,
-                        "offset": 171
-                      }
-                    },
-                    "cond": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 20,
-                          "offset": 91
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 22,
-                          "offset": 93
-                        }
-                      },
-                      "name": "v",
-                      "curly": false
-                    },
-                    "arms": [
-                      {
-                        "kind": "matcharm",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 10,
-                            "column": 8,
-                            "offset": 105
-                          },
-                          "end": {
-                            "line": 10,
-                            "column": 18,
-                            "offset": 115
-                          }
-                        },
-                        "conds": [
-                          {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 10,
-                                "column": 8,
-                                "offset": 105
-                              },
-                              "end": {
-                                "line": 10,
-                                "column": 9,
-                                "offset": 106
-                              }
-                            },
-                            "value": "1"
-                          }
-                        ],
-                        "body": {
-                          "kind": "call",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 10,
-                              "column": 13,
-                              "offset": 110
-                            },
-                            "end": {
-                              "line": 10,
-                              "column": 18,
-                              "offset": 115
-                            }
-                          },
-                          "what": {
-                            "kind": "name",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 10,
-                                "column": 13,
-                                "offset": 110
-                              },
-                              "end": {
-                                "line": 10,
-                                "column": 16,
-                                "offset": 113
-                              }
-                            },
-                            "name": "foo",
-                            "resolution": "uqn"
-                          },
-                          "arguments": []
-                        }
-                      },
-                      {
-                        "kind": "matcharm",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 8,
-                            "offset": 125
-                          },
-                          "end": {
-                            "line": 11,
-                            "column": 21,
-                            "offset": 138
-                          }
-                        },
-                        "conds": [
-                          {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 8,
-                                "offset": 125
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 9,
-                                "offset": 126
-                              }
-                            },
-                            "value": "2"
-                          },
-                          {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 11,
-                                "offset": 128
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 12,
-                                "offset": 129
-                              }
-                            },
-                            "value": "3"
-                          }
-                        ],
-                        "body": {
-                          "kind": "call",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 16,
-                              "offset": 133
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 21,
-                              "offset": 138
-                            }
-                          },
-                          "what": {
-                            "kind": "name",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 16,
-                                "offset": 133
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 19,
-                                "offset": 136
-                              }
-                            },
-                            "name": "bar",
-                            "resolution": "uqn"
-                          },
-                          "arguments": []
-                        }
-                      },
-                      {
-                        "kind": "matcharm",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 8,
-                            "offset": 148
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 24,
-                            "offset": 164
-                          }
-                        },
-                        "conds": null,
-                        "body": {
-                          "kind": "call",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 19,
-                              "offset": 159
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 24,
-                              "offset": 164
-                            }
-                          },
-                          "what": {
-                            "kind": "name",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 12,
-                                "column": 19,
-                                "offset": 159
-                              },
-                              "end": {
-                                "line": 12,
-                                "column": 22,
-                                "offset": 162
-                              }
-                            },
-                            "name": "baz",
-                            "resolution": "uqn"
-                          },
-                          "arguments": []
-                        }
-                      }
-                    ]
-                  },
-                  "operator": "="
-                }
-              },
-              {
-                "kind": "return",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 15,
-                    "column": 4,
-                    "offset": 178
-                  },
-                  "end": {
-                    "line": 15,
-                    "column": 18,
-                    "offset": 192
-                  }
-                },
-                "expr": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 15,
-                      "column": 11,
-                      "offset": 185
-                    },
-                    "end": {
-                      "line": 15,
-                      "column": 17,
-                      "offset": 191
-                    }
-                  },
-                  "name": "value",
-                  "curly": false
-                }
-              }
-            ]
-          },
-          "attrGroups": []
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
         }
       },
       "loc": {
@@ -3895,67 +1079,89 @@
           "line": 16,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
       }
     },
     {
-      "type": "ExpressionStatement",
-      "expression": {
-        "type": "CallExpression",
-        "callee": {
-          "type": "Identifier",
-          "name": "echo",
-          "_meta": {}
-        },
-        "arguments": [
-          {
-            "type": "Identifier",
-            "name": "APP",
+      "type": "ScopedStatement",
+      "body": [
+        {
+          "type": "ExpressionStatement",
+          "expression": {
+            "type": "CallExpression",
+            "callee": {
+              "type": "Identifier",
+              "name": "echo",
+              "_meta": {}
+            },
+            "arguments": [
+              {
+                "type": "Identifier",
+                "name": "APP",
+                "_meta": {
+                  "loc": {
+                    "start": {
+                      "line": 19,
+                      "column": 10
+                    },
+                    "end": {
+                      "line": 19,
+                      "column": 13
+                    },
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                  }
+                },
+                "loc": {
+                  "start": {
+                    "line": 19,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 19,
+                    "column": 13
+                  },
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+                }
+              }
+            ],
             "_meta": {
               "loc": {
                 "start": {
                   "line": 19,
-                  "column": 10
+                  "column": 5
                 },
                 "end": {
                   "line": 19,
-                  "column": 13
+                  "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-              },
-              "origin": {
-                "kind": "name",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 19,
-                    "column": 9,
-                    "offset": 224
-                  },
-                  "end": {
-                    "line": 19,
-                    "column": 12,
-                    "offset": 227
-                  }
-                },
-                "name": "APP",
-                "resolution": "uqn"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
               }
             },
             "loc": {
               "start": {
                 "line": 19,
-                "column": 10
+                "column": 5
               },
               "end": {
                 "line": 19,
-                "column": 13
+                "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
             }
-          }
-        ],
-        "_meta": {
+          },
+          "_meta": {
+            "loc": {
+              "start": {
+                "line": 19,
+                "column": 5
+              },
+              "end": {
+                "line": 19,
+                "column": 14
+              },
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
+            }
+          },
           "loc": {
             "start": {
               "line": 19,
@@ -3965,157 +1171,27 @@
               "line": 19,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-          },
-          "origin": {
-            "kind": "echo",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 19,
-                "column": 4,
-                "offset": 219
-              },
-              "end": {
-                "line": 19,
-                "column": 13,
-                "offset": 228
-              }
-            },
-            "shortForm": false,
-            "expressions": [
-              {
-                "kind": "name",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 19,
-                    "column": 9,
-                    "offset": 224
-                  },
-                  "end": {
-                    "line": 19,
-                    "column": 12,
-                    "offset": 227
-                  }
-                },
-                "name": "APP",
-                "resolution": "uqn"
-              }
-            ]
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
           }
-        },
-        "loc": {
-          "start": {
-            "line": 19,
-            "column": 5
-          },
-          "end": {
-            "line": 19,
-            "column": 14
-          },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
         }
-      },
+      ],
+      "id": null,
       "_meta": {
         "loc": {
           "start": {
-            "line": 19,
-            "column": 5
+            "line": 18,
+            "column": 1
           },
           "end": {
-            "line": 19,
-            "column": 14
+            "line": 20,
+            "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-        },
-        "origin": {
-          "kind": "echo",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 19,
-              "column": 4,
-              "offset": 219
-            },
-            "end": {
-              "line": 19,
-              "column": 13,
-              "offset": 228
-            }
-          },
-          "shortForm": false,
-          "expressions": [
-            {
-              "kind": "name",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 19,
-                  "column": 9,
-                  "offset": 224
-                },
-                "end": {
-                  "line": 19,
-                  "column": 12,
-                  "offset": 227
-                }
-              },
-              "name": "APP",
-              "resolution": "uqn"
-            }
-          ]
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
         },
         "declare": {
-          "mode": "block",
           "directives": [
             {
               "key": {
-                "type": "Identifier",
-                "name": "ticks",
-                "_meta": {
-                  "loc": {
-                    "start": {
-                      "line": 18,
-                      "column": 9
-                    },
-                    "end": {
-                      "line": 18,
-                      "column": 14
-                    },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                  },
-                  "origin": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 18,
-                        "column": 8,
-                        "offset": 204
-                      },
-                      "end": {
-                        "line": 18,
-                        "column": 13,
-                        "offset": 209
-                      }
-                    },
-                    "name": "ticks"
-                  }
-                },
-                "loc": {
-                  "start": {
-                    "line": 18,
-                    "column": 9
-                  },
-                  "end": {
-                    "line": 18,
-                    "column": 14
-                  },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                }
-              },
-              "value": {
                 "type": "Literal",
                 "value": 1,
                 "literalType": "number",
@@ -4129,24 +1205,7 @@
                       "line": 18,
                       "column": 16
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-                  },
-                  "origin": {
-                    "kind": "number",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 18,
-                        "column": 14,
-                        "offset": 210
-                      },
-                      "end": {
-                        "line": 18,
-                        "column": 15,
-                        "offset": 211
-                      }
-                    },
-                    "value": "1"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                   }
                 },
                 "loc": {
@@ -4158,29 +1217,30 @@
                     "line": 18,
                     "column": 16
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
                 }
-              }
+              },
+              "value": null
             }
           ]
         }
       },
       "loc": {
         "start": {
-          "line": 19,
-          "column": 5
+          "line": 18,
+          "column": 1
         },
         "end": {
-          "line": 19,
-          "column": 14
+          "line": 20,
+          "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -4192,701 +1252,7 @@
         "line": 21,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
-    },
-    "origin": {
-      "kind": "program",
-      "loc": {
-        "source": null,
-        "start": {
-          "line": 1,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "line": 21,
-          "column": 0,
-          "offset": 231
-        }
-      },
-      "children": [
-        {
-          "kind": "constantstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 7
-            },
-            "end": {
-              "line": 3,
-              "column": 14,
-              "offset": 21
-            }
-          },
-          "constants": [
-            {
-              "kind": "constant",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 6,
-                  "offset": 13
-                },
-                "end": {
-                  "line": 3,
-                  "column": 13,
-                  "offset": 20
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 6,
-                    "offset": 13
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 9,
-                    "offset": 16
-                  }
-                },
-                "name": "APP"
-              },
-              "value": {
-                "kind": "number",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 12,
-                    "offset": 19
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 13,
-                    "offset": 20
-                  }
-                },
-                "value": "1"
-              }
-            }
-          ]
-        },
-        {
-          "kind": "declare",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 5,
-              "column": 0,
-              "offset": 23
-            },
-            "end": {
-              "line": 5,
-              "column": 24,
-              "offset": 47
-            }
-          },
-          "children": [],
-          "directives": [
-            {
-              "kind": "declaredirective",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 5,
-                  "column": 8,
-                  "offset": 31
-                },
-                "end": {
-                  "line": 5,
-                  "column": 22,
-                  "offset": 45
-                }
-              },
-              "key": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 8,
-                    "offset": 31
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 20,
-                    "offset": 43
-                  }
-                },
-                "name": "strict_types"
-              },
-              "value": {
-                "kind": "number",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 21,
-                    "offset": 44
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 22,
-                    "offset": 45
-                  }
-                },
-                "value": "1"
-              }
-            }
-          ],
-          "mode": "none"
-        },
-        {
-          "kind": "function",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 7,
-              "column": 0,
-              "offset": 49
-            },
-            "end": {
-              "line": 16,
-              "column": 1,
-              "offset": 194
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 7,
-                "column": 9,
-                "offset": 58
-              },
-              "end": {
-                "line": 7,
-                "column": 15,
-                "offset": 64
-              }
-            },
-            "name": "choose"
-          },
-          "arguments": [
-            {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 7,
-                  "column": 16,
-                  "offset": 65
-                },
-                "end": {
-                  "line": 7,
-                  "column": 18,
-                  "offset": 67
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 7,
-                    "column": 16,
-                    "offset": 65
-                  },
-                  "end": {
-                    "line": 7,
-                    "column": 18,
-                    "offset": 67
-                  }
-                },
-                "name": "v"
-              },
-              "value": null,
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
-            }
-          ],
-          "byref": false,
-          "type": null,
-          "nullable": false,
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 8,
-                "column": 0,
-                "offset": 69
-              },
-              "end": {
-                "line": 16,
-                "column": 1,
-                "offset": 194
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 9,
-                    "column": 4,
-                    "offset": 75
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 6,
-                    "offset": 172
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 9,
-                      "column": 4,
-                      "offset": 75
-                    },
-                    "end": {
-                      "line": 13,
-                      "column": 6,
-                      "offset": 172
-                    }
-                  },
-                  "left": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 4,
-                        "offset": 75
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 10,
-                        "offset": 81
-                      }
-                    },
-                    "name": "value",
-                    "curly": false
-                  },
-                  "right": {
-                    "kind": "match",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 13,
-                        "offset": 84
-                      },
-                      "end": {
-                        "line": 13,
-                        "column": 5,
-                        "offset": 171
-                      }
-                    },
-                    "cond": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 20,
-                          "offset": 91
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 22,
-                          "offset": 93
-                        }
-                      },
-                      "name": "v",
-                      "curly": false
-                    },
-                    "arms": [
-                      {
-                        "kind": "matcharm",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 10,
-                            "column": 8,
-                            "offset": 105
-                          },
-                          "end": {
-                            "line": 10,
-                            "column": 18,
-                            "offset": 115
-                          }
-                        },
-                        "conds": [
-                          {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 10,
-                                "column": 8,
-                                "offset": 105
-                              },
-                              "end": {
-                                "line": 10,
-                                "column": 9,
-                                "offset": 106
-                              }
-                            },
-                            "value": "1"
-                          }
-                        ],
-                        "body": {
-                          "kind": "call",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 10,
-                              "column": 13,
-                              "offset": 110
-                            },
-                            "end": {
-                              "line": 10,
-                              "column": 18,
-                              "offset": 115
-                            }
-                          },
-                          "what": {
-                            "kind": "name",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 10,
-                                "column": 13,
-                                "offset": 110
-                              },
-                              "end": {
-                                "line": 10,
-                                "column": 16,
-                                "offset": 113
-                              }
-                            },
-                            "name": "foo",
-                            "resolution": "uqn"
-                          },
-                          "arguments": []
-                        }
-                      },
-                      {
-                        "kind": "matcharm",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 8,
-                            "offset": 125
-                          },
-                          "end": {
-                            "line": 11,
-                            "column": 21,
-                            "offset": 138
-                          }
-                        },
-                        "conds": [
-                          {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 8,
-                                "offset": 125
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 9,
-                                "offset": 126
-                              }
-                            },
-                            "value": "2"
-                          },
-                          {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 11,
-                                "offset": 128
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 12,
-                                "offset": 129
-                              }
-                            },
-                            "value": "3"
-                          }
-                        ],
-                        "body": {
-                          "kind": "call",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 16,
-                              "offset": 133
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 21,
-                              "offset": 138
-                            }
-                          },
-                          "what": {
-                            "kind": "name",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 16,
-                                "offset": 133
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 19,
-                                "offset": 136
-                              }
-                            },
-                            "name": "bar",
-                            "resolution": "uqn"
-                          },
-                          "arguments": []
-                        }
-                      },
-                      {
-                        "kind": "matcharm",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 8,
-                            "offset": 148
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 24,
-                            "offset": 164
-                          }
-                        },
-                        "conds": null,
-                        "body": {
-                          "kind": "call",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 19,
-                              "offset": 159
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 24,
-                              "offset": 164
-                            }
-                          },
-                          "what": {
-                            "kind": "name",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 12,
-                                "column": 19,
-                                "offset": 159
-                              },
-                              "end": {
-                                "line": 12,
-                                "column": 22,
-                                "offset": 162
-                              }
-                            },
-                            "name": "baz",
-                            "resolution": "uqn"
-                          },
-                          "arguments": []
-                        }
-                      }
-                    ]
-                  },
-                  "operator": "="
-                }
-              },
-              {
-                "kind": "return",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 15,
-                    "column": 4,
-                    "offset": 178
-                  },
-                  "end": {
-                    "line": 15,
-                    "column": 18,
-                    "offset": 192
-                  }
-                },
-                "expr": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 15,
-                      "column": 11,
-                      "offset": 185
-                    },
-                    "end": {
-                      "line": 15,
-                      "column": 17,
-                      "offset": 191
-                    }
-                  },
-                  "name": "value",
-                  "curly": false
-                }
-              }
-            ]
-          },
-          "attrGroups": []
-        },
-        {
-          "kind": "declare",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 18,
-              "column": 0,
-              "offset": 196
-            },
-            "end": {
-              "line": 20,
-              "column": 1,
-              "offset": 230
-            }
-          },
-          "children": [
-            {
-              "kind": "echo",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 19,
-                  "column": 4,
-                  "offset": 219
-                },
-                "end": {
-                  "line": 19,
-                  "column": 13,
-                  "offset": 228
-                }
-              },
-              "shortForm": false,
-              "expressions": [
-                {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 19,
-                      "column": 9,
-                      "offset": 224
-                    },
-                    "end": {
-                      "line": 19,
-                      "column": 12,
-                      "offset": 227
-                    }
-                  },
-                  "name": "APP",
-                  "resolution": "uqn"
-                }
-              ]
-            }
-          ],
-          "directives": [
-            {
-              "kind": "declaredirective",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 18,
-                  "column": 8,
-                  "offset": 204
-                },
-                "end": {
-                  "line": 18,
-                  "column": 15,
-                  "offset": 211
-                }
-              },
-              "key": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 18,
-                    "column": 8,
-                    "offset": 204
-                  },
-                  "end": {
-                    "line": 18,
-                    "column": 13,
-                    "offset": 209
-                  }
-                },
-                "name": "ticks"
-              },
-              "value": {
-                "kind": "number",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 18,
-                    "column": 14,
-                    "offset": 210
-                  },
-                  "end": {
-                    "line": 18,
-                    "column": 15,
-                    "offset": 211
-                  }
-                },
-                "value": "1"
-              }
-            }
-          ],
-          "mode": "block"
-        }
-      ],
-      "errors": [],
-      "comments": []
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
     }
   },
   "loc": {
@@ -4898,6 +1264,6 @@
       "line": 21,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/advanced.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/advanced.php.json
+++ b/parser-PHP/tests/benchmark/base/advanced.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 10
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
           },
           "origin": {
             "kind": "identifier",
@@ -45,7 +45,7 @@
             "line": 3,
             "column": 10
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
         }
       },
       "init": {
@@ -62,7 +62,7 @@
               "line": 3,
               "column": 14
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
           },
           "origin": {
             "kind": "number",
@@ -91,7 +91,7 @@
             "line": 3,
             "column": 14
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
         }
       },
       "cloned": false,
@@ -110,7 +110,7 @@
             "line": 3,
             "column": 14
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
         },
         "origin": {
           "kind": "constant",
@@ -173,7 +173,7 @@
           "line": 3,
           "column": 14
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
       }
     },
     {
@@ -188,7 +188,7 @@
             "line": 5,
             "column": 25
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
         },
         "origin": {
           "kind": "declare",
@@ -277,7 +277,7 @@
                       "line": 5,
                       "column": 21
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                   },
                   "origin": {
                     "kind": "identifier",
@@ -306,7 +306,7 @@
                     "line": 5,
                     "column": 21
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                 }
               },
               "value": {
@@ -323,7 +323,7 @@
                       "line": 5,
                       "column": 23
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                   },
                   "origin": {
                     "kind": "number",
@@ -352,7 +352,7 @@
                     "line": 5,
                     "column": 23
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                 }
               }
             }
@@ -368,7 +368,7 @@
           "line": 5,
           "column": 25
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
       }
     },
     {
@@ -386,7 +386,7 @@
               "line": 7,
               "column": 16
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
           },
           "origin": {
             "kind": "identifier",
@@ -415,7 +415,7 @@
             "line": 7,
             "column": 16
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
         }
       },
       "parameters": [
@@ -434,7 +434,7 @@
                   "line": 7,
                   "column": 19
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -463,7 +463,7 @@
                 "line": 7,
                 "column": 19
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
             }
           },
           "init": null,
@@ -486,7 +486,7 @@
                 "line": 7,
                 "column": 19
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
             },
             "origin": {
               "kind": "parameter",
@@ -539,7 +539,7 @@
               "line": 7,
               "column": 19
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
           }
         }
       ],
@@ -568,7 +568,7 @@
                       "line": 9,
                       "column": 11
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                   },
                   "origin": {
                     "kind": "variable",
@@ -598,7 +598,7 @@
                     "line": 9,
                     "column": 11
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                 }
               },
               "right": {
@@ -622,7 +622,7 @@
                           "line": 9,
                           "column": 23
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                       },
                       "origin": {
                         "kind": "variable",
@@ -652,7 +652,7 @@
                         "line": 9,
                         "column": 23
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                     }
                   },
                   {
@@ -685,7 +685,7 @@
                                         "line": 10,
                                         "column": 10
                                       },
-                                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                     },
                                     "origin": {
                                       "kind": "number",
@@ -714,7 +714,7 @@
                                       "line": 10,
                                       "column": 10
                                     },
-                                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                   }
                                 }
                               ],
@@ -730,7 +730,7 @@
                                   "line": 10,
                                   "column": 19
                                 },
-                                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                               },
                               "origin": {
                                 "kind": "matcharm",
@@ -812,7 +812,7 @@
                                 "line": 10,
                                 "column": 19
                               },
-                              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                             }
                           },
                           {
@@ -837,7 +837,7 @@
                                       "line": 10,
                                       "column": 17
                                     },
-                                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                   },
                                   "origin": {
                                     "kind": "name",
@@ -867,7 +867,7 @@
                                     "line": 10,
                                     "column": 17
                                   },
-                                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                 }
                               },
                               "arguments": [],
@@ -881,7 +881,7 @@
                                     "line": 10,
                                     "column": 19
                                   },
-                                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                 },
                                 "origin": {
                                   "kind": "call",
@@ -928,7 +928,7 @@
                                   "line": 10,
                                   "column": 19
                                 },
-                                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "_meta": {
@@ -941,7 +941,7 @@
                                   "line": 10,
                                   "column": 19
                                 },
-                                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                               },
                               "origin": {
                                 "kind": "matcharm",
@@ -1023,7 +1023,7 @@
                                 "line": 10,
                                 "column": 19
                               },
-                              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                             }
                           }
                         ],
@@ -1038,7 +1038,7 @@
                               "line": 10,
                               "column": 19
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                           },
                           "origin": {
                             "kind": "matcharm",
@@ -1120,7 +1120,7 @@
                             "line": 10,
                             "column": 19
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                         }
                       },
                       {
@@ -1150,7 +1150,7 @@
                                         "line": 11,
                                         "column": 10
                                       },
-                                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                     },
                                     "origin": {
                                       "kind": "number",
@@ -1179,7 +1179,7 @@
                                       "line": 11,
                                       "column": 10
                                     },
-                                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                   }
                                 },
                                 {
@@ -1196,7 +1196,7 @@
                                         "line": 11,
                                         "column": 13
                                       },
-                                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                     },
                                     "origin": {
                                       "kind": "number",
@@ -1225,7 +1225,7 @@
                                       "line": 11,
                                       "column": 13
                                     },
-                                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                   }
                                 }
                               ],
@@ -1241,7 +1241,7 @@
                                   "line": 11,
                                   "column": 22
                                 },
-                                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                               },
                               "origin": {
                                 "kind": "matcharm",
@@ -1340,7 +1340,7 @@
                                 "line": 11,
                                 "column": 22
                               },
-                              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                             }
                           },
                           {
@@ -1365,7 +1365,7 @@
                                       "line": 11,
                                       "column": 20
                                     },
-                                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                   },
                                   "origin": {
                                     "kind": "name",
@@ -1395,7 +1395,7 @@
                                     "line": 11,
                                     "column": 20
                                   },
-                                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                 }
                               },
                               "arguments": [],
@@ -1409,7 +1409,7 @@
                                     "line": 11,
                                     "column": 22
                                   },
-                                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                 },
                                 "origin": {
                                   "kind": "call",
@@ -1456,7 +1456,7 @@
                                   "line": 11,
                                   "column": 22
                                 },
-                                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "_meta": {
@@ -1469,7 +1469,7 @@
                                   "line": 11,
                                   "column": 22
                                 },
-                                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                               },
                               "origin": {
                                 "kind": "matcharm",
@@ -1568,7 +1568,7 @@
                                 "line": 11,
                                 "column": 22
                               },
-                              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                             }
                           }
                         ],
@@ -1583,7 +1583,7 @@
                               "line": 11,
                               "column": 22
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                           },
                           "origin": {
                             "kind": "matcharm",
@@ -1682,7 +1682,7 @@
                             "line": 11,
                             "column": 22
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                         }
                       },
                       {
@@ -1717,7 +1717,7 @@
                                   "line": 12,
                                   "column": 25
                                 },
-                                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                               },
                               "origin": {
                                 "kind": "matcharm",
@@ -1781,7 +1781,7 @@
                                 "line": 12,
                                 "column": 25
                               },
-                              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                             }
                           },
                           {
@@ -1806,7 +1806,7 @@
                                       "line": 12,
                                       "column": 23
                                     },
-                                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                   },
                                   "origin": {
                                     "kind": "name",
@@ -1836,7 +1836,7 @@
                                     "line": 12,
                                     "column": 23
                                   },
-                                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                 }
                               },
                               "arguments": [],
@@ -1850,7 +1850,7 @@
                                     "line": 12,
                                     "column": 25
                                   },
-                                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                                 },
                                 "origin": {
                                   "kind": "call",
@@ -1897,7 +1897,7 @@
                                   "line": 12,
                                   "column": 25
                                 },
-                                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                               }
                             },
                             "_meta": {
@@ -1910,7 +1910,7 @@
                                   "line": 12,
                                   "column": 25
                                 },
-                                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                               },
                               "origin": {
                                 "kind": "matcharm",
@@ -1974,7 +1974,7 @@
                                 "line": 12,
                                 "column": 25
                               },
-                              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                             }
                           }
                         ],
@@ -1990,7 +1990,7 @@
                               "line": 12,
                               "column": 25
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                           },
                           "origin": {
                             "kind": "matcharm",
@@ -2054,7 +2054,7 @@
                             "line": 12,
                             "column": 25
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                         }
                       }
                     ],
@@ -2072,7 +2072,7 @@
                       "line": 13,
                       "column": 6
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                   },
                   "origin": {
                     "kind": "match",
@@ -2329,7 +2329,7 @@
                     "line": 13,
                     "column": 6
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                 }
               },
               "operator": "=",
@@ -2344,7 +2344,7 @@
                     "line": 13,
                     "column": 7
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                 },
                 "origin": {
                   "kind": "assign",
@@ -2636,7 +2636,7 @@
                   "line": 13,
                   "column": 7
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
               }
             },
             "_meta": {
@@ -2649,7 +2649,7 @@
                   "line": 13,
                   "column": 7
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
               },
               "origin": {
                 "kind": "expressionstatement",
@@ -2957,7 +2957,7 @@
                 "line": 13,
                 "column": 7
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
             }
           },
           {
@@ -2975,7 +2975,7 @@
                     "line": 15,
                     "column": 18
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                 },
                 "origin": {
                   "kind": "variable",
@@ -3005,7 +3005,7 @@
                   "line": 15,
                   "column": 18
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
               }
             },
             "isYield": false,
@@ -3019,7 +3019,7 @@
                   "line": 15,
                   "column": 19
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
               },
               "origin": {
                 "kind": "return",
@@ -3065,7 +3065,7 @@
                 "line": 15,
                 "column": 19
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
             }
           }
         ],
@@ -3080,7 +3080,7 @@
               "line": 16,
               "column": 2
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
           },
           "origin": {
             "kind": "block",
@@ -3440,7 +3440,7 @@
             "line": 16,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
         }
       },
       "modifiers": [],
@@ -3455,7 +3455,7 @@
             "line": 16,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
         },
         "origin": {
           "kind": "function",
@@ -3895,7 +3895,7 @@
           "line": 16,
           "column": 2
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
       }
     },
     {
@@ -3921,7 +3921,7 @@
                   "line": 19,
                   "column": 13
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
               },
               "origin": {
                 "kind": "name",
@@ -3951,7 +3951,7 @@
                 "line": 19,
                 "column": 13
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
             }
           }
         ],
@@ -3965,7 +3965,7 @@
               "line": 19,
               "column": 14
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
           },
           "origin": {
             "kind": "echo",
@@ -4014,7 +4014,7 @@
             "line": 19,
             "column": 14
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
         }
       },
       "_meta": {
@@ -4027,7 +4027,7 @@
             "line": 19,
             "column": 14
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
         },
         "origin": {
           "kind": "echo",
@@ -4083,7 +4083,7 @@
                       "line": 18,
                       "column": 14
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                   },
                   "origin": {
                     "kind": "identifier",
@@ -4112,7 +4112,7 @@
                     "line": 18,
                     "column": 14
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                 }
               },
               "value": {
@@ -4129,7 +4129,7 @@
                       "line": 18,
                       "column": 16
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                   },
                   "origin": {
                     "kind": "number",
@@ -4158,7 +4158,7 @@
                     "line": 18,
                     "column": 16
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
                 }
               }
             }
@@ -4174,13 +4174,13 @@
           "line": 19,
           "column": 14
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -4192,7 +4192,7 @@
         "line": 21,
         "column": 1
       },
-      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
     },
     "origin": {
       "kind": "program",
@@ -4898,6 +4898,6 @@
       "line": 21,
       "column": 1
     },
-    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/advanced.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/basic.php.json
+++ b/parser-PHP/tests/benchmark/base/basic.php.json
@@ -18,7 +18,7 @@
                 "line": 2,
                 "column": 3
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
             },
             "origin": {
               "kind": "variable",
@@ -48,7 +48,7 @@
               "line": 2,
               "column": 3
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
           }
         },
         "right": {
@@ -66,7 +66,7 @@
                   "line": 2,
                   "column": 11
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
               },
               "origin": {
                 "kind": "variable",
@@ -96,7 +96,7 @@
                 "line": 2,
                 "column": 11
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
             }
           },
           "property": {
@@ -113,7 +113,7 @@
                   "line": 2,
                   "column": 16
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
               },
               "origin": {
                 "kind": "string",
@@ -145,7 +145,7 @@
                 "line": 2,
                 "column": 16
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
             }
           },
           "computed": true,
@@ -159,7 +159,7 @@
                 "line": 2,
                 "column": 17
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
             },
             "origin": {
               "kind": "offsetlookup",
@@ -225,7 +225,7 @@
               "line": 2,
               "column": 17
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
           }
         },
         "operator": "=",
@@ -240,7 +240,7 @@
               "line": 2,
               "column": 18
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
           },
           "origin": {
             "kind": "assign",
@@ -341,7 +341,7 @@
             "line": 2,
             "column": 18
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
         }
       },
       "_meta": {
@@ -354,7 +354,7 @@
             "line": 2,
             "column": 18
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
         },
         "origin": {
           "kind": "expressionstatement",
@@ -471,7 +471,7 @@
           "line": 2,
           "column": 18
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
       }
     },
     {
@@ -497,7 +497,7 @@
                   "line": 3,
                   "column": 8
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
               },
               "origin": {
                 "kind": "variable",
@@ -527,7 +527,7 @@
                 "line": 3,
                 "column": 8
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
             }
           }
         ],
@@ -541,7 +541,7 @@
               "line": 3,
               "column": 9
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
           },
           "origin": {
             "kind": "echo",
@@ -590,7 +590,7 @@
             "line": 3,
             "column": 9
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
         }
       },
       "_meta": {
@@ -603,7 +603,7 @@
             "line": 3,
             "column": 9
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
         },
         "origin": {
           "kind": "echo",
@@ -652,13 +652,13 @@
           "line": 3,
           "column": 9
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -670,7 +670,7 @@
         "line": 4,
         "column": 1
       },
-      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
     },
     "origin": {
       "kind": "program",
@@ -844,6 +844,6 @@
       "line": 4,
       "column": 1
     },
-    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/basic.php.json
+++ b/parser-PHP/tests/benchmark/base/basic.php.json
@@ -18,7 +18,7 @@
                 "line": 2,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
             }
           },
           "loc": {
@@ -30,7 +30,7 @@
               "line": 2,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
           }
         },
         "right": {
@@ -48,7 +48,7 @@
                   "line": 2,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
               }
             },
             "loc": {
@@ -60,7 +60,7 @@
                 "line": 2,
                 "column": 11
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
             }
           },
           "property": {
@@ -77,7 +77,7 @@
                   "line": 2,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
               },
               "encapsed": true
             },
@@ -90,7 +90,7 @@
                 "line": 2,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
             }
           },
           "computed": true,
@@ -104,7 +104,7 @@
                 "line": 2,
                 "column": 17
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
             }
           },
           "loc": {
@@ -116,7 +116,7 @@
               "line": 2,
               "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
           }
         },
         "operator": "=",
@@ -131,7 +131,7 @@
               "line": 2,
               "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
           }
         },
         "loc": {
@@ -143,7 +143,7 @@
             "line": 2,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
         }
       },
       "_meta": {
@@ -156,7 +156,7 @@
             "line": 2,
             "column": 18
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
         }
       },
       "loc": {
@@ -168,7 +168,7 @@
           "line": 2,
           "column": 18
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
       }
     },
     {
@@ -194,7 +194,7 @@
                   "line": 3,
                   "column": 8
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
               }
             },
             "loc": {
@@ -206,7 +206,7 @@
                 "line": 3,
                 "column": 8
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
             }
           }
         ],
@@ -220,7 +220,7 @@
               "line": 3,
               "column": 9
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
           }
         },
         "loc": {
@@ -232,7 +232,7 @@
             "line": 3,
             "column": 9
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
         }
       },
       "_meta": {
@@ -245,7 +245,7 @@
             "line": 3,
             "column": 9
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
         }
       },
       "loc": {
@@ -257,13 +257,13 @@
           "line": 3,
           "column": 9
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -275,7 +275,7 @@
         "line": 4,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
     }
   },
   "loc": {
@@ -287,6 +287,6 @@
       "line": 4,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/basic.php.json
+++ b/parser-PHP/tests/benchmark/base/basic.php.json
@@ -18,25 +18,7 @@
                 "line": 2,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
-            },
-            "origin": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 0,
-                  "offset": 6
-                },
-                "end": {
-                  "line": 2,
-                  "column": 2,
-                  "offset": 8
-                }
-              },
-              "name": "a",
-              "curly": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
             }
           },
           "loc": {
@@ -48,7 +30,7 @@
               "line": 2,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
           }
         },
         "right": {
@@ -66,25 +48,7 @@
                   "line": 2,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
-              },
-              "origin": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 5,
-                    "offset": 11
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 10,
-                    "offset": 16
-                  }
-                },
-                "name": "_GET",
-                "curly": false
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
               }
             },
             "loc": {
@@ -96,7 +60,7 @@
                 "line": 2,
                 "column": 11
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
             }
           },
           "property": {
@@ -113,28 +77,9 @@
                   "line": 2,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
               },
-              "origin": {
-                "kind": "string",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 11,
-                    "offset": 17
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 15,
-                    "offset": 21
-                  }
-                },
-                "value": "id",
-                "raw": "\"id\"",
-                "unicode": false,
-                "isDoubleQuote": true
-              }
+              "encapsed": true
             },
             "loc": {
               "start": {
@@ -145,7 +90,7 @@
                 "line": 2,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
             }
           },
           "computed": true,
@@ -159,61 +104,7 @@
                 "line": 2,
                 "column": 17
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
-            },
-            "origin": {
-              "kind": "offsetlookup",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 5,
-                  "offset": 11
-                },
-                "end": {
-                  "line": 2,
-                  "column": 16,
-                  "offset": 22
-                }
-              },
-              "what": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 5,
-                    "offset": 11
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 10,
-                    "offset": 16
-                  }
-                },
-                "name": "_GET",
-                "curly": false
-              },
-              "offset": {
-                "kind": "string",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 11,
-                    "offset": 17
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 15,
-                    "offset": 21
-                  }
-                },
-                "value": "id",
-                "raw": "\"id\"",
-                "unicode": false,
-                "isDoubleQuote": true
-              }
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
             }
           },
           "loc": {
@@ -225,7 +116,7 @@
               "line": 2,
               "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
           }
         },
         "operator": "=",
@@ -238,98 +129,9 @@
             },
             "end": {
               "line": 2,
-              "column": 18
+              "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
-          },
-          "origin": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 2,
-                "column": 0,
-                "offset": 6
-              },
-              "end": {
-                "line": 2,
-                "column": 17,
-                "offset": 23
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 0,
-                  "offset": 6
-                },
-                "end": {
-                  "line": 2,
-                  "column": 2,
-                  "offset": 8
-                }
-              },
-              "name": "a",
-              "curly": false
-            },
-            "right": {
-              "kind": "offsetlookup",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 5,
-                  "offset": 11
-                },
-                "end": {
-                  "line": 2,
-                  "column": 16,
-                  "offset": 22
-                }
-              },
-              "what": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 5,
-                    "offset": 11
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 10,
-                    "offset": 16
-                  }
-                },
-                "name": "_GET",
-                "curly": false
-              },
-              "offset": {
-                "kind": "string",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 11,
-                    "offset": 17
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 15,
-                    "offset": 21
-                  }
-                },
-                "value": "id",
-                "raw": "\"id\"",
-                "unicode": false,
-                "isDoubleQuote": true
-              }
-            },
-            "operator": "="
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
           }
         },
         "loc": {
@@ -339,9 +141,9 @@
           },
           "end": {
             "line": 2,
-            "column": 18
+            "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
         }
       },
       "_meta": {
@@ -354,112 +156,7 @@
             "line": 2,
             "column": 18
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
-        },
-        "origin": {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 2,
-              "column": 0,
-              "offset": 6
-            },
-            "end": {
-              "line": 2,
-              "column": 17,
-              "offset": 23
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 2,
-                "column": 0,
-                "offset": 6
-              },
-              "end": {
-                "line": 2,
-                "column": 17,
-                "offset": 23
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 0,
-                  "offset": 6
-                },
-                "end": {
-                  "line": 2,
-                  "column": 2,
-                  "offset": 8
-                }
-              },
-              "name": "a",
-              "curly": false
-            },
-            "right": {
-              "kind": "offsetlookup",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 5,
-                  "offset": 11
-                },
-                "end": {
-                  "line": 2,
-                  "column": 16,
-                  "offset": 22
-                }
-              },
-              "what": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 5,
-                    "offset": 11
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 10,
-                    "offset": 16
-                  }
-                },
-                "name": "_GET",
-                "curly": false
-              },
-              "offset": {
-                "kind": "string",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 11,
-                    "offset": 17
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 15,
-                    "offset": 21
-                  }
-                },
-                "value": "id",
-                "raw": "\"id\"",
-                "unicode": false,
-                "isDoubleQuote": true
-              }
-            },
-            "operator": "="
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
         }
       },
       "loc": {
@@ -471,7 +168,7 @@
           "line": 2,
           "column": 18
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
       }
     },
     {
@@ -497,25 +194,7 @@
                   "line": 3,
                   "column": 8
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
-              },
-              "origin": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 5,
-                    "offset": 29
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 7,
-                    "offset": 31
-                  }
-                },
-                "name": "a",
-                "curly": false
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
               }
             },
             "loc": {
@@ -527,7 +206,7 @@
                 "line": 3,
                 "column": 8
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
             }
           }
         ],
@@ -541,44 +220,7 @@
               "line": 3,
               "column": 9
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
-          },
-          "origin": {
-            "kind": "echo",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 0,
-                "offset": 24
-              },
-              "end": {
-                "line": 3,
-                "column": 8,
-                "offset": 32
-              }
-            },
-            "shortForm": false,
-            "expressions": [
-              {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 5,
-                    "offset": 29
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 7,
-                    "offset": 31
-                  }
-                },
-                "name": "a",
-                "curly": false
-              }
-            ]
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
           }
         },
         "loc": {
@@ -590,7 +232,7 @@
             "line": 3,
             "column": 9
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
         }
       },
       "_meta": {
@@ -603,44 +245,7 @@
             "line": 3,
             "column": 9
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
-        },
-        "origin": {
-          "kind": "echo",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 24
-            },
-            "end": {
-              "line": 3,
-              "column": 8,
-              "offset": 32
-            }
-          },
-          "shortForm": false,
-          "expressions": [
-            {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 5,
-                  "offset": 29
-                },
-                "end": {
-                  "line": 3,
-                  "column": 7,
-                  "offset": 31
-                }
-              },
-              "name": "a",
-              "curly": false
-            }
-          ]
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
         }
       },
       "loc": {
@@ -652,13 +257,13 @@
           "line": 3,
           "column": 9
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -670,169 +275,7 @@
         "line": 4,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
-    },
-    "origin": {
-      "kind": "program",
-      "loc": {
-        "source": null,
-        "start": {
-          "line": 1,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "line": 4,
-          "column": 0,
-          "offset": 33
-        }
-      },
-      "children": [
-        {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 2,
-              "column": 0,
-              "offset": 6
-            },
-            "end": {
-              "line": 2,
-              "column": 17,
-              "offset": 23
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 2,
-                "column": 0,
-                "offset": 6
-              },
-              "end": {
-                "line": 2,
-                "column": 17,
-                "offset": 23
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 0,
-                  "offset": 6
-                },
-                "end": {
-                  "line": 2,
-                  "column": 2,
-                  "offset": 8
-                }
-              },
-              "name": "a",
-              "curly": false
-            },
-            "right": {
-              "kind": "offsetlookup",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 5,
-                  "offset": 11
-                },
-                "end": {
-                  "line": 2,
-                  "column": 16,
-                  "offset": 22
-                }
-              },
-              "what": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 5,
-                    "offset": 11
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 10,
-                    "offset": 16
-                  }
-                },
-                "name": "_GET",
-                "curly": false
-              },
-              "offset": {
-                "kind": "string",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 11,
-                    "offset": 17
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 15,
-                    "offset": 21
-                  }
-                },
-                "value": "id",
-                "raw": "\"id\"",
-                "unicode": false,
-                "isDoubleQuote": true
-              }
-            },
-            "operator": "="
-          }
-        },
-        {
-          "kind": "echo",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 24
-            },
-            "end": {
-              "line": 3,
-              "column": 8,
-              "offset": 32
-            }
-          },
-          "shortForm": false,
-          "expressions": [
-            {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 5,
-                  "offset": 29
-                },
-                "end": {
-                  "line": 3,
-                  "column": 7,
-                  "offset": 31
-                }
-              },
-              "name": "a",
-              "curly": false
-            }
-          ]
-        }
-      ],
-      "errors": [],
-      "comments": []
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
     }
   },
   "loc": {
@@ -844,6 +287,6 @@
       "line": 4,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/basic.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/basic.php.json
+++ b/parser-PHP/tests/benchmark/base/basic.php.json
@@ -18,7 +18,7 @@
                 "line": 2,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+              "sourcefile": "basic.php"
             }
           },
           "loc": {
@@ -30,7 +30,7 @@
               "line": 2,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+            "sourcefile": "basic.php"
           }
         },
         "right": {
@@ -48,7 +48,7 @@
                   "line": 2,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+                "sourcefile": "basic.php"
               }
             },
             "loc": {
@@ -60,7 +60,7 @@
                 "line": 2,
                 "column": 11
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+              "sourcefile": "basic.php"
             }
           },
           "property": {
@@ -77,7 +77,7 @@
                   "line": 2,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+                "sourcefile": "basic.php"
               },
               "encapsed": true
             },
@@ -90,7 +90,7 @@
                 "line": 2,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+              "sourcefile": "basic.php"
             }
           },
           "computed": true,
@@ -104,7 +104,7 @@
                 "line": 2,
                 "column": 17
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+              "sourcefile": "basic.php"
             }
           },
           "loc": {
@@ -116,7 +116,7 @@
               "line": 2,
               "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+            "sourcefile": "basic.php"
           }
         },
         "operator": "=",
@@ -131,7 +131,7 @@
               "line": 2,
               "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+            "sourcefile": "basic.php"
           }
         },
         "loc": {
@@ -143,7 +143,7 @@
             "line": 2,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+          "sourcefile": "basic.php"
         }
       },
       "_meta": {
@@ -156,7 +156,7 @@
             "line": 2,
             "column": 18
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+          "sourcefile": "basic.php"
         }
       },
       "loc": {
@@ -168,7 +168,7 @@
           "line": 2,
           "column": 18
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+        "sourcefile": "basic.php"
       }
     },
     {
@@ -194,7 +194,7 @@
                   "line": 3,
                   "column": 8
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+                "sourcefile": "basic.php"
               }
             },
             "loc": {
@@ -206,7 +206,7 @@
                 "line": 3,
                 "column": 8
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+              "sourcefile": "basic.php"
             }
           }
         ],
@@ -220,7 +220,7 @@
               "line": 3,
               "column": 9
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+            "sourcefile": "basic.php"
           }
         },
         "loc": {
@@ -232,7 +232,7 @@
             "line": 3,
             "column": 9
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+          "sourcefile": "basic.php"
         }
       },
       "_meta": {
@@ -245,7 +245,7 @@
             "line": 3,
             "column": 9
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+          "sourcefile": "basic.php"
         }
       },
       "loc": {
@@ -257,13 +257,13 @@
           "line": 3,
           "column": 9
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+        "sourcefile": "basic.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php",
+  "uri": "basic.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -275,7 +275,7 @@
         "line": 4,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+      "sourcefile": "basic.php"
     }
   },
   "loc": {
@@ -287,6 +287,6 @@
       "line": 4,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/basic.php"
+    "sourcefile": "basic.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/closure-class.php.json
+++ b/parser-PHP/tests/benchmark/base/closure-class.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 11
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
           }
         },
         "loc": {
@@ -28,7 +28,7 @@
             "line": 3,
             "column": 11
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
         }
       },
       "body": [
@@ -47,7 +47,7 @@
                   "line": 5,
                   "column": 17
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
               }
             },
             "loc": {
@@ -59,7 +59,7 @@
                 "line": 5,
                 "column": 17
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "init": {
@@ -76,7 +76,7 @@
                   "line": 5,
                   "column": 23
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
               }
             },
             "loc": {
@@ -88,7 +88,7 @@
                 "line": 5,
                 "column": 23
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "cloned": false,
@@ -110,7 +110,7 @@
                 "line": 5,
                 "column": 23
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "loc": {
@@ -122,7 +122,7 @@
               "line": 5,
               "column": 23
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
           }
         },
         {
@@ -140,7 +140,7 @@
                   "line": 6,
                   "column": 26
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
               }
             },
             "loc": {
@@ -152,7 +152,7 @@
                 "line": 6,
                 "column": 26
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "init": {
@@ -169,7 +169,7 @@
                   "line": 6,
                   "column": 30
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
               }
             },
             "loc": {
@@ -181,7 +181,7 @@
                 "line": 6,
                 "column": 30
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "cloned": false,
@@ -203,7 +203,7 @@
                 "line": 6,
                 "column": 30
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "loc": {
@@ -215,7 +215,7 @@
               "line": 6,
               "column": 30
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
           }
         },
         {
@@ -233,7 +233,7 @@
                   "line": 7,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
               }
             },
             "loc": {
@@ -245,7 +245,7 @@
                 "line": 7,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "init": {
@@ -262,7 +262,7 @@
                   "line": 7,
                   "column": 28
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
               }
             },
             "loc": {
@@ -274,7 +274,7 @@
                 "line": 7,
                 "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "cloned": false,
@@ -294,7 +294,7 @@
                 "line": 7,
                 "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "loc": {
@@ -306,7 +306,7 @@
               "line": 7,
               "column": 28
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
           }
         },
         {
@@ -324,7 +324,7 @@
                   "line": 9,
                   "column": 26
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
               }
             },
             "loc": {
@@ -336,7 +336,7 @@
                 "line": 9,
                 "column": 26
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "parameters": [
@@ -355,7 +355,7 @@
                       "line": 9,
                       "column": 33
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "loc": {
@@ -367,7 +367,7 @@
                     "line": 9,
                     "column": 33
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                 }
               },
               "init": null,
@@ -388,7 +388,7 @@
                     "line": 9,
                     "column": 33
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                 }
               },
               "loc": {
@@ -400,7 +400,7 @@
                   "line": 9,
                   "column": 33
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
               }
             }
           ],
@@ -429,7 +429,7 @@
                           "line": 11,
                           "column": 17
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "loc": {
@@ -441,7 +441,7 @@
                         "line": 11,
                         "column": 17
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "right": {
@@ -463,7 +463,7 @@
                                 "line": 11,
                                 "column": 32
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                             }
                           },
                           "loc": {
@@ -475,7 +475,7 @@
                               "line": 11,
                               "column": 32
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         },
                         "init": null,
@@ -496,7 +496,7 @@
                               "line": 11,
                               "column": 32
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         },
                         "loc": {
@@ -508,7 +508,7 @@
                             "line": 11,
                             "column": 32
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       }
                     ],
@@ -538,7 +538,7 @@
                                     "line": 12,
                                     "column": 22
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                                 }
                               },
                               "loc": {
@@ -550,7 +550,7 @@
                                   "line": 12,
                                   "column": 22
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                               }
                             },
                             "right": {
@@ -566,7 +566,7 @@
                                     "line": 12,
                                     "column": 31
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                                 }
                               },
                               "loc": {
@@ -578,7 +578,7 @@
                                   "line": 12,
                                   "column": 31
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                               }
                             },
                             "_meta": {
@@ -591,7 +591,7 @@
                                   "line": 12,
                                   "column": 31
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                               }
                             },
                             "loc": {
@@ -603,7 +603,7 @@
                                 "line": 12,
                                 "column": 31
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                             }
                           },
                           "isYield": false,
@@ -617,7 +617,7 @@
                                 "line": 12,
                                 "column": 32
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                             }
                           },
                           "loc": {
@@ -629,7 +629,7 @@
                               "line": 12,
                               "column": 32
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         }
                       ],
@@ -644,7 +644,7 @@
                             "line": 13,
                             "column": 10
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       },
                       "loc": {
@@ -656,7 +656,7 @@
                           "line": 13,
                           "column": 10
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "modifiers": [],
@@ -670,7 +670,7 @@
                           "line": 13,
                           "column": 10
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       },
                       "uses": [
                         {
@@ -686,7 +686,7 @@
                                 "line": 11,
                                 "column": 45
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                             }
                           },
                           "loc": {
@@ -698,7 +698,7 @@
                               "line": 11,
                               "column": 45
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         }
                       ]
@@ -712,7 +712,7 @@
                         "line": 13,
                         "column": 10
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "operator": "=",
@@ -727,7 +727,7 @@
                         "line": 13,
                         "column": 10
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "loc": {
@@ -739,7 +739,7 @@
                       "line": 13,
                       "column": 10
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "_meta": {
@@ -752,7 +752,7 @@
                       "line": 13,
                       "column": 11
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "loc": {
@@ -764,7 +764,7 @@
                     "line": 13,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                 }
               },
               {
@@ -784,7 +784,7 @@
                           "line": 15,
                           "column": 15
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "loc": {
@@ -796,7 +796,7 @@
                         "line": 15,
                         "column": 15
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "right": {
@@ -812,7 +812,7 @@
                           "line": 15,
                           "column": 25
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "loc": {
@@ -824,7 +824,7 @@
                         "line": 15,
                         "column": 25
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "operator": "=",
@@ -840,7 +840,7 @@
                         "line": 15,
                         "column": 25
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "loc": {
@@ -852,7 +852,7 @@
                       "line": 15,
                       "column": 25
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "_meta": {
@@ -865,7 +865,7 @@
                       "line": 15,
                       "column": 26
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "loc": {
@@ -877,7 +877,7 @@
                     "line": 15,
                     "column": 26
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                 }
               },
               {
@@ -897,7 +897,7 @@
                           "line": 16,
                           "column": 14
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "loc": {
@@ -909,7 +909,7 @@
                         "line": 16,
                         "column": 14
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "right": {
@@ -933,7 +933,7 @@
                               "line": 16,
                               "column": 28
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         },
                         "loc": {
@@ -945,7 +945,7 @@
                             "line": 16,
                             "column": 28
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       }
                     ],
@@ -959,7 +959,7 @@
                           "line": 16,
                           "column": 28
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "loc": {
@@ -971,7 +971,7 @@
                         "line": 16,
                         "column": 28
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "operator": "=",
@@ -986,7 +986,7 @@
                         "line": 16,
                         "column": 28
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "loc": {
@@ -998,7 +998,7 @@
                       "line": 16,
                       "column": 28
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "_meta": {
@@ -1011,7 +1011,7 @@
                       "line": 16,
                       "column": 29
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "loc": {
@@ -1023,7 +1023,7 @@
                     "line": 16,
                     "column": 29
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                 }
               },
               {
@@ -1046,7 +1046,7 @@
                             "line": 18,
                             "column": 18
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       },
                       "loc": {
@@ -1058,7 +1058,7 @@
                           "line": 18,
                           "column": 18
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "arguments": [
@@ -1075,7 +1075,7 @@
                               "line": 18,
                               "column": 25
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         },
                         "loc": {
@@ -1087,7 +1087,7 @@
                             "line": 18,
                             "column": 25
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       },
                       {
@@ -1103,7 +1103,7 @@
                               "line": 18,
                               "column": 32
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         },
                         "loc": {
@@ -1115,7 +1115,7 @@
                             "line": 18,
                             "column": 32
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       }
                     ],
@@ -1129,7 +1129,7 @@
                           "line": 18,
                           "column": 33
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "loc": {
@@ -1141,7 +1141,7 @@
                         "line": 18,
                         "column": 33
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "right": {
@@ -1162,7 +1162,7 @@
                               "line": 18,
                               "column": 43
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         },
                         "loc": {
@@ -1174,7 +1174,7 @@
                             "line": 18,
                             "column": 43
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       },
                       "arguments": [
@@ -1191,7 +1191,7 @@
                                 "line": 18,
                                 "column": 50
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                             }
                           },
                           "loc": {
@@ -1203,7 +1203,7 @@
                               "line": 18,
                               "column": 50
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         }
                       ],
@@ -1217,7 +1217,7 @@
                             "line": 18,
                             "column": 51
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       },
                       "loc": {
@@ -1229,7 +1229,7 @@
                           "line": 18,
                           "column": 51
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "isSuffix": false,
@@ -1243,7 +1243,7 @@
                           "line": 18,
                           "column": 51
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "loc": {
@@ -1255,7 +1255,7 @@
                         "line": 18,
                         "column": 51
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "_meta": {
@@ -1268,7 +1268,7 @@
                         "line": 18,
                         "column": 51
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "loc": {
@@ -1280,7 +1280,7 @@
                       "line": 18,
                       "column": 51
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "consequent": {
@@ -1303,7 +1303,7 @@
                                 "line": 19,
                                 "column": 28
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                             }
                           },
                           "loc": {
@@ -1315,7 +1315,7 @@
                               "line": 19,
                               "column": 28
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         },
                         "arguments": [
@@ -1332,7 +1332,7 @@
                                   "line": 19,
                                   "column": 35
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                               }
                             },
                             "loc": {
@@ -1344,7 +1344,7 @@
                                 "line": 19,
                                 "column": 35
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                             }
                           }
                         ],
@@ -1358,7 +1358,7 @@
                               "line": 19,
                               "column": 36
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         },
                         "loc": {
@@ -1370,7 +1370,7 @@
                             "line": 19,
                             "column": 36
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       },
                       "isYield": false,
@@ -1384,7 +1384,7 @@
                             "line": 19,
                             "column": 37
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       },
                       "loc": {
@@ -1396,7 +1396,7 @@
                           "line": 19,
                           "column": 37
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     }
                   ],
@@ -1411,7 +1411,7 @@
                         "line": 20,
                         "column": 10
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "loc": {
@@ -1423,7 +1423,7 @@
                       "line": 20,
                       "column": 10
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "alternative": null,
@@ -1437,7 +1437,7 @@
                       "line": 20,
                       "column": 10
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "loc": {
@@ -1449,7 +1449,7 @@
                     "line": 20,
                     "column": 10
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                 }
               },
               {
@@ -1468,7 +1468,7 @@
                         "line": 22,
                         "column": 20
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "loc": {
@@ -1480,7 +1480,7 @@
                       "line": 22,
                       "column": 20
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "isYield": false,
@@ -1494,7 +1494,7 @@
                       "line": 22,
                       "column": 21
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "loc": {
@@ -1506,7 +1506,7 @@
                     "line": 22,
                     "column": 21
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                 }
               }
             ],
@@ -1521,7 +1521,7 @@
                   "line": 23,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
               }
             },
             "loc": {
@@ -1533,7 +1533,7 @@
                 "line": 23,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "modifiers": [
@@ -1549,7 +1549,7 @@
                 "line": 23,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "loc": {
@@ -1561,7 +1561,7 @@
               "line": 23,
               "column": 6
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
           }
         }
       ],
@@ -1576,7 +1576,7 @@
             "line": 24,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
         }
       },
       "loc": {
@@ -1588,13 +1588,13 @@
           "line": 24,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -1606,7 +1606,7 @@
         "line": 25,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
     }
   },
   "loc": {
@@ -1618,6 +1618,6 @@
       "line": 25,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/closure-class.php.json
+++ b/parser-PHP/tests/benchmark/base/closure-class.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 11
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
           },
           "origin": {
             "kind": "identifier",
@@ -45,7 +45,7 @@
             "line": 3,
             "column": 11
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
         }
       },
       "body": [
@@ -64,7 +64,7 @@
                   "line": 5,
                   "column": 17
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -93,7 +93,7 @@
                 "line": 5,
                 "column": 17
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "init": {
@@ -110,7 +110,7 @@
                   "line": 5,
                   "column": 23
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
               },
               "origin": {
                 "kind": "string",
@@ -142,7 +142,7 @@
                 "line": 5,
                 "column": 23
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "cloned": false,
@@ -161,7 +161,7 @@
                 "line": 5,
                 "column": 23
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             },
             "origin": {
               "kind": "property",
@@ -234,7 +234,7 @@
               "line": 5,
               "column": 23
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
           }
         },
         {
@@ -252,7 +252,7 @@
                   "line": 6,
                   "column": 26
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -281,7 +281,7 @@
                 "line": 6,
                 "column": 26
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "init": {
@@ -298,7 +298,7 @@
                   "line": 6,
                   "column": 30
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
               },
               "origin": {
                 "kind": "number",
@@ -327,7 +327,7 @@
                 "line": 6,
                 "column": 30
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "cloned": false,
@@ -346,7 +346,7 @@
                 "line": 6,
                 "column": 30
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             },
             "origin": {
               "kind": "property",
@@ -416,7 +416,7 @@
               "line": 6,
               "column": 30
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
           }
         },
         {
@@ -434,7 +434,7 @@
                   "line": 7,
                   "column": 24
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -463,7 +463,7 @@
                 "line": 7,
                 "column": 24
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "init": {
@@ -480,7 +480,7 @@
                   "line": 7,
                   "column": 28
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
               },
               "origin": {
                 "kind": "number",
@@ -509,7 +509,7 @@
                 "line": 7,
                 "column": 28
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "cloned": false,
@@ -528,7 +528,7 @@
                 "line": 7,
                 "column": 28
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             },
             "origin": {
               "kind": "constant",
@@ -594,7 +594,7 @@
               "line": 7,
               "column": 28
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
           }
         },
         {
@@ -612,7 +612,7 @@
                   "line": 9,
                   "column": 26
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -641,7 +641,7 @@
                 "line": 9,
                 "column": 26
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "parameters": [
@@ -660,7 +660,7 @@
                       "line": 9,
                       "column": 33
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   },
                   "origin": {
                     "kind": "identifier",
@@ -689,7 +689,7 @@
                     "line": 9,
                     "column": 33
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                 }
               },
               "init": null,
@@ -712,7 +712,7 @@
                     "line": 9,
                     "column": 33
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                 },
                 "origin": {
                   "kind": "parameter",
@@ -765,7 +765,7 @@
                   "line": 9,
                   "column": 33
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
               }
             }
           ],
@@ -794,7 +794,7 @@
                           "line": 11,
                           "column": 17
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       },
                       "origin": {
                         "kind": "variable",
@@ -824,7 +824,7 @@
                         "line": 11,
                         "column": 17
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "right": {
@@ -846,7 +846,7 @@
                                 "line": 11,
                                 "column": 32
                               },
-                              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                             },
                             "origin": {
                               "kind": "identifier",
@@ -875,7 +875,7 @@
                               "line": 11,
                               "column": 32
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         },
                         "init": null,
@@ -898,7 +898,7 @@
                               "line": 11,
                               "column": 32
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           },
                           "origin": {
                             "kind": "parameter",
@@ -951,7 +951,7 @@
                             "line": 11,
                             "column": 32
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       }
                     ],
@@ -981,7 +981,7 @@
                                     "line": 12,
                                     "column": 22
                                   },
-                                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                                 },
                                 "origin": {
                                   "kind": "variable",
@@ -1011,7 +1011,7 @@
                                   "line": 12,
                                   "column": 22
                                 },
-                                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                               }
                             },
                             "right": {
@@ -1027,7 +1027,7 @@
                                     "line": 12,
                                     "column": 31
                                   },
-                                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                                 },
                                 "origin": {
                                   "kind": "variable",
@@ -1057,7 +1057,7 @@
                                   "line": 12,
                                   "column": 31
                                 },
-                                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                               }
                             },
                             "_meta": {
@@ -1070,7 +1070,7 @@
                                   "line": 12,
                                   "column": 31
                                 },
-                                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                               },
                               "origin": {
                                 "kind": "bin",
@@ -1135,7 +1135,7 @@
                                 "line": 12,
                                 "column": 31
                               },
-                              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                             }
                           },
                           "isYield": false,
@@ -1149,7 +1149,7 @@
                                 "line": 12,
                                 "column": 32
                               },
-                              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                             },
                             "origin": {
                               "kind": "return",
@@ -1230,7 +1230,7 @@
                               "line": 12,
                               "column": 32
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         }
                       ],
@@ -1245,7 +1245,7 @@
                             "line": 13,
                             "column": 10
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                         },
                         "origin": {
                           "kind": "block",
@@ -1344,7 +1344,7 @@
                           "line": 13,
                           "column": 10
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "modifiers": [],
@@ -1359,7 +1359,7 @@
                           "line": 13,
                           "column": 10
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       },
                       "origin": {
                         "kind": "closure",
@@ -1546,7 +1546,7 @@
                                 "line": 11,
                                 "column": 45
                               },
-                              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                             },
                             "origin": {
                               "kind": "variable",
@@ -1577,7 +1577,7 @@
                               "line": 11,
                               "column": 45
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         }
                       ],
@@ -1592,7 +1592,7 @@
                         "line": 13,
                         "column": 10
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "operator": "=",
@@ -1607,7 +1607,7 @@
                         "line": 13,
                         "column": 11
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     },
                     "origin": {
                       "kind": "assign",
@@ -1825,7 +1825,7 @@
                       "line": 13,
                       "column": 11
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "_meta": {
@@ -1838,7 +1838,7 @@
                       "line": 13,
                       "column": 11
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   },
                   "origin": {
                     "kind": "expressionstatement",
@@ -2072,7 +2072,7 @@
                     "line": 13,
                     "column": 11
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                 }
               },
               {
@@ -2092,7 +2092,7 @@
                           "line": 15,
                           "column": 15
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       },
                       "origin": {
                         "kind": "variable",
@@ -2122,7 +2122,7 @@
                         "line": 15,
                         "column": 15
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "right": {
@@ -2138,7 +2138,7 @@
                           "line": 15,
                           "column": 25
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       },
                       "origin": {
                         "kind": "variable",
@@ -2168,7 +2168,7 @@
                         "line": 15,
                         "column": 25
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "operator": "=",
@@ -2184,7 +2184,7 @@
                         "line": 15,
                         "column": 26
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     },
                     "origin": {
                       "kind": "assignref",
@@ -2248,7 +2248,7 @@
                       "line": 15,
                       "column": 26
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "_meta": {
@@ -2261,7 +2261,7 @@
                       "line": 15,
                       "column": 26
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   },
                   "origin": {
                     "kind": "expressionstatement",
@@ -2341,7 +2341,7 @@
                     "line": 15,
                     "column": 26
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                 }
               },
               {
@@ -2361,7 +2361,7 @@
                           "line": 16,
                           "column": 14
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       },
                       "origin": {
                         "kind": "variable",
@@ -2391,7 +2391,7 @@
                         "line": 16,
                         "column": 14
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "right": {
@@ -2415,7 +2415,7 @@
                               "line": 16,
                               "column": 28
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           },
                           "origin": {
                             "kind": "variable",
@@ -2445,7 +2445,7 @@
                             "line": 16,
                             "column": 28
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       }
                     ],
@@ -2460,7 +2460,7 @@
                           "line": 16,
                           "column": 28
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       },
                       "origin": {
                         "kind": "clone",
@@ -2506,7 +2506,7 @@
                         "line": 16,
                         "column": 28
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "operator": "=",
@@ -2521,7 +2521,7 @@
                         "line": 16,
                         "column": 29
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     },
                     "origin": {
                       "kind": "assign",
@@ -2602,7 +2602,7 @@
                       "line": 16,
                       "column": 29
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "_meta": {
@@ -2615,7 +2615,7 @@
                       "line": 16,
                       "column": 29
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   },
                   "origin": {
                     "kind": "expressionstatement",
@@ -2712,7 +2712,7 @@
                     "line": 16,
                     "column": 29
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                 }
               },
               {
@@ -2741,7 +2741,7 @@
                               "line": 18,
                               "column": 25
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           },
                           "origin": {
                             "kind": "variable",
@@ -2771,7 +2771,7 @@
                             "line": 18,
                             "column": 25
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       },
                       {
@@ -2787,7 +2787,7 @@
                               "line": 18,
                               "column": 32
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           },
                           "origin": {
                             "kind": "variable",
@@ -2817,7 +2817,7 @@
                             "line": 18,
                             "column": 32
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       }
                     ],
@@ -2832,7 +2832,7 @@
                           "line": 18,
                           "column": 33
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       },
                       "origin": {
                         "kind": "isset",
@@ -2898,7 +2898,7 @@
                         "line": 18,
                         "column": 33
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "right": {
@@ -2925,7 +2925,7 @@
                                 "line": 18,
                                 "column": 50
                               },
-                              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                             },
                             "origin": {
                               "kind": "variable",
@@ -2955,7 +2955,7 @@
                               "line": 18,
                               "column": 50
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         }
                       ],
@@ -2970,7 +2970,7 @@
                             "line": 18,
                             "column": 51
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                         },
                         "origin": {
                           "kind": "empty",
@@ -3016,7 +3016,7 @@
                           "line": 18,
                           "column": 51
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "isSuffix": false,
@@ -3030,7 +3030,7 @@
                           "line": 18,
                           "column": 51
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       },
                       "origin": {
                         "kind": "unary",
@@ -3093,7 +3093,7 @@
                         "line": 18,
                         "column": 51
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "_meta": {
@@ -3106,7 +3106,7 @@
                         "line": 18,
                         "column": 51
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     },
                     "origin": {
                       "kind": "bin",
@@ -3240,7 +3240,7 @@
                       "line": 18,
                       "column": 51
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "consequent": {
@@ -3263,7 +3263,7 @@
                                 "line": 19,
                                 "column": 28
                               },
-                              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                             },
                             "origin": {
                               "kind": "variable",
@@ -3293,7 +3293,7 @@
                               "line": 19,
                               "column": 28
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         },
                         "arguments": [
@@ -3310,7 +3310,7 @@
                                   "line": 19,
                                   "column": 35
                                 },
-                                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                               },
                               "origin": {
                                 "kind": "variable",
@@ -3340,7 +3340,7 @@
                                 "line": 19,
                                 "column": 35
                               },
-                              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                             }
                           }
                         ],
@@ -3354,7 +3354,7 @@
                               "line": 19,
                               "column": 36
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                           },
                           "origin": {
                             "kind": "call",
@@ -3420,7 +3420,7 @@
                             "line": 19,
                             "column": 36
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       },
                       "isYield": false,
@@ -3434,7 +3434,7 @@
                             "line": 19,
                             "column": 37
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                         },
                         "origin": {
                           "kind": "return",
@@ -3516,7 +3516,7 @@
                           "line": 19,
                           "column": 37
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     }
                   ],
@@ -3531,7 +3531,7 @@
                         "line": 20,
                         "column": 10
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     },
                     "origin": {
                       "kind": "block",
@@ -3631,7 +3631,7 @@
                       "line": 20,
                       "column": 10
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "alternative": null,
@@ -3645,7 +3645,7 @@
                       "line": 20,
                       "column": 10
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   },
                   "origin": {
                     "kind": "if",
@@ -3885,7 +3885,7 @@
                     "line": 20,
                     "column": 10
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                 }
               },
               {
@@ -3904,7 +3904,7 @@
                         "line": 22,
                         "column": 20
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                     },
                     "origin": {
                       "kind": "nullkeyword",
@@ -3933,7 +3933,7 @@
                       "line": 22,
                       "column": 20
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "isYield": false,
@@ -3947,7 +3947,7 @@
                       "line": 22,
                       "column": 21
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                   },
                   "origin": {
                     "kind": "return",
@@ -3992,7 +3992,7 @@
                     "line": 22,
                     "column": 21
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
                 }
               }
             ],
@@ -4007,7 +4007,7 @@
                   "line": 23,
                   "column": 6
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
               },
               "origin": {
                 "kind": "block",
@@ -4673,7 +4673,7 @@
                 "line": 23,
                 "column": 6
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "modifiers": [
@@ -4690,7 +4690,7 @@
                 "line": 23,
                 "column": 6
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             },
             "origin": {
               "kind": "method",
@@ -5441,7 +5441,7 @@
               "line": 23,
               "column": 6
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
           }
         }
       ],
@@ -5459,7 +5459,7 @@
                 "line": 3,
                 "column": 29
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
             },
             "origin": {
               "kind": "name",
@@ -5489,7 +5489,7 @@
               "line": 3,
               "column": 29
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
           }
         }
       ],
@@ -5508,7 +5508,7 @@
             "line": 24,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
         },
         "origin": {
           "kind": "class",
@@ -6542,13 +6542,13 @@
           "line": 24,
           "column": 2
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -6560,7 +6560,7 @@
         "line": 25,
         "column": 1
       },
-      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
     },
     "origin": {
       "kind": "program",
@@ -7614,6 +7614,6 @@
       "line": 25,
       "column": 1
     },
-    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/closure-class.php.json
+++ b/parser-PHP/tests/benchmark/base/closure-class.php.json
@@ -16,24 +16,7 @@
               "line": 3,
               "column": 11
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-          },
-          "origin": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 6,
-                "offset": 13
-              },
-              "end": {
-                "line": 3,
-                "column": 10,
-                "offset": 17
-              }
-            },
-            "name": "Demo"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
           }
         },
         "loc": {
@@ -45,7 +28,7 @@
             "line": 3,
             "column": 11
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
         }
       },
       "body": [
@@ -64,24 +47,7 @@
                   "line": 5,
                   "column": 17
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 11,
-                    "offset": 49
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 16,
-                    "offset": 54
-                  }
-                },
-                "name": "name"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
               }
             },
             "loc": {
@@ -93,7 +59,7 @@
                 "line": 5,
                 "column": 17
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "init": {
@@ -110,27 +76,7 @@
                   "line": 5,
                   "column": 23
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-              },
-              "origin": {
-                "kind": "string",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 19,
-                    "offset": 57
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 22,
-                    "offset": 60
-                  }
-                },
-                "value": "x",
-                "raw": "'x'",
-                "unicode": false,
-                "isDoubleQuote": false
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
               }
             },
             "loc": {
@@ -142,7 +88,7 @@
                 "line": 5,
                 "column": 23
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "cloned": false,
@@ -152,6 +98,9 @@
             "_meta": {}
           },
           "_meta": {
+            "visibility": "public",
+            "isStatic": false,
+            "readonly": false,
             "loc": {
               "start": {
                 "line": 5,
@@ -161,69 +110,8 @@
                 "line": 5,
                 "column": 23
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-            },
-            "origin": {
-              "kind": "property",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 5,
-                  "column": 11,
-                  "offset": 49
-                },
-                "end": {
-                  "line": 5,
-                  "column": 22,
-                  "offset": 60
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 11,
-                    "offset": 49
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 16,
-                    "offset": 54
-                  }
-                },
-                "name": "name"
-              },
-              "value": {
-                "kind": "string",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 19,
-                    "offset": 57
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 22,
-                    "offset": 60
-                  }
-                },
-                "value": "x",
-                "raw": "'x'",
-                "unicode": false,
-                "isDoubleQuote": false
-              },
-              "readonly": false,
-              "nullable": false,
-              "type": null,
-              "attrGroups": []
-            },
-            "visibility": "public",
-            "isStatic": false,
-            "readonly": false,
-            "attributes": []
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+            }
           },
           "loc": {
             "start": {
@@ -234,7 +122,7 @@
               "line": 5,
               "column": 23
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
           }
         },
         {
@@ -252,24 +140,7 @@
                   "line": 6,
                   "column": 26
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 19,
-                    "offset": 81
-                  },
-                  "end": {
-                    "line": 6,
-                    "column": 25,
-                    "offset": 87
-                  }
-                },
-                "name": "count"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
               }
             },
             "loc": {
@@ -281,7 +152,7 @@
                 "line": 6,
                 "column": 26
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "init": {
@@ -298,24 +169,7 @@
                   "line": 6,
                   "column": 30
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-              },
-              "origin": {
-                "kind": "number",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 28,
-                    "offset": 90
-                  },
-                  "end": {
-                    "line": 6,
-                    "column": 29,
-                    "offset": 91
-                  }
-                },
-                "value": "1"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
               }
             },
             "loc": {
@@ -327,7 +181,7 @@
                 "line": 6,
                 "column": 30
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "cloned": false,
@@ -337,6 +191,9 @@
             "_meta": {}
           },
           "_meta": {
+            "visibility": "private",
+            "isStatic": true,
+            "readonly": false,
             "loc": {
               "start": {
                 "line": 6,
@@ -346,66 +203,8 @@
                 "line": 6,
                 "column": 30
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-            },
-            "origin": {
-              "kind": "property",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 6,
-                  "column": 19,
-                  "offset": 81
-                },
-                "end": {
-                  "line": 6,
-                  "column": 29,
-                  "offset": 91
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 19,
-                    "offset": 81
-                  },
-                  "end": {
-                    "line": 6,
-                    "column": 25,
-                    "offset": 87
-                  }
-                },
-                "name": "count"
-              },
-              "value": {
-                "kind": "number",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 28,
-                    "offset": 90
-                  },
-                  "end": {
-                    "line": 6,
-                    "column": 29,
-                    "offset": 91
-                  }
-                },
-                "value": "1"
-              },
-              "readonly": false,
-              "nullable": false,
-              "type": null,
-              "attrGroups": []
-            },
-            "visibility": "private",
-            "isStatic": true,
-            "readonly": false,
-            "attributes": []
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+            }
           },
           "loc": {
             "start": {
@@ -416,7 +215,7 @@
               "line": 6,
               "column": 30
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
           }
         },
         {
@@ -434,24 +233,7 @@
                   "line": 7,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 7,
-                    "column": 10,
-                    "offset": 103
-                  },
-                  "end": {
-                    "line": 7,
-                    "column": 23,
-                    "offset": 116
-                  }
-                },
-                "name": "DEFAULT_COUNT"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
               }
             },
             "loc": {
@@ -463,7 +245,7 @@
                 "line": 7,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "init": {
@@ -480,24 +262,7 @@
                   "line": 7,
                   "column": 28
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-              },
-              "origin": {
-                "kind": "number",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 7,
-                    "column": 26,
-                    "offset": 119
-                  },
-                  "end": {
-                    "line": 7,
-                    "column": 27,
-                    "offset": 120
-                  }
-                },
-                "value": "2"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
               }
             },
             "loc": {
@@ -509,7 +274,7 @@
                 "line": 7,
                 "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "cloned": false,
@@ -519,6 +284,7 @@
             "_meta": {}
           },
           "_meta": {
+            "constant": true,
             "loc": {
               "start": {
                 "line": 7,
@@ -528,62 +294,8 @@
                 "line": 7,
                 "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-            },
-            "origin": {
-              "kind": "constant",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 7,
-                  "column": 10,
-                  "offset": 103
-                },
-                "end": {
-                  "line": 7,
-                  "column": 27,
-                  "offset": 120
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 7,
-                    "column": 10,
-                    "offset": 103
-                  },
-                  "end": {
-                    "line": 7,
-                    "column": 23,
-                    "offset": 116
-                  }
-                },
-                "name": "DEFAULT_COUNT"
-              },
-              "value": {
-                "kind": "number",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 7,
-                    "column": 26,
-                    "offset": 119
-                  },
-                  "end": {
-                    "line": 7,
-                    "column": 27,
-                    "offset": 120
-                  }
-                },
-                "value": "2"
-              }
-            },
-            "constant": true,
-            "visibility": null,
-            "final": false,
-            "attributes": []
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+            }
           },
           "loc": {
             "start": {
@@ -594,7 +306,7 @@
               "line": 7,
               "column": 28
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
           }
         },
         {
@@ -612,24 +324,7 @@
                   "line": 9,
                   "column": 26
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 9,
-                    "column": 20,
-                    "offset": 143
-                  },
-                  "end": {
-                    "line": 9,
-                    "column": 25,
-                    "offset": 148
-                  }
-                },
-                "name": "build"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
               }
             },
             "loc": {
@@ -641,7 +336,7 @@
                 "line": 9,
                 "column": 26
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "parameters": [
@@ -660,24 +355,7 @@
                       "line": 9,
                       "column": 33
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                  },
-                  "origin": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 26,
-                        "offset": 149
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 32,
-                        "offset": 155
-                      }
-                    },
-                    "name": "input"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "loc": {
@@ -689,7 +367,7 @@
                     "line": 9,
                     "column": 33
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                 }
               },
               "init": null,
@@ -700,9 +378,7 @@
                 "_meta": {}
               },
               "_meta": {
-                "byref": false,
                 "variadic": false,
-                "attributes": [],
                 "loc": {
                   "start": {
                     "line": 9,
@@ -712,48 +388,7 @@
                     "line": 9,
                     "column": 33
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                },
-                "origin": {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 9,
-                      "column": 26,
-                      "offset": 149
-                    },
-                    "end": {
-                      "line": 9,
-                      "column": 32,
-                      "offset": 155
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 26,
-                        "offset": 149
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 32,
-                        "offset": 155
-                      }
-                    },
-                    "name": "input"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": []
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                 }
               },
               "loc": {
@@ -765,7 +400,7 @@
                   "line": 9,
                   "column": 33
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
               }
             }
           ],
@@ -794,25 +429,7 @@
                           "line": 11,
                           "column": 17
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                      },
-                      "origin": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 8,
-                            "offset": 171
-                          },
-                          "end": {
-                            "line": 11,
-                            "column": 16,
-                            "offset": 179
-                          }
-                        },
-                        "name": "handler",
-                        "curly": false
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "loc": {
@@ -824,7 +441,7 @@
                         "line": 11,
                         "column": 17
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "right": {
@@ -846,24 +463,7 @@
                                 "line": 11,
                                 "column": 32
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                            },
-                            "origin": {
-                              "kind": "identifier",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 11,
-                                  "column": 29,
-                                  "offset": 192
-                                },
-                                "end": {
-                                  "line": 11,
-                                  "column": 31,
-                                  "offset": 194
-                                }
-                              },
-                              "name": "x"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                             }
                           },
                           "loc": {
@@ -875,7 +475,7 @@
                               "line": 11,
                               "column": 32
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         },
                         "init": null,
@@ -886,9 +486,7 @@
                           "_meta": {}
                         },
                         "_meta": {
-                          "byref": false,
                           "variadic": false,
-                          "attributes": [],
                           "loc": {
                             "start": {
                               "line": 11,
@@ -898,48 +496,7 @@
                               "line": 11,
                               "column": 32
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                          },
-                          "origin": {
-                            "kind": "parameter",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 29,
-                                "offset": 192
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 31,
-                                "offset": 194
-                              }
-                            },
-                            "name": {
-                              "kind": "identifier",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 11,
-                                  "column": 29,
-                                  "offset": 192
-                                },
-                                "end": {
-                                  "line": 11,
-                                  "column": 31,
-                                  "offset": 194
-                                }
-                              },
-                              "name": "x"
-                            },
-                            "value": null,
-                            "type": null,
-                            "byref": false,
-                            "variadic": false,
-                            "readonly": false,
-                            "nullable": false,
-                            "flags": 0,
-                            "attrGroups": []
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         },
                         "loc": {
@@ -951,7 +508,7 @@
                             "line": 11,
                             "column": 32
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       }
                     ],
@@ -981,25 +538,7 @@
                                     "line": 12,
                                     "column": 22
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                                },
-                                "origin": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 19,
-                                      "offset": 230
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 21,
-                                      "offset": 232
-                                    }
-                                  },
-                                  "name": "x",
-                                  "curly": false
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                                 }
                               },
                               "loc": {
@@ -1011,7 +550,7 @@
                                   "line": 12,
                                   "column": 22
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                               }
                             },
                             "right": {
@@ -1027,25 +566,7 @@
                                     "line": 12,
                                     "column": 31
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                                },
-                                "origin": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 24,
-                                      "offset": 235
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 30,
-                                      "offset": 241
-                                    }
-                                  },
-                                  "name": "input",
-                                  "curly": false
+                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                                 }
                               },
                               "loc": {
@@ -1057,7 +578,7 @@
                                   "line": 12,
                                   "column": 31
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                               }
                             },
                             "_meta": {
@@ -1070,60 +591,7 @@
                                   "line": 12,
                                   "column": 31
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                              },
-                              "origin": {
-                                "kind": "bin",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 12,
-                                    "column": 19,
-                                    "offset": 230
-                                  },
-                                  "end": {
-                                    "line": 12,
-                                    "column": 30,
-                                    "offset": 241
-                                  }
-                                },
-                                "type": "+",
-                                "left": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 19,
-                                      "offset": 230
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 21,
-                                      "offset": 232
-                                    }
-                                  },
-                                  "name": "x",
-                                  "curly": false
-                                },
-                                "right": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 24,
-                                      "offset": 235
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 30,
-                                      "offset": 241
-                                    }
-                                  },
-                                  "name": "input",
-                                  "curly": false
-                                }
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                               }
                             },
                             "loc": {
@@ -1135,7 +603,7 @@
                                 "line": 12,
                                 "column": 31
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                             }
                           },
                           "isYield": false,
@@ -1149,76 +617,7 @@
                                 "line": 12,
                                 "column": 32
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                            },
-                            "origin": {
-                              "kind": "return",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 12,
-                                  "column": 12,
-                                  "offset": 223
-                                },
-                                "end": {
-                                  "line": 12,
-                                  "column": 31,
-                                  "offset": 242
-                                }
-                              },
-                              "expr": {
-                                "kind": "bin",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 12,
-                                    "column": 19,
-                                    "offset": 230
-                                  },
-                                  "end": {
-                                    "line": 12,
-                                    "column": 30,
-                                    "offset": 241
-                                  }
-                                },
-                                "type": "+",
-                                "left": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 19,
-                                      "offset": 230
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 21,
-                                      "offset": 232
-                                    }
-                                  },
-                                  "name": "x",
-                                  "curly": false
-                                },
-                                "right": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 24,
-                                      "offset": 235
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 30,
-                                      "offset": 241
-                                    }
-                                  },
-                                  "name": "input",
-                                  "curly": false
-                                }
-                              }
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                             }
                           },
                           "loc": {
@@ -1230,7 +629,7 @@
                               "line": 12,
                               "column": 32
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         }
                       ],
@@ -1245,94 +644,7 @@
                             "line": 13,
                             "column": 10
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                        },
-                        "origin": {
-                          "kind": "block",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 46,
-                              "offset": 209
-                            },
-                            "end": {
-                              "line": 13,
-                              "column": 9,
-                              "offset": 252
-                            }
-                          },
-                          "children": [
-                            {
-                              "kind": "return",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 12,
-                                  "column": 12,
-                                  "offset": 223
-                                },
-                                "end": {
-                                  "line": 12,
-                                  "column": 31,
-                                  "offset": 242
-                                }
-                              },
-                              "expr": {
-                                "kind": "bin",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 12,
-                                    "column": 19,
-                                    "offset": 230
-                                  },
-                                  "end": {
-                                    "line": 12,
-                                    "column": 30,
-                                    "offset": 241
-                                  }
-                                },
-                                "type": "+",
-                                "left": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 19,
-                                      "offset": 230
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 21,
-                                      "offset": 232
-                                    }
-                                  },
-                                  "name": "x",
-                                  "curly": false
-                                },
-                                "right": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 24,
-                                      "offset": 235
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 30,
-                                      "offset": 241
-                                    }
-                                  },
-                                  "name": "input",
-                                  "curly": false
-                                }
-                              }
-                            }
-                          ]
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       },
                       "loc": {
@@ -1344,12 +656,11 @@
                           "line": 13,
                           "column": 10
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "modifiers": [],
                     "_meta": {
-                      "attributes": [],
                       "loc": {
                         "start": {
                           "line": 11,
@@ -1359,178 +670,7 @@
                           "line": 13,
                           "column": 10
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                      },
-                      "origin": {
-                        "kind": "closure",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 19,
-                            "offset": 182
-                          },
-                          "end": {
-                            "line": 13,
-                            "column": 9,
-                            "offset": 252
-                          }
-                        },
-                        "uses": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 38,
-                                "offset": 201
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 44,
-                                "offset": 207
-                              }
-                            },
-                            "name": "input",
-                            "curly": false
-                          }
-                        ],
-                        "arguments": [
-                          {
-                            "kind": "parameter",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 29,
-                                "offset": 192
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 31,
-                                "offset": 194
-                              }
-                            },
-                            "name": {
-                              "kind": "identifier",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 11,
-                                  "column": 29,
-                                  "offset": 192
-                                },
-                                "end": {
-                                  "line": 11,
-                                  "column": 31,
-                                  "offset": 194
-                                }
-                              },
-                              "name": "x"
-                            },
-                            "value": null,
-                            "type": null,
-                            "byref": false,
-                            "variadic": false,
-                            "readonly": false,
-                            "nullable": false,
-                            "flags": 0,
-                            "attrGroups": []
-                          }
-                        ],
-                        "byref": false,
-                        "type": null,
-                        "nullable": false,
-                        "isStatic": false,
-                        "body": {
-                          "kind": "block",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 46,
-                              "offset": 209
-                            },
-                            "end": {
-                              "line": 13,
-                              "column": 9,
-                              "offset": 252
-                            }
-                          },
-                          "children": [
-                            {
-                              "kind": "return",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 12,
-                                  "column": 12,
-                                  "offset": 223
-                                },
-                                "end": {
-                                  "line": 12,
-                                  "column": 31,
-                                  "offset": 242
-                                }
-                              },
-                              "expr": {
-                                "kind": "bin",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 12,
-                                    "column": 19,
-                                    "offset": 230
-                                  },
-                                  "end": {
-                                    "line": 12,
-                                    "column": 30,
-                                    "offset": 241
-                                  }
-                                },
-                                "type": "+",
-                                "left": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 19,
-                                      "offset": 230
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 21,
-                                      "offset": 232
-                                    }
-                                  },
-                                  "name": "x",
-                                  "curly": false
-                                },
-                                "right": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 24,
-                                      "offset": 235
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 30,
-                                      "offset": 241
-                                    }
-                                  },
-                                  "name": "input",
-                                  "curly": false
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        "attrGroups": []
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                       },
                       "uses": [
                         {
@@ -1546,27 +686,8 @@
                                 "line": 11,
                                 "column": 45
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                            },
-                            "origin": {
-                              "kind": "variable",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 11,
-                                  "column": 38,
-                                  "offset": 201
-                                },
-                                "end": {
-                                  "line": 11,
-                                  "column": 44,
-                                  "offset": 207
-                                }
-                              },
-                              "name": "input",
-                              "curly": false
-                            },
-                            "byref": false
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                            }
                           },
                           "loc": {
                             "start": {
@@ -1577,11 +698,10 @@
                               "line": 11,
                               "column": 45
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         }
-                      ],
-                      "byref": false
+                      ]
                     },
                     "loc": {
                       "start": {
@@ -1592,7 +712,7 @@
                         "line": 13,
                         "column": 10
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "operator": "=",
@@ -1605,215 +725,9 @@
                       },
                       "end": {
                         "line": 13,
-                        "column": 11
+                        "column": 10
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                    },
-                    "origin": {
-                      "kind": "assign",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 11,
-                          "column": 8,
-                          "offset": 171
-                        },
-                        "end": {
-                          "line": 13,
-                          "column": 10,
-                          "offset": 253
-                        }
-                      },
-                      "left": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 8,
-                            "offset": 171
-                          },
-                          "end": {
-                            "line": 11,
-                            "column": 16,
-                            "offset": 179
-                          }
-                        },
-                        "name": "handler",
-                        "curly": false
-                      },
-                      "right": {
-                        "kind": "closure",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 19,
-                            "offset": 182
-                          },
-                          "end": {
-                            "line": 13,
-                            "column": 9,
-                            "offset": 252
-                          }
-                        },
-                        "uses": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 38,
-                                "offset": 201
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 44,
-                                "offset": 207
-                              }
-                            },
-                            "name": "input",
-                            "curly": false
-                          }
-                        ],
-                        "arguments": [
-                          {
-                            "kind": "parameter",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 29,
-                                "offset": 192
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 31,
-                                "offset": 194
-                              }
-                            },
-                            "name": {
-                              "kind": "identifier",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 11,
-                                  "column": 29,
-                                  "offset": 192
-                                },
-                                "end": {
-                                  "line": 11,
-                                  "column": 31,
-                                  "offset": 194
-                                }
-                              },
-                              "name": "x"
-                            },
-                            "value": null,
-                            "type": null,
-                            "byref": false,
-                            "variadic": false,
-                            "readonly": false,
-                            "nullable": false,
-                            "flags": 0,
-                            "attrGroups": []
-                          }
-                        ],
-                        "byref": false,
-                        "type": null,
-                        "nullable": false,
-                        "isStatic": false,
-                        "body": {
-                          "kind": "block",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 46,
-                              "offset": 209
-                            },
-                            "end": {
-                              "line": 13,
-                              "column": 9,
-                              "offset": 252
-                            }
-                          },
-                          "children": [
-                            {
-                              "kind": "return",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 12,
-                                  "column": 12,
-                                  "offset": 223
-                                },
-                                "end": {
-                                  "line": 12,
-                                  "column": 31,
-                                  "offset": 242
-                                }
-                              },
-                              "expr": {
-                                "kind": "bin",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 12,
-                                    "column": 19,
-                                    "offset": 230
-                                  },
-                                  "end": {
-                                    "line": 12,
-                                    "column": 30,
-                                    "offset": 241
-                                  }
-                                },
-                                "type": "+",
-                                "left": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 19,
-                                      "offset": 230
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 21,
-                                      "offset": 232
-                                    }
-                                  },
-                                  "name": "x",
-                                  "curly": false
-                                },
-                                "right": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 24,
-                                      "offset": 235
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 30,
-                                      "offset": 241
-                                    }
-                                  },
-                                  "name": "input",
-                                  "curly": false
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        "attrGroups": []
-                      },
-                      "operator": "="
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "loc": {
@@ -1823,9 +737,9 @@
                     },
                     "end": {
                       "line": 13,
-                      "column": 11
+                      "column": 10
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "_meta": {
@@ -1838,229 +752,7 @@
                       "line": 13,
                       "column": 11
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                  },
-                  "origin": {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 11,
-                        "column": 8,
-                        "offset": 171
-                      },
-                      "end": {
-                        "line": 13,
-                        "column": 10,
-                        "offset": 253
-                      }
-                    },
-                    "expression": {
-                      "kind": "assign",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 11,
-                          "column": 8,
-                          "offset": 171
-                        },
-                        "end": {
-                          "line": 13,
-                          "column": 10,
-                          "offset": 253
-                        }
-                      },
-                      "left": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 8,
-                            "offset": 171
-                          },
-                          "end": {
-                            "line": 11,
-                            "column": 16,
-                            "offset": 179
-                          }
-                        },
-                        "name": "handler",
-                        "curly": false
-                      },
-                      "right": {
-                        "kind": "closure",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 19,
-                            "offset": 182
-                          },
-                          "end": {
-                            "line": 13,
-                            "column": 9,
-                            "offset": 252
-                          }
-                        },
-                        "uses": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 38,
-                                "offset": 201
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 44,
-                                "offset": 207
-                              }
-                            },
-                            "name": "input",
-                            "curly": false
-                          }
-                        ],
-                        "arguments": [
-                          {
-                            "kind": "parameter",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 29,
-                                "offset": 192
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 31,
-                                "offset": 194
-                              }
-                            },
-                            "name": {
-                              "kind": "identifier",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 11,
-                                  "column": 29,
-                                  "offset": 192
-                                },
-                                "end": {
-                                  "line": 11,
-                                  "column": 31,
-                                  "offset": 194
-                                }
-                              },
-                              "name": "x"
-                            },
-                            "value": null,
-                            "type": null,
-                            "byref": false,
-                            "variadic": false,
-                            "readonly": false,
-                            "nullable": false,
-                            "flags": 0,
-                            "attrGroups": []
-                          }
-                        ],
-                        "byref": false,
-                        "type": null,
-                        "nullable": false,
-                        "isStatic": false,
-                        "body": {
-                          "kind": "block",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 46,
-                              "offset": 209
-                            },
-                            "end": {
-                              "line": 13,
-                              "column": 9,
-                              "offset": 252
-                            }
-                          },
-                          "children": [
-                            {
-                              "kind": "return",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 12,
-                                  "column": 12,
-                                  "offset": 223
-                                },
-                                "end": {
-                                  "line": 12,
-                                  "column": 31,
-                                  "offset": 242
-                                }
-                              },
-                              "expr": {
-                                "kind": "bin",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 12,
-                                    "column": 19,
-                                    "offset": 230
-                                  },
-                                  "end": {
-                                    "line": 12,
-                                    "column": 30,
-                                    "offset": 241
-                                  }
-                                },
-                                "type": "+",
-                                "left": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 19,
-                                      "offset": 230
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 21,
-                                      "offset": 232
-                                    }
-                                  },
-                                  "name": "x",
-                                  "curly": false
-                                },
-                                "right": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 24,
-                                      "offset": 235
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 30,
-                                      "offset": 241
-                                    }
-                                  },
-                                  "name": "input",
-                                  "curly": false
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        "attrGroups": []
-                      },
-                      "operator": "="
-                    }
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "loc": {
@@ -2072,7 +764,7 @@
                     "line": 13,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                 }
               },
               {
@@ -2092,25 +784,7 @@
                           "line": 15,
                           "column": 15
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                      },
-                      "origin": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 15,
-                            "column": 8,
-                            "offset": 263
-                          },
-                          "end": {
-                            "line": 15,
-                            "column": 14,
-                            "offset": 269
-                          }
-                        },
-                        "name": "alias",
-                        "curly": false
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "loc": {
@@ -2122,7 +796,7 @@
                         "line": 15,
                         "column": 15
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "right": {
@@ -2138,25 +812,7 @@
                           "line": 15,
                           "column": 25
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                      },
-                      "origin": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 15,
-                            "column": 18,
-                            "offset": 273
-                          },
-                          "end": {
-                            "line": 15,
-                            "column": 24,
-                            "offset": 279
-                          }
-                        },
-                        "name": "input",
-                        "curly": false
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "loc": {
@@ -2168,7 +824,7 @@
                         "line": 15,
                         "column": 25
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "operator": "=",
@@ -2182,61 +838,9 @@
                       },
                       "end": {
                         "line": 15,
-                        "column": 26
+                        "column": 25
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                    },
-                    "origin": {
-                      "kind": "assignref",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 15,
-                          "column": 8,
-                          "offset": 263
-                        },
-                        "end": {
-                          "line": 15,
-                          "column": 25,
-                          "offset": 280
-                        }
-                      },
-                      "left": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 15,
-                            "column": 8,
-                            "offset": 263
-                          },
-                          "end": {
-                            "line": 15,
-                            "column": 14,
-                            "offset": 269
-                          }
-                        },
-                        "name": "alias",
-                        "curly": false
-                      },
-                      "right": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 15,
-                            "column": 18,
-                            "offset": 273
-                          },
-                          "end": {
-                            "line": 15,
-                            "column": 24,
-                            "offset": 279
-                          }
-                        },
-                        "name": "input",
-                        "curly": false
-                      }
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "loc": {
@@ -2246,9 +850,9 @@
                     },
                     "end": {
                       "line": 15,
-                      "column": 26
+                      "column": 25
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "_meta": {
@@ -2261,75 +865,7 @@
                       "line": 15,
                       "column": 26
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                  },
-                  "origin": {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 15,
-                        "column": 8,
-                        "offset": 263
-                      },
-                      "end": {
-                        "line": 15,
-                        "column": 25,
-                        "offset": 280
-                      }
-                    },
-                    "expression": {
-                      "kind": "assignref",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 15,
-                          "column": 8,
-                          "offset": 263
-                        },
-                        "end": {
-                          "line": 15,
-                          "column": 25,
-                          "offset": 280
-                        }
-                      },
-                      "left": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 15,
-                            "column": 8,
-                            "offset": 263
-                          },
-                          "end": {
-                            "line": 15,
-                            "column": 14,
-                            "offset": 269
-                          }
-                        },
-                        "name": "alias",
-                        "curly": false
-                      },
-                      "right": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 15,
-                            "column": 18,
-                            "offset": 273
-                          },
-                          "end": {
-                            "line": 15,
-                            "column": 24,
-                            "offset": 279
-                          }
-                        },
-                        "name": "input",
-                        "curly": false
-                      }
-                    }
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "loc": {
@@ -2341,7 +877,7 @@
                     "line": 15,
                     "column": 26
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                 }
               },
               {
@@ -2361,25 +897,7 @@
                           "line": 16,
                           "column": 14
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                      },
-                      "origin": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 16,
-                            "column": 8,
-                            "offset": 289
-                          },
-                          "end": {
-                            "line": 16,
-                            "column": 13,
-                            "offset": 294
-                          }
-                        },
-                        "name": "copy",
-                        "curly": false
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "loc": {
@@ -2391,7 +909,7 @@
                         "line": 16,
                         "column": 14
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "right": {
@@ -2415,25 +933,7 @@
                               "line": 16,
                               "column": 28
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                          },
-                          "origin": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 16,
-                                "column": 22,
-                                "offset": 303
-                              },
-                              "end": {
-                                "line": 16,
-                                "column": 27,
-                                "offset": 308
-                              }
-                            },
-                            "name": "this",
-                            "curly": false
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         },
                         "loc": {
@@ -2445,12 +945,11 @@
                             "line": 16,
                             "column": 28
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       }
                     ],
                     "_meta": {
-                      "synthetic": true,
                       "loc": {
                         "start": {
                           "line": 16,
@@ -2460,41 +959,7 @@
                           "line": 16,
                           "column": 28
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                      },
-                      "origin": {
-                        "kind": "clone",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 16,
-                            "column": 16,
-                            "offset": 297
-                          },
-                          "end": {
-                            "line": 16,
-                            "column": 27,
-                            "offset": 308
-                          }
-                        },
-                        "what": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 16,
-                              "column": 22,
-                              "offset": 303
-                            },
-                            "end": {
-                              "line": 16,
-                              "column": 27,
-                              "offset": 308
-                            }
-                          },
-                          "name": "this",
-                          "curly": false
-                        }
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "loc": {
@@ -2506,7 +971,7 @@
                         "line": 16,
                         "column": 28
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "operator": "=",
@@ -2519,78 +984,9 @@
                       },
                       "end": {
                         "line": 16,
-                        "column": 29
+                        "column": 28
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                    },
-                    "origin": {
-                      "kind": "assign",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 16,
-                          "column": 8,
-                          "offset": 289
-                        },
-                        "end": {
-                          "line": 16,
-                          "column": 28,
-                          "offset": 309
-                        }
-                      },
-                      "left": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 16,
-                            "column": 8,
-                            "offset": 289
-                          },
-                          "end": {
-                            "line": 16,
-                            "column": 13,
-                            "offset": 294
-                          }
-                        },
-                        "name": "copy",
-                        "curly": false
-                      },
-                      "right": {
-                        "kind": "clone",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 16,
-                            "column": 16,
-                            "offset": 297
-                          },
-                          "end": {
-                            "line": 16,
-                            "column": 27,
-                            "offset": 308
-                          }
-                        },
-                        "what": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 16,
-                              "column": 22,
-                              "offset": 303
-                            },
-                            "end": {
-                              "line": 16,
-                              "column": 27,
-                              "offset": 308
-                            }
-                          },
-                          "name": "this",
-                          "curly": false
-                        }
-                      },
-                      "operator": "="
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "loc": {
@@ -2600,9 +996,9 @@
                     },
                     "end": {
                       "line": 16,
-                      "column": 29
+                      "column": 28
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "_meta": {
@@ -2615,92 +1011,7 @@
                       "line": 16,
                       "column": 29
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                  },
-                  "origin": {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 16,
-                        "column": 8,
-                        "offset": 289
-                      },
-                      "end": {
-                        "line": 16,
-                        "column": 28,
-                        "offset": 309
-                      }
-                    },
-                    "expression": {
-                      "kind": "assign",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 16,
-                          "column": 8,
-                          "offset": 289
-                        },
-                        "end": {
-                          "line": 16,
-                          "column": 28,
-                          "offset": 309
-                        }
-                      },
-                      "left": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 16,
-                            "column": 8,
-                            "offset": 289
-                          },
-                          "end": {
-                            "line": 16,
-                            "column": 13,
-                            "offset": 294
-                          }
-                        },
-                        "name": "copy",
-                        "curly": false
-                      },
-                      "right": {
-                        "kind": "clone",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 16,
-                            "column": 16,
-                            "offset": 297
-                          },
-                          "end": {
-                            "line": 16,
-                            "column": 27,
-                            "offset": 308
-                          }
-                        },
-                        "what": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 16,
-                              "column": 22,
-                              "offset": 303
-                            },
-                            "end": {
-                              "line": 16,
-                              "column": 27,
-                              "offset": 308
-                            }
-                          },
-                          "name": "this",
-                          "curly": false
-                        }
-                      },
-                      "operator": "="
-                    }
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "loc": {
@@ -2712,7 +1023,7 @@
                     "line": 16,
                     "column": 29
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                 }
               },
               {
@@ -2725,7 +1036,30 @@
                     "callee": {
                       "type": "Identifier",
                       "name": "isset",
-                      "_meta": {}
+                      "_meta": {
+                        "loc": {
+                          "start": {
+                            "line": 18,
+                            "column": 13
+                          },
+                          "end": {
+                            "line": 18,
+                            "column": 18
+                          },
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                        }
+                      },
+                      "loc": {
+                        "start": {
+                          "line": 18,
+                          "column": 13
+                        },
+                        "end": {
+                          "line": 18,
+                          "column": 18
+                        },
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                      }
                     },
                     "arguments": [
                       {
@@ -2741,25 +1075,7 @@
                               "line": 18,
                               "column": 25
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                          },
-                          "origin": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 18,
-                                "offset": 329
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 24,
-                                "offset": 335
-                              }
-                            },
-                            "name": "alias",
-                            "curly": false
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         },
                         "loc": {
@@ -2771,7 +1087,7 @@
                             "line": 18,
                             "column": 25
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       },
                       {
@@ -2787,25 +1103,7 @@
                               "line": 18,
                               "column": 32
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                          },
-                          "origin": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 26,
-                                "offset": 337
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 31,
-                                "offset": 342
-                              }
-                            },
-                            "name": "copy",
-                            "curly": false
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         },
                         "loc": {
@@ -2817,12 +1115,11 @@
                             "line": 18,
                             "column": 32
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       }
                     ],
                     "_meta": {
-                      "synthetic": true,
                       "loc": {
                         "start": {
                           "line": 18,
@@ -2832,61 +1129,7 @@
                           "line": 18,
                           "column": 33
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                      },
-                      "origin": {
-                        "kind": "isset",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 18,
-                            "column": 12,
-                            "offset": 323
-                          },
-                          "end": {
-                            "line": 18,
-                            "column": 32,
-                            "offset": 343
-                          }
-                        },
-                        "variables": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 18,
-                                "offset": 329
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 24,
-                                "offset": 335
-                              }
-                            },
-                            "name": "alias",
-                            "curly": false
-                          },
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 26,
-                                "offset": 337
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 31,
-                                "offset": 342
-                              }
-                            },
-                            "name": "copy",
-                            "curly": false
-                          }
-                        ]
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "loc": {
@@ -2898,7 +1141,7 @@
                         "line": 18,
                         "column": 33
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "right": {
@@ -2909,7 +1152,30 @@
                       "callee": {
                         "type": "Identifier",
                         "name": "empty",
-                        "_meta": {}
+                        "_meta": {
+                          "loc": {
+                            "start": {
+                              "line": 18,
+                              "column": 38
+                            },
+                            "end": {
+                              "line": 18,
+                              "column": 43
+                            },
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                          }
+                        },
+                        "loc": {
+                          "start": {
+                            "line": 18,
+                            "column": 38
+                          },
+                          "end": {
+                            "line": 18,
+                            "column": 43
+                          },
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
+                        }
                       },
                       "arguments": [
                         {
@@ -2925,25 +1191,7 @@
                                 "line": 18,
                                 "column": 50
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                            },
-                            "origin": {
-                              "kind": "variable",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 18,
-                                  "column": 43,
-                                  "offset": 354
-                                },
-                                "end": {
-                                  "line": 18,
-                                  "column": 49,
-                                  "offset": 360
-                                }
-                              },
-                              "name": "input",
-                              "curly": false
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                             }
                           },
                           "loc": {
@@ -2955,12 +1203,11 @@
                               "line": 18,
                               "column": 50
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         }
                       ],
                       "_meta": {
-                        "synthetic": true,
                         "loc": {
                           "start": {
                             "line": 18,
@@ -2970,41 +1217,7 @@
                             "line": 18,
                             "column": 51
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                        },
-                        "origin": {
-                          "kind": "empty",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 18,
-                              "column": 37,
-                              "offset": 348
-                            },
-                            "end": {
-                              "line": 18,
-                              "column": 50,
-                              "offset": 361
-                            }
-                          },
-                          "expression": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 43,
-                                "offset": 354
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 49,
-                                "offset": 360
-                              }
-                            },
-                            "name": "input",
-                            "curly": false
-                          }
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       },
                       "loc": {
@@ -3016,7 +1229,7 @@
                           "line": 18,
                           "column": 51
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "isSuffix": false,
@@ -3030,58 +1243,7 @@
                           "line": 18,
                           "column": 51
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                      },
-                      "origin": {
-                        "kind": "unary",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 18,
-                            "column": 36,
-                            "offset": 347
-                          },
-                          "end": {
-                            "line": 18,
-                            "column": 50,
-                            "offset": 361
-                          }
-                        },
-                        "type": "!",
-                        "what": {
-                          "kind": "empty",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 18,
-                              "column": 37,
-                              "offset": 348
-                            },
-                            "end": {
-                              "line": 18,
-                              "column": 50,
-                              "offset": 361
-                            }
-                          },
-                          "expression": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 43,
-                                "offset": 354
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 49,
-                                "offset": 360
-                              }
-                            },
-                            "name": "input",
-                            "curly": false
-                          }
-                        }
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     },
                     "loc": {
@@ -3093,7 +1255,7 @@
                         "line": 18,
                         "column": 51
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "_meta": {
@@ -3106,129 +1268,7 @@
                         "line": 18,
                         "column": 51
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                    },
-                    "origin": {
-                      "kind": "bin",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 18,
-                          "column": 12,
-                          "offset": 323
-                        },
-                        "end": {
-                          "line": 18,
-                          "column": 50,
-                          "offset": 361
-                        }
-                      },
-                      "type": "&&",
-                      "left": {
-                        "kind": "isset",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 18,
-                            "column": 12,
-                            "offset": 323
-                          },
-                          "end": {
-                            "line": 18,
-                            "column": 32,
-                            "offset": 343
-                          }
-                        },
-                        "variables": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 18,
-                                "offset": 329
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 24,
-                                "offset": 335
-                              }
-                            },
-                            "name": "alias",
-                            "curly": false
-                          },
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 26,
-                                "offset": 337
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 31,
-                                "offset": 342
-                              }
-                            },
-                            "name": "copy",
-                            "curly": false
-                          }
-                        ]
-                      },
-                      "right": {
-                        "kind": "unary",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 18,
-                            "column": 36,
-                            "offset": 347
-                          },
-                          "end": {
-                            "line": 18,
-                            "column": 50,
-                            "offset": 361
-                          }
-                        },
-                        "type": "!",
-                        "what": {
-                          "kind": "empty",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 18,
-                              "column": 37,
-                              "offset": 348
-                            },
-                            "end": {
-                              "line": 18,
-                              "column": 50,
-                              "offset": 361
-                            }
-                          },
-                          "expression": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 43,
-                                "offset": 354
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 49,
-                                "offset": 360
-                              }
-                            },
-                            "name": "input",
-                            "curly": false
-                          }
-                        }
-                      }
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "loc": {
@@ -3240,7 +1280,7 @@
                       "line": 18,
                       "column": 51
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "consequent": {
@@ -3263,25 +1303,7 @@
                                 "line": 19,
                                 "column": 28
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                            },
-                            "origin": {
-                              "kind": "variable",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 19,
-                                  "column": 19,
-                                  "offset": 384
-                                },
-                                "end": {
-                                  "line": 19,
-                                  "column": 27,
-                                  "offset": 392
-                                }
-                              },
-                              "name": "handler",
-                              "curly": false
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                             }
                           },
                           "loc": {
@@ -3293,7 +1315,7 @@
                               "line": 19,
                               "column": 28
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         },
                         "arguments": [
@@ -3310,25 +1332,7 @@
                                   "line": 19,
                                   "column": 35
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                              },
-                              "origin": {
-                                "kind": "variable",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 19,
-                                    "column": 28,
-                                    "offset": 393
-                                  },
-                                  "end": {
-                                    "line": 19,
-                                    "column": 34,
-                                    "offset": 399
-                                  }
-                                },
-                                "name": "alias",
-                                "curly": false
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                               }
                             },
                             "loc": {
@@ -3340,7 +1344,7 @@
                                 "line": 19,
                                 "column": 35
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                             }
                           }
                         ],
@@ -3354,61 +1358,7 @@
                               "line": 19,
                               "column": 36
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                          },
-                          "origin": {
-                            "kind": "call",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 19,
-                                "column": 19,
-                                "offset": 384
-                              },
-                              "end": {
-                                "line": 19,
-                                "column": 35,
-                                "offset": 400
-                              }
-                            },
-                            "what": {
-                              "kind": "variable",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 19,
-                                  "column": 19,
-                                  "offset": 384
-                                },
-                                "end": {
-                                  "line": 19,
-                                  "column": 27,
-                                  "offset": 392
-                                }
-                              },
-                              "name": "handler",
-                              "curly": false
-                            },
-                            "arguments": [
-                              {
-                                "kind": "variable",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 19,
-                                    "column": 28,
-                                    "offset": 393
-                                  },
-                                  "end": {
-                                    "line": 19,
-                                    "column": 34,
-                                    "offset": 399
-                                  }
-                                },
-                                "name": "alias",
-                                "curly": false
-                              }
-                            ]
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                           }
                         },
                         "loc": {
@@ -3420,7 +1370,7 @@
                             "line": 19,
                             "column": 36
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       },
                       "isYield": false,
@@ -3434,77 +1384,7 @@
                             "line": 19,
                             "column": 37
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                        },
-                        "origin": {
-                          "kind": "return",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 19,
-                              "column": 12,
-                              "offset": 377
-                            },
-                            "end": {
-                              "line": 19,
-                              "column": 36,
-                              "offset": 401
-                            }
-                          },
-                          "expr": {
-                            "kind": "call",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 19,
-                                "column": 19,
-                                "offset": 384
-                              },
-                              "end": {
-                                "line": 19,
-                                "column": 35,
-                                "offset": 400
-                              }
-                            },
-                            "what": {
-                              "kind": "variable",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 19,
-                                  "column": 19,
-                                  "offset": 384
-                                },
-                                "end": {
-                                  "line": 19,
-                                  "column": 27,
-                                  "offset": 392
-                                }
-                              },
-                              "name": "handler",
-                              "curly": false
-                            },
-                            "arguments": [
-                              {
-                                "kind": "variable",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 19,
-                                    "column": 28,
-                                    "offset": 393
-                                  },
-                                  "end": {
-                                    "line": 19,
-                                    "column": 34,
-                                    "offset": 399
-                                  }
-                                },
-                                "name": "alias",
-                                "curly": false
-                              }
-                            ]
-                          }
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                         }
                       },
                       "loc": {
@@ -3516,7 +1396,7 @@
                           "line": 19,
                           "column": 37
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                       }
                     }
                   ],
@@ -3531,95 +1411,7 @@
                         "line": 20,
                         "column": 10
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                    },
-                    "origin": {
-                      "kind": "block",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 18,
-                          "column": 52,
-                          "offset": 363
-                        },
-                        "end": {
-                          "line": 20,
-                          "column": 9,
-                          "offset": 411
-                        }
-                      },
-                      "children": [
-                        {
-                          "kind": "return",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 19,
-                              "column": 12,
-                              "offset": 377
-                            },
-                            "end": {
-                              "line": 19,
-                              "column": 36,
-                              "offset": 401
-                            }
-                          },
-                          "expr": {
-                            "kind": "call",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 19,
-                                "column": 19,
-                                "offset": 384
-                              },
-                              "end": {
-                                "line": 19,
-                                "column": 35,
-                                "offset": 400
-                              }
-                            },
-                            "what": {
-                              "kind": "variable",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 19,
-                                  "column": 19,
-                                  "offset": 384
-                                },
-                                "end": {
-                                  "line": 19,
-                                  "column": 27,
-                                  "offset": 392
-                                }
-                              },
-                              "name": "handler",
-                              "curly": false
-                            },
-                            "arguments": [
-                              {
-                                "kind": "variable",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 19,
-                                    "column": 28,
-                                    "offset": 393
-                                  },
-                                  "end": {
-                                    "line": 19,
-                                    "column": 34,
-                                    "offset": 399
-                                  }
-                                },
-                                "name": "alias",
-                                "curly": false
-                              }
-                            ]
-                          }
-                        }
-                      ]
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "loc": {
@@ -3631,7 +1423,7 @@
                       "line": 20,
                       "column": 10
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "alternative": null,
@@ -3645,235 +1437,7 @@
                       "line": 20,
                       "column": 10
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                  },
-                  "origin": {
-                    "kind": "if",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 18,
-                        "column": 8,
-                        "offset": 319
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 9,
-                        "offset": 411
-                      }
-                    },
-                    "test": {
-                      "kind": "bin",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 18,
-                          "column": 12,
-                          "offset": 323
-                        },
-                        "end": {
-                          "line": 18,
-                          "column": 50,
-                          "offset": 361
-                        }
-                      },
-                      "type": "&&",
-                      "left": {
-                        "kind": "isset",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 18,
-                            "column": 12,
-                            "offset": 323
-                          },
-                          "end": {
-                            "line": 18,
-                            "column": 32,
-                            "offset": 343
-                          }
-                        },
-                        "variables": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 18,
-                                "offset": 329
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 24,
-                                "offset": 335
-                              }
-                            },
-                            "name": "alias",
-                            "curly": false
-                          },
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 26,
-                                "offset": 337
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 31,
-                                "offset": 342
-                              }
-                            },
-                            "name": "copy",
-                            "curly": false
-                          }
-                        ]
-                      },
-                      "right": {
-                        "kind": "unary",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 18,
-                            "column": 36,
-                            "offset": 347
-                          },
-                          "end": {
-                            "line": 18,
-                            "column": 50,
-                            "offset": 361
-                          }
-                        },
-                        "type": "!",
-                        "what": {
-                          "kind": "empty",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 18,
-                              "column": 37,
-                              "offset": 348
-                            },
-                            "end": {
-                              "line": 18,
-                              "column": 50,
-                              "offset": 361
-                            }
-                          },
-                          "expression": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 43,
-                                "offset": 354
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 49,
-                                "offset": 360
-                              }
-                            },
-                            "name": "input",
-                            "curly": false
-                          }
-                        }
-                      }
-                    },
-                    "body": {
-                      "kind": "block",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 18,
-                          "column": 52,
-                          "offset": 363
-                        },
-                        "end": {
-                          "line": 20,
-                          "column": 9,
-                          "offset": 411
-                        }
-                      },
-                      "children": [
-                        {
-                          "kind": "return",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 19,
-                              "column": 12,
-                              "offset": 377
-                            },
-                            "end": {
-                              "line": 19,
-                              "column": 36,
-                              "offset": 401
-                            }
-                          },
-                          "expr": {
-                            "kind": "call",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 19,
-                                "column": 19,
-                                "offset": 384
-                              },
-                              "end": {
-                                "line": 19,
-                                "column": 35,
-                                "offset": 400
-                              }
-                            },
-                            "what": {
-                              "kind": "variable",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 19,
-                                  "column": 19,
-                                  "offset": 384
-                                },
-                                "end": {
-                                  "line": 19,
-                                  "column": 27,
-                                  "offset": 392
-                                }
-                              },
-                              "name": "handler",
-                              "curly": false
-                            },
-                            "arguments": [
-                              {
-                                "kind": "variable",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 19,
-                                    "column": 28,
-                                    "offset": 393
-                                  },
-                                  "end": {
-                                    "line": 19,
-                                    "column": 34,
-                                    "offset": 399
-                                  }
-                                },
-                                "name": "alias",
-                                "curly": false
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    },
-                    "alternate": null,
-                    "shortForm": false
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "loc": {
@@ -3885,7 +1449,7 @@
                     "line": 20,
                     "column": 10
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                 }
               },
               {
@@ -3904,24 +1468,7 @@
                         "line": 22,
                         "column": 20
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                    },
-                    "origin": {
-                      "kind": "nullkeyword",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 22,
-                          "column": 15,
-                          "offset": 428
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 19,
-                          "offset": 432
-                        }
-                      },
-                      "raw": "null"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                     }
                   },
                   "loc": {
@@ -3933,7 +1480,7 @@
                       "line": 22,
                       "column": 20
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "isYield": false,
@@ -3947,40 +1494,7 @@
                       "line": 22,
                       "column": 21
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-                  },
-                  "origin": {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 8,
-                        "offset": 421
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 20,
-                        "offset": 433
-                      }
-                    },
-                    "expr": {
-                      "kind": "nullkeyword",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 22,
-                          "column": 15,
-                          "offset": 428
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 19,
-                          "offset": 432
-                        }
-                      },
-                      "raw": "null"
-                    }
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                   }
                 },
                 "loc": {
@@ -3992,7 +1506,7 @@
                     "line": 22,
                     "column": 21
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
                 }
               }
             ],
@@ -4007,661 +1521,7 @@
                   "line": 23,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-              },
-              "origin": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 10,
-                    "column": 4,
-                    "offset": 161
-                  },
-                  "end": {
-                    "line": 23,
-                    "column": 5,
-                    "offset": 439
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 11,
-                        "column": 8,
-                        "offset": 171
-                      },
-                      "end": {
-                        "line": 13,
-                        "column": 10,
-                        "offset": 253
-                      }
-                    },
-                    "expression": {
-                      "kind": "assign",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 11,
-                          "column": 8,
-                          "offset": 171
-                        },
-                        "end": {
-                          "line": 13,
-                          "column": 10,
-                          "offset": 253
-                        }
-                      },
-                      "left": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 8,
-                            "offset": 171
-                          },
-                          "end": {
-                            "line": 11,
-                            "column": 16,
-                            "offset": 179
-                          }
-                        },
-                        "name": "handler",
-                        "curly": false
-                      },
-                      "right": {
-                        "kind": "closure",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 19,
-                            "offset": 182
-                          },
-                          "end": {
-                            "line": 13,
-                            "column": 9,
-                            "offset": 252
-                          }
-                        },
-                        "uses": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 38,
-                                "offset": 201
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 44,
-                                "offset": 207
-                              }
-                            },
-                            "name": "input",
-                            "curly": false
-                          }
-                        ],
-                        "arguments": [
-                          {
-                            "kind": "parameter",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 29,
-                                "offset": 192
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 31,
-                                "offset": 194
-                              }
-                            },
-                            "name": {
-                              "kind": "identifier",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 11,
-                                  "column": 29,
-                                  "offset": 192
-                                },
-                                "end": {
-                                  "line": 11,
-                                  "column": 31,
-                                  "offset": 194
-                                }
-                              },
-                              "name": "x"
-                            },
-                            "value": null,
-                            "type": null,
-                            "byref": false,
-                            "variadic": false,
-                            "readonly": false,
-                            "nullable": false,
-                            "flags": 0,
-                            "attrGroups": []
-                          }
-                        ],
-                        "byref": false,
-                        "type": null,
-                        "nullable": false,
-                        "isStatic": false,
-                        "body": {
-                          "kind": "block",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 46,
-                              "offset": 209
-                            },
-                            "end": {
-                              "line": 13,
-                              "column": 9,
-                              "offset": 252
-                            }
-                          },
-                          "children": [
-                            {
-                              "kind": "return",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 12,
-                                  "column": 12,
-                                  "offset": 223
-                                },
-                                "end": {
-                                  "line": 12,
-                                  "column": 31,
-                                  "offset": 242
-                                }
-                              },
-                              "expr": {
-                                "kind": "bin",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 12,
-                                    "column": 19,
-                                    "offset": 230
-                                  },
-                                  "end": {
-                                    "line": 12,
-                                    "column": 30,
-                                    "offset": 241
-                                  }
-                                },
-                                "type": "+",
-                                "left": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 19,
-                                      "offset": 230
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 21,
-                                      "offset": 232
-                                    }
-                                  },
-                                  "name": "x",
-                                  "curly": false
-                                },
-                                "right": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 24,
-                                      "offset": 235
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 30,
-                                      "offset": 241
-                                    }
-                                  },
-                                  "name": "input",
-                                  "curly": false
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        "attrGroups": []
-                      },
-                      "operator": "="
-                    }
-                  },
-                  {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 15,
-                        "column": 8,
-                        "offset": 263
-                      },
-                      "end": {
-                        "line": 15,
-                        "column": 25,
-                        "offset": 280
-                      }
-                    },
-                    "expression": {
-                      "kind": "assignref",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 15,
-                          "column": 8,
-                          "offset": 263
-                        },
-                        "end": {
-                          "line": 15,
-                          "column": 25,
-                          "offset": 280
-                        }
-                      },
-                      "left": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 15,
-                            "column": 8,
-                            "offset": 263
-                          },
-                          "end": {
-                            "line": 15,
-                            "column": 14,
-                            "offset": 269
-                          }
-                        },
-                        "name": "alias",
-                        "curly": false
-                      },
-                      "right": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 15,
-                            "column": 18,
-                            "offset": 273
-                          },
-                          "end": {
-                            "line": 15,
-                            "column": 24,
-                            "offset": 279
-                          }
-                        },
-                        "name": "input",
-                        "curly": false
-                      }
-                    }
-                  },
-                  {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 16,
-                        "column": 8,
-                        "offset": 289
-                      },
-                      "end": {
-                        "line": 16,
-                        "column": 28,
-                        "offset": 309
-                      }
-                    },
-                    "expression": {
-                      "kind": "assign",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 16,
-                          "column": 8,
-                          "offset": 289
-                        },
-                        "end": {
-                          "line": 16,
-                          "column": 28,
-                          "offset": 309
-                        }
-                      },
-                      "left": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 16,
-                            "column": 8,
-                            "offset": 289
-                          },
-                          "end": {
-                            "line": 16,
-                            "column": 13,
-                            "offset": 294
-                          }
-                        },
-                        "name": "copy",
-                        "curly": false
-                      },
-                      "right": {
-                        "kind": "clone",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 16,
-                            "column": 16,
-                            "offset": 297
-                          },
-                          "end": {
-                            "line": 16,
-                            "column": 27,
-                            "offset": 308
-                          }
-                        },
-                        "what": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 16,
-                              "column": 22,
-                              "offset": 303
-                            },
-                            "end": {
-                              "line": 16,
-                              "column": 27,
-                              "offset": 308
-                            }
-                          },
-                          "name": "this",
-                          "curly": false
-                        }
-                      },
-                      "operator": "="
-                    }
-                  },
-                  {
-                    "kind": "if",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 18,
-                        "column": 8,
-                        "offset": 319
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 9,
-                        "offset": 411
-                      }
-                    },
-                    "test": {
-                      "kind": "bin",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 18,
-                          "column": 12,
-                          "offset": 323
-                        },
-                        "end": {
-                          "line": 18,
-                          "column": 50,
-                          "offset": 361
-                        }
-                      },
-                      "type": "&&",
-                      "left": {
-                        "kind": "isset",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 18,
-                            "column": 12,
-                            "offset": 323
-                          },
-                          "end": {
-                            "line": 18,
-                            "column": 32,
-                            "offset": 343
-                          }
-                        },
-                        "variables": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 18,
-                                "offset": 329
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 24,
-                                "offset": 335
-                              }
-                            },
-                            "name": "alias",
-                            "curly": false
-                          },
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 26,
-                                "offset": 337
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 31,
-                                "offset": 342
-                              }
-                            },
-                            "name": "copy",
-                            "curly": false
-                          }
-                        ]
-                      },
-                      "right": {
-                        "kind": "unary",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 18,
-                            "column": 36,
-                            "offset": 347
-                          },
-                          "end": {
-                            "line": 18,
-                            "column": 50,
-                            "offset": 361
-                          }
-                        },
-                        "type": "!",
-                        "what": {
-                          "kind": "empty",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 18,
-                              "column": 37,
-                              "offset": 348
-                            },
-                            "end": {
-                              "line": 18,
-                              "column": 50,
-                              "offset": 361
-                            }
-                          },
-                          "expression": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 43,
-                                "offset": 354
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 49,
-                                "offset": 360
-                              }
-                            },
-                            "name": "input",
-                            "curly": false
-                          }
-                        }
-                      }
-                    },
-                    "body": {
-                      "kind": "block",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 18,
-                          "column": 52,
-                          "offset": 363
-                        },
-                        "end": {
-                          "line": 20,
-                          "column": 9,
-                          "offset": 411
-                        }
-                      },
-                      "children": [
-                        {
-                          "kind": "return",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 19,
-                              "column": 12,
-                              "offset": 377
-                            },
-                            "end": {
-                              "line": 19,
-                              "column": 36,
-                              "offset": 401
-                            }
-                          },
-                          "expr": {
-                            "kind": "call",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 19,
-                                "column": 19,
-                                "offset": 384
-                              },
-                              "end": {
-                                "line": 19,
-                                "column": 35,
-                                "offset": 400
-                              }
-                            },
-                            "what": {
-                              "kind": "variable",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 19,
-                                  "column": 19,
-                                  "offset": 384
-                                },
-                                "end": {
-                                  "line": 19,
-                                  "column": 27,
-                                  "offset": 392
-                                }
-                              },
-                              "name": "handler",
-                              "curly": false
-                            },
-                            "arguments": [
-                              {
-                                "kind": "variable",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 19,
-                                    "column": 28,
-                                    "offset": 393
-                                  },
-                                  "end": {
-                                    "line": 19,
-                                    "column": 34,
-                                    "offset": 399
-                                  }
-                                },
-                                "name": "alias",
-                                "curly": false
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    },
-                    "alternate": null,
-                    "shortForm": false
-                  },
-                  {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 8,
-                        "offset": 421
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 20,
-                        "offset": 433
-                      }
-                    },
-                    "expr": {
-                      "kind": "nullkeyword",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 22,
-                          "column": 15,
-                          "offset": 428
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 19,
-                          "offset": 432
-                        }
-                      },
-                      "raw": "null"
-                    }
-                  }
-                ]
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
               }
             },
             "loc": {
@@ -4673,14 +1533,13 @@
                 "line": 23,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "modifiers": [
             "public"
           ],
           "_meta": {
-            "attributes": [],
             "loc": {
               "start": {
                 "line": 9,
@@ -4690,746 +1549,7 @@
                 "line": 23,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-            },
-            "origin": {
-              "kind": "method",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 9,
-                  "column": 4,
-                  "offset": 127
-                },
-                "end": {
-                  "line": 23,
-                  "column": 5,
-                  "offset": 439
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 9,
-                    "column": 20,
-                    "offset": 143
-                  },
-                  "end": {
-                    "line": 9,
-                    "column": 25,
-                    "offset": 148
-                  }
-                },
-                "name": "build"
-              },
-              "arguments": [
-                {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 9,
-                      "column": 26,
-                      "offset": 149
-                    },
-                    "end": {
-                      "line": 9,
-                      "column": 32,
-                      "offset": 155
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 26,
-                        "offset": 149
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 32,
-                        "offset": 155
-                      }
-                    },
-                    "name": "input"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": []
-                }
-              ],
-              "byref": false,
-              "type": null,
-              "nullable": false,
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 10,
-                    "column": 4,
-                    "offset": 161
-                  },
-                  "end": {
-                    "line": 23,
-                    "column": 5,
-                    "offset": 439
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 11,
-                        "column": 8,
-                        "offset": 171
-                      },
-                      "end": {
-                        "line": 13,
-                        "column": 10,
-                        "offset": 253
-                      }
-                    },
-                    "expression": {
-                      "kind": "assign",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 11,
-                          "column": 8,
-                          "offset": 171
-                        },
-                        "end": {
-                          "line": 13,
-                          "column": 10,
-                          "offset": 253
-                        }
-                      },
-                      "left": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 8,
-                            "offset": 171
-                          },
-                          "end": {
-                            "line": 11,
-                            "column": 16,
-                            "offset": 179
-                          }
-                        },
-                        "name": "handler",
-                        "curly": false
-                      },
-                      "right": {
-                        "kind": "closure",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 19,
-                            "offset": 182
-                          },
-                          "end": {
-                            "line": 13,
-                            "column": 9,
-                            "offset": 252
-                          }
-                        },
-                        "uses": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 38,
-                                "offset": 201
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 44,
-                                "offset": 207
-                              }
-                            },
-                            "name": "input",
-                            "curly": false
-                          }
-                        ],
-                        "arguments": [
-                          {
-                            "kind": "parameter",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 29,
-                                "offset": 192
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 31,
-                                "offset": 194
-                              }
-                            },
-                            "name": {
-                              "kind": "identifier",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 11,
-                                  "column": 29,
-                                  "offset": 192
-                                },
-                                "end": {
-                                  "line": 11,
-                                  "column": 31,
-                                  "offset": 194
-                                }
-                              },
-                              "name": "x"
-                            },
-                            "value": null,
-                            "type": null,
-                            "byref": false,
-                            "variadic": false,
-                            "readonly": false,
-                            "nullable": false,
-                            "flags": 0,
-                            "attrGroups": []
-                          }
-                        ],
-                        "byref": false,
-                        "type": null,
-                        "nullable": false,
-                        "isStatic": false,
-                        "body": {
-                          "kind": "block",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 46,
-                              "offset": 209
-                            },
-                            "end": {
-                              "line": 13,
-                              "column": 9,
-                              "offset": 252
-                            }
-                          },
-                          "children": [
-                            {
-                              "kind": "return",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 12,
-                                  "column": 12,
-                                  "offset": 223
-                                },
-                                "end": {
-                                  "line": 12,
-                                  "column": 31,
-                                  "offset": 242
-                                }
-                              },
-                              "expr": {
-                                "kind": "bin",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 12,
-                                    "column": 19,
-                                    "offset": 230
-                                  },
-                                  "end": {
-                                    "line": 12,
-                                    "column": 30,
-                                    "offset": 241
-                                  }
-                                },
-                                "type": "+",
-                                "left": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 19,
-                                      "offset": 230
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 21,
-                                      "offset": 232
-                                    }
-                                  },
-                                  "name": "x",
-                                  "curly": false
-                                },
-                                "right": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 24,
-                                      "offset": 235
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 30,
-                                      "offset": 241
-                                    }
-                                  },
-                                  "name": "input",
-                                  "curly": false
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        "attrGroups": []
-                      },
-                      "operator": "="
-                    }
-                  },
-                  {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 15,
-                        "column": 8,
-                        "offset": 263
-                      },
-                      "end": {
-                        "line": 15,
-                        "column": 25,
-                        "offset": 280
-                      }
-                    },
-                    "expression": {
-                      "kind": "assignref",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 15,
-                          "column": 8,
-                          "offset": 263
-                        },
-                        "end": {
-                          "line": 15,
-                          "column": 25,
-                          "offset": 280
-                        }
-                      },
-                      "left": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 15,
-                            "column": 8,
-                            "offset": 263
-                          },
-                          "end": {
-                            "line": 15,
-                            "column": 14,
-                            "offset": 269
-                          }
-                        },
-                        "name": "alias",
-                        "curly": false
-                      },
-                      "right": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 15,
-                            "column": 18,
-                            "offset": 273
-                          },
-                          "end": {
-                            "line": 15,
-                            "column": 24,
-                            "offset": 279
-                          }
-                        },
-                        "name": "input",
-                        "curly": false
-                      }
-                    }
-                  },
-                  {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 16,
-                        "column": 8,
-                        "offset": 289
-                      },
-                      "end": {
-                        "line": 16,
-                        "column": 28,
-                        "offset": 309
-                      }
-                    },
-                    "expression": {
-                      "kind": "assign",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 16,
-                          "column": 8,
-                          "offset": 289
-                        },
-                        "end": {
-                          "line": 16,
-                          "column": 28,
-                          "offset": 309
-                        }
-                      },
-                      "left": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 16,
-                            "column": 8,
-                            "offset": 289
-                          },
-                          "end": {
-                            "line": 16,
-                            "column": 13,
-                            "offset": 294
-                          }
-                        },
-                        "name": "copy",
-                        "curly": false
-                      },
-                      "right": {
-                        "kind": "clone",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 16,
-                            "column": 16,
-                            "offset": 297
-                          },
-                          "end": {
-                            "line": 16,
-                            "column": 27,
-                            "offset": 308
-                          }
-                        },
-                        "what": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 16,
-                              "column": 22,
-                              "offset": 303
-                            },
-                            "end": {
-                              "line": 16,
-                              "column": 27,
-                              "offset": 308
-                            }
-                          },
-                          "name": "this",
-                          "curly": false
-                        }
-                      },
-                      "operator": "="
-                    }
-                  },
-                  {
-                    "kind": "if",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 18,
-                        "column": 8,
-                        "offset": 319
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 9,
-                        "offset": 411
-                      }
-                    },
-                    "test": {
-                      "kind": "bin",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 18,
-                          "column": 12,
-                          "offset": 323
-                        },
-                        "end": {
-                          "line": 18,
-                          "column": 50,
-                          "offset": 361
-                        }
-                      },
-                      "type": "&&",
-                      "left": {
-                        "kind": "isset",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 18,
-                            "column": 12,
-                            "offset": 323
-                          },
-                          "end": {
-                            "line": 18,
-                            "column": 32,
-                            "offset": 343
-                          }
-                        },
-                        "variables": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 18,
-                                "offset": 329
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 24,
-                                "offset": 335
-                              }
-                            },
-                            "name": "alias",
-                            "curly": false
-                          },
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 26,
-                                "offset": 337
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 31,
-                                "offset": 342
-                              }
-                            },
-                            "name": "copy",
-                            "curly": false
-                          }
-                        ]
-                      },
-                      "right": {
-                        "kind": "unary",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 18,
-                            "column": 36,
-                            "offset": 347
-                          },
-                          "end": {
-                            "line": 18,
-                            "column": 50,
-                            "offset": 361
-                          }
-                        },
-                        "type": "!",
-                        "what": {
-                          "kind": "empty",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 18,
-                              "column": 37,
-                              "offset": 348
-                            },
-                            "end": {
-                              "line": 18,
-                              "column": 50,
-                              "offset": 361
-                            }
-                          },
-                          "expression": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 43,
-                                "offset": 354
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 49,
-                                "offset": 360
-                              }
-                            },
-                            "name": "input",
-                            "curly": false
-                          }
-                        }
-                      }
-                    },
-                    "body": {
-                      "kind": "block",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 18,
-                          "column": 52,
-                          "offset": 363
-                        },
-                        "end": {
-                          "line": 20,
-                          "column": 9,
-                          "offset": 411
-                        }
-                      },
-                      "children": [
-                        {
-                          "kind": "return",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 19,
-                              "column": 12,
-                              "offset": 377
-                            },
-                            "end": {
-                              "line": 19,
-                              "column": 36,
-                              "offset": 401
-                            }
-                          },
-                          "expr": {
-                            "kind": "call",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 19,
-                                "column": 19,
-                                "offset": 384
-                              },
-                              "end": {
-                                "line": 19,
-                                "column": 35,
-                                "offset": 400
-                              }
-                            },
-                            "what": {
-                              "kind": "variable",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 19,
-                                  "column": 19,
-                                  "offset": 384
-                                },
-                                "end": {
-                                  "line": 19,
-                                  "column": 27,
-                                  "offset": 392
-                                }
-                              },
-                              "name": "handler",
-                              "curly": false
-                            },
-                            "arguments": [
-                              {
-                                "kind": "variable",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 19,
-                                    "column": 28,
-                                    "offset": 393
-                                  },
-                                  "end": {
-                                    "line": 19,
-                                    "column": 34,
-                                    "offset": 399
-                                  }
-                                },
-                                "name": "alias",
-                                "curly": false
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    },
-                    "alternate": null,
-                    "shortForm": false
-                  },
-                  {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 8,
-                        "offset": 421
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 20,
-                        "offset": 433
-                      }
-                    },
-                    "expr": {
-                      "kind": "nullkeyword",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 22,
-                          "column": 15,
-                          "offset": 428
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 19,
-                          "offset": 432
-                        }
-                      },
-                      "raw": "null"
-                    }
-                  }
-                ]
-              },
-              "attrGroups": [],
-              "isAbstract": false,
-              "isFinal": false,
-              "isReadonly": false,
-              "visibility": "public",
-              "isStatic": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
             }
           },
           "loc": {
@@ -5441,64 +1561,12 @@
               "line": 23,
               "column": 6
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
           }
         }
       ],
-      "supers": [
-        {
-          "type": "Identifier",
-          "name": "BaseClass",
-          "_meta": {
-            "loc": {
-              "start": {
-                "line": 3,
-                "column": 20
-              },
-              "end": {
-                "line": 3,
-                "column": 29
-              },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-            },
-            "origin": {
-              "kind": "name",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 19,
-                  "offset": 26
-                },
-                "end": {
-                  "line": 3,
-                  "column": 28,
-                  "offset": 35
-                }
-              },
-              "name": "BaseClass",
-              "resolution": "uqn"
-            }
-          },
-          "loc": {
-            "start": {
-              "line": 3,
-              "column": 20
-            },
-            "end": {
-              "line": 3,
-              "column": 29
-            },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-          }
-        }
-      ],
+      "supers": [],
       "_meta": {
-        "implements": [],
-        "isAbstract": false,
-        "isFinal": false,
-        "isReadonly": false,
-        "attributes": [],
         "loc": {
           "start": {
             "line": 3,
@@ -5508,1029 +1576,7 @@
             "line": 24,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-        },
-        "origin": {
-          "kind": "class",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 7
-            },
-            "end": {
-              "line": 24,
-              "column": 1,
-              "offset": 441
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 6,
-                "offset": 13
-              },
-              "end": {
-                "line": 3,
-                "column": 10,
-                "offset": 17
-              }
-            },
-            "name": "Demo"
-          },
-          "isAnonymous": false,
-          "extends": {
-            "kind": "name",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 19,
-                "offset": 26
-              },
-              "end": {
-                "line": 3,
-                "column": 28,
-                "offset": 35
-              }
-            },
-            "name": "BaseClass",
-            "resolution": "uqn"
-          },
-          "implements": null,
-          "body": [
-            {
-              "kind": "propertystatement",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 5,
-                  "column": 11,
-                  "offset": 49
-                },
-                "end": {
-                  "line": 5,
-                  "column": 22,
-                  "offset": 60
-                }
-              },
-              "properties": [
-                {
-                  "kind": "property",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 11,
-                      "offset": 49
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 22,
-                      "offset": 60
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 11,
-                        "offset": 49
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 16,
-                        "offset": 54
-                      }
-                    },
-                    "name": "name"
-                  },
-                  "value": {
-                    "kind": "string",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 19,
-                        "offset": 57
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 22,
-                        "offset": 60
-                      }
-                    },
-                    "value": "x",
-                    "raw": "'x'",
-                    "unicode": false,
-                    "isDoubleQuote": false
-                  },
-                  "readonly": false,
-                  "nullable": false,
-                  "type": null,
-                  "attrGroups": []
-                }
-              ],
-              "visibility": "public",
-              "isStatic": false
-            },
-            {
-              "kind": "propertystatement",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 6,
-                  "column": 19,
-                  "offset": 81
-                },
-                "end": {
-                  "line": 6,
-                  "column": 29,
-                  "offset": 91
-                }
-              },
-              "properties": [
-                {
-                  "kind": "property",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 19,
-                      "offset": 81
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 29,
-                      "offset": 91
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 19,
-                        "offset": 81
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 25,
-                        "offset": 87
-                      }
-                    },
-                    "name": "count"
-                  },
-                  "value": {
-                    "kind": "number",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 28,
-                        "offset": 90
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 29,
-                        "offset": 91
-                      }
-                    },
-                    "value": "1"
-                  },
-                  "readonly": false,
-                  "nullable": false,
-                  "type": null,
-                  "attrGroups": []
-                }
-              ],
-              "visibility": "private",
-              "isStatic": true
-            },
-            {
-              "kind": "classconstant",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 7,
-                  "column": 10,
-                  "offset": 103
-                },
-                "end": {
-                  "line": 7,
-                  "column": 27,
-                  "offset": 120
-                }
-              },
-              "constants": [
-                {
-                  "kind": "constant",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 7,
-                      "column": 10,
-                      "offset": 103
-                    },
-                    "end": {
-                      "line": 7,
-                      "column": 27,
-                      "offset": 120
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 7,
-                        "column": 10,
-                        "offset": 103
-                      },
-                      "end": {
-                        "line": 7,
-                        "column": 23,
-                        "offset": 116
-                      }
-                    },
-                    "name": "DEFAULT_COUNT"
-                  },
-                  "value": {
-                    "kind": "number",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 7,
-                        "column": 26,
-                        "offset": 119
-                      },
-                      "end": {
-                        "line": 7,
-                        "column": 27,
-                        "offset": 120
-                      }
-                    },
-                    "value": "2"
-                  }
-                }
-              ],
-              "visibility": "",
-              "final": false,
-              "nullable": false,
-              "type": null,
-              "attrGroups": []
-            },
-            {
-              "kind": "method",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 9,
-                  "column": 4,
-                  "offset": 127
-                },
-                "end": {
-                  "line": 23,
-                  "column": 5,
-                  "offset": 439
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 9,
-                    "column": 20,
-                    "offset": 143
-                  },
-                  "end": {
-                    "line": 9,
-                    "column": 25,
-                    "offset": 148
-                  }
-                },
-                "name": "build"
-              },
-              "arguments": [
-                {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 9,
-                      "column": 26,
-                      "offset": 149
-                    },
-                    "end": {
-                      "line": 9,
-                      "column": 32,
-                      "offset": 155
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 26,
-                        "offset": 149
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 32,
-                        "offset": 155
-                      }
-                    },
-                    "name": "input"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": []
-                }
-              ],
-              "byref": false,
-              "type": null,
-              "nullable": false,
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 10,
-                    "column": 4,
-                    "offset": 161
-                  },
-                  "end": {
-                    "line": 23,
-                    "column": 5,
-                    "offset": 439
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 11,
-                        "column": 8,
-                        "offset": 171
-                      },
-                      "end": {
-                        "line": 13,
-                        "column": 10,
-                        "offset": 253
-                      }
-                    },
-                    "expression": {
-                      "kind": "assign",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 11,
-                          "column": 8,
-                          "offset": 171
-                        },
-                        "end": {
-                          "line": 13,
-                          "column": 10,
-                          "offset": 253
-                        }
-                      },
-                      "left": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 8,
-                            "offset": 171
-                          },
-                          "end": {
-                            "line": 11,
-                            "column": 16,
-                            "offset": 179
-                          }
-                        },
-                        "name": "handler",
-                        "curly": false
-                      },
-                      "right": {
-                        "kind": "closure",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 19,
-                            "offset": 182
-                          },
-                          "end": {
-                            "line": 13,
-                            "column": 9,
-                            "offset": 252
-                          }
-                        },
-                        "uses": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 38,
-                                "offset": 201
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 44,
-                                "offset": 207
-                              }
-                            },
-                            "name": "input",
-                            "curly": false
-                          }
-                        ],
-                        "arguments": [
-                          {
-                            "kind": "parameter",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 29,
-                                "offset": 192
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 31,
-                                "offset": 194
-                              }
-                            },
-                            "name": {
-                              "kind": "identifier",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 11,
-                                  "column": 29,
-                                  "offset": 192
-                                },
-                                "end": {
-                                  "line": 11,
-                                  "column": 31,
-                                  "offset": 194
-                                }
-                              },
-                              "name": "x"
-                            },
-                            "value": null,
-                            "type": null,
-                            "byref": false,
-                            "variadic": false,
-                            "readonly": false,
-                            "nullable": false,
-                            "flags": 0,
-                            "attrGroups": []
-                          }
-                        ],
-                        "byref": false,
-                        "type": null,
-                        "nullable": false,
-                        "isStatic": false,
-                        "body": {
-                          "kind": "block",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 46,
-                              "offset": 209
-                            },
-                            "end": {
-                              "line": 13,
-                              "column": 9,
-                              "offset": 252
-                            }
-                          },
-                          "children": [
-                            {
-                              "kind": "return",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 12,
-                                  "column": 12,
-                                  "offset": 223
-                                },
-                                "end": {
-                                  "line": 12,
-                                  "column": 31,
-                                  "offset": 242
-                                }
-                              },
-                              "expr": {
-                                "kind": "bin",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 12,
-                                    "column": 19,
-                                    "offset": 230
-                                  },
-                                  "end": {
-                                    "line": 12,
-                                    "column": 30,
-                                    "offset": 241
-                                  }
-                                },
-                                "type": "+",
-                                "left": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 19,
-                                      "offset": 230
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 21,
-                                      "offset": 232
-                                    }
-                                  },
-                                  "name": "x",
-                                  "curly": false
-                                },
-                                "right": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 24,
-                                      "offset": 235
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 30,
-                                      "offset": 241
-                                    }
-                                  },
-                                  "name": "input",
-                                  "curly": false
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        "attrGroups": []
-                      },
-                      "operator": "="
-                    }
-                  },
-                  {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 15,
-                        "column": 8,
-                        "offset": 263
-                      },
-                      "end": {
-                        "line": 15,
-                        "column": 25,
-                        "offset": 280
-                      }
-                    },
-                    "expression": {
-                      "kind": "assignref",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 15,
-                          "column": 8,
-                          "offset": 263
-                        },
-                        "end": {
-                          "line": 15,
-                          "column": 25,
-                          "offset": 280
-                        }
-                      },
-                      "left": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 15,
-                            "column": 8,
-                            "offset": 263
-                          },
-                          "end": {
-                            "line": 15,
-                            "column": 14,
-                            "offset": 269
-                          }
-                        },
-                        "name": "alias",
-                        "curly": false
-                      },
-                      "right": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 15,
-                            "column": 18,
-                            "offset": 273
-                          },
-                          "end": {
-                            "line": 15,
-                            "column": 24,
-                            "offset": 279
-                          }
-                        },
-                        "name": "input",
-                        "curly": false
-                      }
-                    }
-                  },
-                  {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 16,
-                        "column": 8,
-                        "offset": 289
-                      },
-                      "end": {
-                        "line": 16,
-                        "column": 28,
-                        "offset": 309
-                      }
-                    },
-                    "expression": {
-                      "kind": "assign",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 16,
-                          "column": 8,
-                          "offset": 289
-                        },
-                        "end": {
-                          "line": 16,
-                          "column": 28,
-                          "offset": 309
-                        }
-                      },
-                      "left": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 16,
-                            "column": 8,
-                            "offset": 289
-                          },
-                          "end": {
-                            "line": 16,
-                            "column": 13,
-                            "offset": 294
-                          }
-                        },
-                        "name": "copy",
-                        "curly": false
-                      },
-                      "right": {
-                        "kind": "clone",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 16,
-                            "column": 16,
-                            "offset": 297
-                          },
-                          "end": {
-                            "line": 16,
-                            "column": 27,
-                            "offset": 308
-                          }
-                        },
-                        "what": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 16,
-                              "column": 22,
-                              "offset": 303
-                            },
-                            "end": {
-                              "line": 16,
-                              "column": 27,
-                              "offset": 308
-                            }
-                          },
-                          "name": "this",
-                          "curly": false
-                        }
-                      },
-                      "operator": "="
-                    }
-                  },
-                  {
-                    "kind": "if",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 18,
-                        "column": 8,
-                        "offset": 319
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 9,
-                        "offset": 411
-                      }
-                    },
-                    "test": {
-                      "kind": "bin",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 18,
-                          "column": 12,
-                          "offset": 323
-                        },
-                        "end": {
-                          "line": 18,
-                          "column": 50,
-                          "offset": 361
-                        }
-                      },
-                      "type": "&&",
-                      "left": {
-                        "kind": "isset",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 18,
-                            "column": 12,
-                            "offset": 323
-                          },
-                          "end": {
-                            "line": 18,
-                            "column": 32,
-                            "offset": 343
-                          }
-                        },
-                        "variables": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 18,
-                                "offset": 329
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 24,
-                                "offset": 335
-                              }
-                            },
-                            "name": "alias",
-                            "curly": false
-                          },
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 26,
-                                "offset": 337
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 31,
-                                "offset": 342
-                              }
-                            },
-                            "name": "copy",
-                            "curly": false
-                          }
-                        ]
-                      },
-                      "right": {
-                        "kind": "unary",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 18,
-                            "column": 36,
-                            "offset": 347
-                          },
-                          "end": {
-                            "line": 18,
-                            "column": 50,
-                            "offset": 361
-                          }
-                        },
-                        "type": "!",
-                        "what": {
-                          "kind": "empty",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 18,
-                              "column": 37,
-                              "offset": 348
-                            },
-                            "end": {
-                              "line": 18,
-                              "column": 50,
-                              "offset": 361
-                            }
-                          },
-                          "expression": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 43,
-                                "offset": 354
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 49,
-                                "offset": 360
-                              }
-                            },
-                            "name": "input",
-                            "curly": false
-                          }
-                        }
-                      }
-                    },
-                    "body": {
-                      "kind": "block",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 18,
-                          "column": 52,
-                          "offset": 363
-                        },
-                        "end": {
-                          "line": 20,
-                          "column": 9,
-                          "offset": 411
-                        }
-                      },
-                      "children": [
-                        {
-                          "kind": "return",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 19,
-                              "column": 12,
-                              "offset": 377
-                            },
-                            "end": {
-                              "line": 19,
-                              "column": 36,
-                              "offset": 401
-                            }
-                          },
-                          "expr": {
-                            "kind": "call",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 19,
-                                "column": 19,
-                                "offset": 384
-                              },
-                              "end": {
-                                "line": 19,
-                                "column": 35,
-                                "offset": 400
-                              }
-                            },
-                            "what": {
-                              "kind": "variable",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 19,
-                                  "column": 19,
-                                  "offset": 384
-                                },
-                                "end": {
-                                  "line": 19,
-                                  "column": 27,
-                                  "offset": 392
-                                }
-                              },
-                              "name": "handler",
-                              "curly": false
-                            },
-                            "arguments": [
-                              {
-                                "kind": "variable",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 19,
-                                    "column": 28,
-                                    "offset": 393
-                                  },
-                                  "end": {
-                                    "line": 19,
-                                    "column": 34,
-                                    "offset": 399
-                                  }
-                                },
-                                "name": "alias",
-                                "curly": false
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    },
-                    "alternate": null,
-                    "shortForm": false
-                  },
-                  {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 8,
-                        "offset": 421
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 20,
-                        "offset": 433
-                      }
-                    },
-                    "expr": {
-                      "kind": "nullkeyword",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 22,
-                          "column": 15,
-                          "offset": 428
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 19,
-                          "offset": 432
-                        }
-                      },
-                      "raw": "null"
-                    }
-                  }
-                ]
-              },
-              "attrGroups": [],
-              "isAbstract": false,
-              "isFinal": false,
-              "isReadonly": false,
-              "visibility": "public",
-              "isStatic": false
-            }
-          ],
-          "attrGroups": [],
-          "isAbstract": false,
-          "isFinal": false,
-          "isReadonly": false
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
         }
       },
       "loc": {
@@ -6542,13 +1588,13 @@
           "line": 24,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -6560,1049 +1606,7 @@
         "line": 25,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
-    },
-    "origin": {
-      "kind": "program",
-      "loc": {
-        "source": null,
-        "start": {
-          "line": 1,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "line": 25,
-          "column": 0,
-          "offset": 442
-        }
-      },
-      "children": [
-        {
-          "kind": "class",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 7
-            },
-            "end": {
-              "line": 24,
-              "column": 1,
-              "offset": 441
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 6,
-                "offset": 13
-              },
-              "end": {
-                "line": 3,
-                "column": 10,
-                "offset": 17
-              }
-            },
-            "name": "Demo"
-          },
-          "isAnonymous": false,
-          "extends": {
-            "kind": "name",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 19,
-                "offset": 26
-              },
-              "end": {
-                "line": 3,
-                "column": 28,
-                "offset": 35
-              }
-            },
-            "name": "BaseClass",
-            "resolution": "uqn"
-          },
-          "implements": null,
-          "body": [
-            {
-              "kind": "propertystatement",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 5,
-                  "column": 11,
-                  "offset": 49
-                },
-                "end": {
-                  "line": 5,
-                  "column": 22,
-                  "offset": 60
-                }
-              },
-              "properties": [
-                {
-                  "kind": "property",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 11,
-                      "offset": 49
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 22,
-                      "offset": 60
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 11,
-                        "offset": 49
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 16,
-                        "offset": 54
-                      }
-                    },
-                    "name": "name"
-                  },
-                  "value": {
-                    "kind": "string",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 19,
-                        "offset": 57
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 22,
-                        "offset": 60
-                      }
-                    },
-                    "value": "x",
-                    "raw": "'x'",
-                    "unicode": false,
-                    "isDoubleQuote": false
-                  },
-                  "readonly": false,
-                  "nullable": false,
-                  "type": null,
-                  "attrGroups": []
-                }
-              ],
-              "visibility": "public",
-              "isStatic": false
-            },
-            {
-              "kind": "propertystatement",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 6,
-                  "column": 19,
-                  "offset": 81
-                },
-                "end": {
-                  "line": 6,
-                  "column": 29,
-                  "offset": 91
-                }
-              },
-              "properties": [
-                {
-                  "kind": "property",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 19,
-                      "offset": 81
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 29,
-                      "offset": 91
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 19,
-                        "offset": 81
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 25,
-                        "offset": 87
-                      }
-                    },
-                    "name": "count"
-                  },
-                  "value": {
-                    "kind": "number",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 28,
-                        "offset": 90
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 29,
-                        "offset": 91
-                      }
-                    },
-                    "value": "1"
-                  },
-                  "readonly": false,
-                  "nullable": false,
-                  "type": null,
-                  "attrGroups": []
-                }
-              ],
-              "visibility": "private",
-              "isStatic": true
-            },
-            {
-              "kind": "classconstant",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 7,
-                  "column": 10,
-                  "offset": 103
-                },
-                "end": {
-                  "line": 7,
-                  "column": 27,
-                  "offset": 120
-                }
-              },
-              "constants": [
-                {
-                  "kind": "constant",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 7,
-                      "column": 10,
-                      "offset": 103
-                    },
-                    "end": {
-                      "line": 7,
-                      "column": 27,
-                      "offset": 120
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 7,
-                        "column": 10,
-                        "offset": 103
-                      },
-                      "end": {
-                        "line": 7,
-                        "column": 23,
-                        "offset": 116
-                      }
-                    },
-                    "name": "DEFAULT_COUNT"
-                  },
-                  "value": {
-                    "kind": "number",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 7,
-                        "column": 26,
-                        "offset": 119
-                      },
-                      "end": {
-                        "line": 7,
-                        "column": 27,
-                        "offset": 120
-                      }
-                    },
-                    "value": "2"
-                  }
-                }
-              ],
-              "visibility": "",
-              "final": false,
-              "nullable": false,
-              "type": null,
-              "attrGroups": []
-            },
-            {
-              "kind": "method",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 9,
-                  "column": 4,
-                  "offset": 127
-                },
-                "end": {
-                  "line": 23,
-                  "column": 5,
-                  "offset": 439
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 9,
-                    "column": 20,
-                    "offset": 143
-                  },
-                  "end": {
-                    "line": 9,
-                    "column": 25,
-                    "offset": 148
-                  }
-                },
-                "name": "build"
-              },
-              "arguments": [
-                {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 9,
-                      "column": 26,
-                      "offset": 149
-                    },
-                    "end": {
-                      "line": 9,
-                      "column": 32,
-                      "offset": 155
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 26,
-                        "offset": 149
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 32,
-                        "offset": 155
-                      }
-                    },
-                    "name": "input"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": []
-                }
-              ],
-              "byref": false,
-              "type": null,
-              "nullable": false,
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 10,
-                    "column": 4,
-                    "offset": 161
-                  },
-                  "end": {
-                    "line": 23,
-                    "column": 5,
-                    "offset": 439
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 11,
-                        "column": 8,
-                        "offset": 171
-                      },
-                      "end": {
-                        "line": 13,
-                        "column": 10,
-                        "offset": 253
-                      }
-                    },
-                    "expression": {
-                      "kind": "assign",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 11,
-                          "column": 8,
-                          "offset": 171
-                        },
-                        "end": {
-                          "line": 13,
-                          "column": 10,
-                          "offset": 253
-                        }
-                      },
-                      "left": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 8,
-                            "offset": 171
-                          },
-                          "end": {
-                            "line": 11,
-                            "column": 16,
-                            "offset": 179
-                          }
-                        },
-                        "name": "handler",
-                        "curly": false
-                      },
-                      "right": {
-                        "kind": "closure",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 19,
-                            "offset": 182
-                          },
-                          "end": {
-                            "line": 13,
-                            "column": 9,
-                            "offset": 252
-                          }
-                        },
-                        "uses": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 38,
-                                "offset": 201
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 44,
-                                "offset": 207
-                              }
-                            },
-                            "name": "input",
-                            "curly": false
-                          }
-                        ],
-                        "arguments": [
-                          {
-                            "kind": "parameter",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 29,
-                                "offset": 192
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 31,
-                                "offset": 194
-                              }
-                            },
-                            "name": {
-                              "kind": "identifier",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 11,
-                                  "column": 29,
-                                  "offset": 192
-                                },
-                                "end": {
-                                  "line": 11,
-                                  "column": 31,
-                                  "offset": 194
-                                }
-                              },
-                              "name": "x"
-                            },
-                            "value": null,
-                            "type": null,
-                            "byref": false,
-                            "variadic": false,
-                            "readonly": false,
-                            "nullable": false,
-                            "flags": 0,
-                            "attrGroups": []
-                          }
-                        ],
-                        "byref": false,
-                        "type": null,
-                        "nullable": false,
-                        "isStatic": false,
-                        "body": {
-                          "kind": "block",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 46,
-                              "offset": 209
-                            },
-                            "end": {
-                              "line": 13,
-                              "column": 9,
-                              "offset": 252
-                            }
-                          },
-                          "children": [
-                            {
-                              "kind": "return",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 12,
-                                  "column": 12,
-                                  "offset": 223
-                                },
-                                "end": {
-                                  "line": 12,
-                                  "column": 31,
-                                  "offset": 242
-                                }
-                              },
-                              "expr": {
-                                "kind": "bin",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 12,
-                                    "column": 19,
-                                    "offset": 230
-                                  },
-                                  "end": {
-                                    "line": 12,
-                                    "column": 30,
-                                    "offset": 241
-                                  }
-                                },
-                                "type": "+",
-                                "left": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 19,
-                                      "offset": 230
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 21,
-                                      "offset": 232
-                                    }
-                                  },
-                                  "name": "x",
-                                  "curly": false
-                                },
-                                "right": {
-                                  "kind": "variable",
-                                  "loc": {
-                                    "source": null,
-                                    "start": {
-                                      "line": 12,
-                                      "column": 24,
-                                      "offset": 235
-                                    },
-                                    "end": {
-                                      "line": 12,
-                                      "column": 30,
-                                      "offset": 241
-                                    }
-                                  },
-                                  "name": "input",
-                                  "curly": false
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        "attrGroups": []
-                      },
-                      "operator": "="
-                    }
-                  },
-                  {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 15,
-                        "column": 8,
-                        "offset": 263
-                      },
-                      "end": {
-                        "line": 15,
-                        "column": 25,
-                        "offset": 280
-                      }
-                    },
-                    "expression": {
-                      "kind": "assignref",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 15,
-                          "column": 8,
-                          "offset": 263
-                        },
-                        "end": {
-                          "line": 15,
-                          "column": 25,
-                          "offset": 280
-                        }
-                      },
-                      "left": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 15,
-                            "column": 8,
-                            "offset": 263
-                          },
-                          "end": {
-                            "line": 15,
-                            "column": 14,
-                            "offset": 269
-                          }
-                        },
-                        "name": "alias",
-                        "curly": false
-                      },
-                      "right": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 15,
-                            "column": 18,
-                            "offset": 273
-                          },
-                          "end": {
-                            "line": 15,
-                            "column": 24,
-                            "offset": 279
-                          }
-                        },
-                        "name": "input",
-                        "curly": false
-                      }
-                    }
-                  },
-                  {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 16,
-                        "column": 8,
-                        "offset": 289
-                      },
-                      "end": {
-                        "line": 16,
-                        "column": 28,
-                        "offset": 309
-                      }
-                    },
-                    "expression": {
-                      "kind": "assign",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 16,
-                          "column": 8,
-                          "offset": 289
-                        },
-                        "end": {
-                          "line": 16,
-                          "column": 28,
-                          "offset": 309
-                        }
-                      },
-                      "left": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 16,
-                            "column": 8,
-                            "offset": 289
-                          },
-                          "end": {
-                            "line": 16,
-                            "column": 13,
-                            "offset": 294
-                          }
-                        },
-                        "name": "copy",
-                        "curly": false
-                      },
-                      "right": {
-                        "kind": "clone",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 16,
-                            "column": 16,
-                            "offset": 297
-                          },
-                          "end": {
-                            "line": 16,
-                            "column": 27,
-                            "offset": 308
-                          }
-                        },
-                        "what": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 16,
-                              "column": 22,
-                              "offset": 303
-                            },
-                            "end": {
-                              "line": 16,
-                              "column": 27,
-                              "offset": 308
-                            }
-                          },
-                          "name": "this",
-                          "curly": false
-                        }
-                      },
-                      "operator": "="
-                    }
-                  },
-                  {
-                    "kind": "if",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 18,
-                        "column": 8,
-                        "offset": 319
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 9,
-                        "offset": 411
-                      }
-                    },
-                    "test": {
-                      "kind": "bin",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 18,
-                          "column": 12,
-                          "offset": 323
-                        },
-                        "end": {
-                          "line": 18,
-                          "column": 50,
-                          "offset": 361
-                        }
-                      },
-                      "type": "&&",
-                      "left": {
-                        "kind": "isset",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 18,
-                            "column": 12,
-                            "offset": 323
-                          },
-                          "end": {
-                            "line": 18,
-                            "column": 32,
-                            "offset": 343
-                          }
-                        },
-                        "variables": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 18,
-                                "offset": 329
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 24,
-                                "offset": 335
-                              }
-                            },
-                            "name": "alias",
-                            "curly": false
-                          },
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 26,
-                                "offset": 337
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 31,
-                                "offset": 342
-                              }
-                            },
-                            "name": "copy",
-                            "curly": false
-                          }
-                        ]
-                      },
-                      "right": {
-                        "kind": "unary",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 18,
-                            "column": 36,
-                            "offset": 347
-                          },
-                          "end": {
-                            "line": 18,
-                            "column": 50,
-                            "offset": 361
-                          }
-                        },
-                        "type": "!",
-                        "what": {
-                          "kind": "empty",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 18,
-                              "column": 37,
-                              "offset": 348
-                            },
-                            "end": {
-                              "line": 18,
-                              "column": 50,
-                              "offset": 361
-                            }
-                          },
-                          "expression": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 18,
-                                "column": 43,
-                                "offset": 354
-                              },
-                              "end": {
-                                "line": 18,
-                                "column": 49,
-                                "offset": 360
-                              }
-                            },
-                            "name": "input",
-                            "curly": false
-                          }
-                        }
-                      }
-                    },
-                    "body": {
-                      "kind": "block",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 18,
-                          "column": 52,
-                          "offset": 363
-                        },
-                        "end": {
-                          "line": 20,
-                          "column": 9,
-                          "offset": 411
-                        }
-                      },
-                      "children": [
-                        {
-                          "kind": "return",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 19,
-                              "column": 12,
-                              "offset": 377
-                            },
-                            "end": {
-                              "line": 19,
-                              "column": 36,
-                              "offset": 401
-                            }
-                          },
-                          "expr": {
-                            "kind": "call",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 19,
-                                "column": 19,
-                                "offset": 384
-                              },
-                              "end": {
-                                "line": 19,
-                                "column": 35,
-                                "offset": 400
-                              }
-                            },
-                            "what": {
-                              "kind": "variable",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 19,
-                                  "column": 19,
-                                  "offset": 384
-                                },
-                                "end": {
-                                  "line": 19,
-                                  "column": 27,
-                                  "offset": 392
-                                }
-                              },
-                              "name": "handler",
-                              "curly": false
-                            },
-                            "arguments": [
-                              {
-                                "kind": "variable",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 19,
-                                    "column": 28,
-                                    "offset": 393
-                                  },
-                                  "end": {
-                                    "line": 19,
-                                    "column": 34,
-                                    "offset": 399
-                                  }
-                                },
-                                "name": "alias",
-                                "curly": false
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    },
-                    "alternate": null,
-                    "shortForm": false
-                  },
-                  {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 8,
-                        "offset": 421
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 20,
-                        "offset": 433
-                      }
-                    },
-                    "expr": {
-                      "kind": "nullkeyword",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 22,
-                          "column": 15,
-                          "offset": 428
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 19,
-                          "offset": 432
-                        }
-                      },
-                      "raw": "null"
-                    }
-                  }
-                ]
-              },
-              "attrGroups": [],
-              "isAbstract": false,
-              "isFinal": false,
-              "isReadonly": false,
-              "visibility": "public",
-              "isStatic": false
-            }
-          ],
-          "attrGroups": [],
-          "isAbstract": false,
-          "isFinal": false,
-          "isReadonly": false
-        }
-      ],
-      "errors": [],
-      "comments": []
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
     }
   },
   "loc": {
@@ -7614,6 +1618,6 @@
       "line": 25,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/closure-class.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/closure-class.php.json
+++ b/parser-PHP/tests/benchmark/base/closure-class.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 11
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+            "sourcefile": "closure-class.php"
           }
         },
         "loc": {
@@ -28,7 +28,7 @@
             "line": 3,
             "column": 11
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+          "sourcefile": "closure-class.php"
         }
       },
       "body": [
@@ -47,7 +47,7 @@
                   "line": 5,
                   "column": 17
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "closure-class.php"
               }
             },
             "loc": {
@@ -59,7 +59,7 @@
                 "line": 5,
                 "column": 17
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "closure-class.php"
             }
           },
           "init": {
@@ -76,7 +76,7 @@
                   "line": 5,
                   "column": 23
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "closure-class.php"
               }
             },
             "loc": {
@@ -88,7 +88,7 @@
                 "line": 5,
                 "column": 23
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "closure-class.php"
             }
           },
           "cloned": false,
@@ -110,7 +110,7 @@
                 "line": 5,
                 "column": 23
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "closure-class.php"
             }
           },
           "loc": {
@@ -122,7 +122,7 @@
               "line": 5,
               "column": 23
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+            "sourcefile": "closure-class.php"
           }
         },
         {
@@ -140,7 +140,7 @@
                   "line": 6,
                   "column": 26
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "closure-class.php"
               }
             },
             "loc": {
@@ -152,7 +152,7 @@
                 "line": 6,
                 "column": 26
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "closure-class.php"
             }
           },
           "init": {
@@ -169,7 +169,7 @@
                   "line": 6,
                   "column": 30
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "closure-class.php"
               }
             },
             "loc": {
@@ -181,7 +181,7 @@
                 "line": 6,
                 "column": 30
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "closure-class.php"
             }
           },
           "cloned": false,
@@ -203,7 +203,7 @@
                 "line": 6,
                 "column": 30
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "closure-class.php"
             }
           },
           "loc": {
@@ -215,7 +215,7 @@
               "line": 6,
               "column": 30
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+            "sourcefile": "closure-class.php"
           }
         },
         {
@@ -233,7 +233,7 @@
                   "line": 7,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "closure-class.php"
               }
             },
             "loc": {
@@ -245,7 +245,7 @@
                 "line": 7,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "closure-class.php"
             }
           },
           "init": {
@@ -262,7 +262,7 @@
                   "line": 7,
                   "column": 28
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "closure-class.php"
               }
             },
             "loc": {
@@ -274,7 +274,7 @@
                 "line": 7,
                 "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "closure-class.php"
             }
           },
           "cloned": false,
@@ -294,7 +294,7 @@
                 "line": 7,
                 "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "closure-class.php"
             }
           },
           "loc": {
@@ -306,7 +306,7 @@
               "line": 7,
               "column": 28
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+            "sourcefile": "closure-class.php"
           }
         },
         {
@@ -324,7 +324,7 @@
                   "line": 9,
                   "column": 26
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "closure-class.php"
               }
             },
             "loc": {
@@ -336,7 +336,7 @@
                 "line": 9,
                 "column": 26
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "closure-class.php"
             }
           },
           "parameters": [
@@ -355,7 +355,7 @@
                       "line": 9,
                       "column": 33
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "closure-class.php"
                   }
                 },
                 "loc": {
@@ -367,7 +367,7 @@
                     "line": 9,
                     "column": 33
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "closure-class.php"
                 }
               },
               "init": null,
@@ -388,7 +388,7 @@
                     "line": 9,
                     "column": 33
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "closure-class.php"
                 }
               },
               "loc": {
@@ -400,7 +400,7 @@
                   "line": 9,
                   "column": 33
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "closure-class.php"
               }
             }
           ],
@@ -429,7 +429,7 @@
                           "line": 11,
                           "column": 17
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "closure-class.php"
                       }
                     },
                     "loc": {
@@ -441,7 +441,7 @@
                         "line": 11,
                         "column": 17
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "closure-class.php"
                     }
                   },
                   "right": {
@@ -463,7 +463,7 @@
                                 "line": 11,
                                 "column": 32
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "closure-class.php"
                             }
                           },
                           "loc": {
@@ -475,7 +475,7 @@
                               "line": 11,
                               "column": 32
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "closure-class.php"
                           }
                         },
                         "init": null,
@@ -496,7 +496,7 @@
                               "line": 11,
                               "column": 32
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "closure-class.php"
                           }
                         },
                         "loc": {
@@ -508,7 +508,7 @@
                             "line": 11,
                             "column": 32
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "closure-class.php"
                         }
                       }
                     ],
@@ -538,7 +538,7 @@
                                     "line": 12,
                                     "column": 22
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                                  "sourcefile": "closure-class.php"
                                 }
                               },
                               "loc": {
@@ -550,7 +550,7 @@
                                   "line": 12,
                                   "column": 22
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                                "sourcefile": "closure-class.php"
                               }
                             },
                             "right": {
@@ -566,7 +566,7 @@
                                     "line": 12,
                                     "column": 31
                                   },
-                                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                                  "sourcefile": "closure-class.php"
                                 }
                               },
                               "loc": {
@@ -578,7 +578,7 @@
                                   "line": 12,
                                   "column": 31
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                                "sourcefile": "closure-class.php"
                               }
                             },
                             "_meta": {
@@ -591,7 +591,7 @@
                                   "line": 12,
                                   "column": 31
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                                "sourcefile": "closure-class.php"
                               }
                             },
                             "loc": {
@@ -603,7 +603,7 @@
                                 "line": 12,
                                 "column": 31
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "closure-class.php"
                             }
                           },
                           "isYield": false,
@@ -617,7 +617,7 @@
                                 "line": 12,
                                 "column": 32
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "closure-class.php"
                             }
                           },
                           "loc": {
@@ -629,7 +629,7 @@
                               "line": 12,
                               "column": 32
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "closure-class.php"
                           }
                         }
                       ],
@@ -644,7 +644,7 @@
                             "line": 13,
                             "column": 10
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "closure-class.php"
                         }
                       },
                       "loc": {
@@ -656,7 +656,7 @@
                           "line": 13,
                           "column": 10
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "closure-class.php"
                       }
                     },
                     "modifiers": [],
@@ -670,7 +670,7 @@
                           "line": 13,
                           "column": 10
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "closure-class.php"
                       },
                       "uses": [
                         {
@@ -686,7 +686,7 @@
                                 "line": 11,
                                 "column": 45
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "closure-class.php"
                             }
                           },
                           "loc": {
@@ -698,7 +698,7 @@
                               "line": 11,
                               "column": 45
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "closure-class.php"
                           }
                         }
                       ]
@@ -712,7 +712,7 @@
                         "line": 13,
                         "column": 10
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "closure-class.php"
                     }
                   },
                   "operator": "=",
@@ -727,7 +727,7 @@
                         "line": 13,
                         "column": 10
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "closure-class.php"
                     }
                   },
                   "loc": {
@@ -739,7 +739,7 @@
                       "line": 13,
                       "column": 10
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "closure-class.php"
                   }
                 },
                 "_meta": {
@@ -752,7 +752,7 @@
                       "line": 13,
                       "column": 11
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "closure-class.php"
                   }
                 },
                 "loc": {
@@ -764,7 +764,7 @@
                     "line": 13,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "closure-class.php"
                 }
               },
               {
@@ -784,7 +784,7 @@
                           "line": 15,
                           "column": 15
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "closure-class.php"
                       }
                     },
                     "loc": {
@@ -796,7 +796,7 @@
                         "line": 15,
                         "column": 15
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "closure-class.php"
                     }
                   },
                   "right": {
@@ -812,7 +812,7 @@
                           "line": 15,
                           "column": 25
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "closure-class.php"
                       }
                     },
                     "loc": {
@@ -824,7 +824,7 @@
                         "line": 15,
                         "column": 25
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "closure-class.php"
                     }
                   },
                   "operator": "=",
@@ -840,7 +840,7 @@
                         "line": 15,
                         "column": 25
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "closure-class.php"
                     }
                   },
                   "loc": {
@@ -852,7 +852,7 @@
                       "line": 15,
                       "column": 25
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "closure-class.php"
                   }
                 },
                 "_meta": {
@@ -865,7 +865,7 @@
                       "line": 15,
                       "column": 26
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "closure-class.php"
                   }
                 },
                 "loc": {
@@ -877,7 +877,7 @@
                     "line": 15,
                     "column": 26
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "closure-class.php"
                 }
               },
               {
@@ -897,7 +897,7 @@
                           "line": 16,
                           "column": 14
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "closure-class.php"
                       }
                     },
                     "loc": {
@@ -909,7 +909,7 @@
                         "line": 16,
                         "column": 14
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "closure-class.php"
                     }
                   },
                   "right": {
@@ -933,7 +933,7 @@
                               "line": 16,
                               "column": 28
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "closure-class.php"
                           }
                         },
                         "loc": {
@@ -945,7 +945,7 @@
                             "line": 16,
                             "column": 28
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "closure-class.php"
                         }
                       }
                     ],
@@ -959,7 +959,7 @@
                           "line": 16,
                           "column": 28
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "closure-class.php"
                       }
                     },
                     "loc": {
@@ -971,7 +971,7 @@
                         "line": 16,
                         "column": 28
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "closure-class.php"
                     }
                   },
                   "operator": "=",
@@ -986,7 +986,7 @@
                         "line": 16,
                         "column": 28
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "closure-class.php"
                     }
                   },
                   "loc": {
@@ -998,7 +998,7 @@
                       "line": 16,
                       "column": 28
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "closure-class.php"
                   }
                 },
                 "_meta": {
@@ -1011,7 +1011,7 @@
                       "line": 16,
                       "column": 29
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "closure-class.php"
                   }
                 },
                 "loc": {
@@ -1023,7 +1023,7 @@
                     "line": 16,
                     "column": 29
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "closure-class.php"
                 }
               },
               {
@@ -1046,7 +1046,7 @@
                             "line": 18,
                             "column": 18
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "closure-class.php"
                         }
                       },
                       "loc": {
@@ -1058,7 +1058,7 @@
                           "line": 18,
                           "column": 18
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "closure-class.php"
                       }
                     },
                     "arguments": [
@@ -1075,7 +1075,7 @@
                               "line": 18,
                               "column": 25
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "closure-class.php"
                           }
                         },
                         "loc": {
@@ -1087,7 +1087,7 @@
                             "line": 18,
                             "column": 25
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "closure-class.php"
                         }
                       },
                       {
@@ -1103,7 +1103,7 @@
                               "line": 18,
                               "column": 32
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "closure-class.php"
                           }
                         },
                         "loc": {
@@ -1115,7 +1115,7 @@
                             "line": 18,
                             "column": 32
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "closure-class.php"
                         }
                       }
                     ],
@@ -1129,7 +1129,7 @@
                           "line": 18,
                           "column": 33
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "closure-class.php"
                       }
                     },
                     "loc": {
@@ -1141,7 +1141,7 @@
                         "line": 18,
                         "column": 33
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "closure-class.php"
                     }
                   },
                   "right": {
@@ -1162,7 +1162,7 @@
                               "line": 18,
                               "column": 43
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "closure-class.php"
                           }
                         },
                         "loc": {
@@ -1174,7 +1174,7 @@
                             "line": 18,
                             "column": 43
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "closure-class.php"
                         }
                       },
                       "arguments": [
@@ -1191,7 +1191,7 @@
                                 "line": 18,
                                 "column": 50
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "closure-class.php"
                             }
                           },
                           "loc": {
@@ -1203,7 +1203,7 @@
                               "line": 18,
                               "column": 50
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "closure-class.php"
                           }
                         }
                       ],
@@ -1217,7 +1217,7 @@
                             "line": 18,
                             "column": 51
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "closure-class.php"
                         }
                       },
                       "loc": {
@@ -1229,7 +1229,7 @@
                           "line": 18,
                           "column": 51
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "closure-class.php"
                       }
                     },
                     "isSuffix": false,
@@ -1243,7 +1243,7 @@
                           "line": 18,
                           "column": 51
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "closure-class.php"
                       }
                     },
                     "loc": {
@@ -1255,7 +1255,7 @@
                         "line": 18,
                         "column": 51
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "closure-class.php"
                     }
                   },
                   "_meta": {
@@ -1268,7 +1268,7 @@
                         "line": 18,
                         "column": 51
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "closure-class.php"
                     }
                   },
                   "loc": {
@@ -1280,7 +1280,7 @@
                       "line": 18,
                       "column": 51
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "closure-class.php"
                   }
                 },
                 "consequent": {
@@ -1303,7 +1303,7 @@
                                 "line": 19,
                                 "column": 28
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "closure-class.php"
                             }
                           },
                           "loc": {
@@ -1315,7 +1315,7 @@
                               "line": 19,
                               "column": 28
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "closure-class.php"
                           }
                         },
                         "arguments": [
@@ -1332,7 +1332,7 @@
                                   "line": 19,
                                   "column": 35
                                 },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                                "sourcefile": "closure-class.php"
                               }
                             },
                             "loc": {
@@ -1344,7 +1344,7 @@
                                 "line": 19,
                                 "column": 35
                               },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                              "sourcefile": "closure-class.php"
                             }
                           }
                         ],
@@ -1358,7 +1358,7 @@
                               "line": 19,
                               "column": 36
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                            "sourcefile": "closure-class.php"
                           }
                         },
                         "loc": {
@@ -1370,7 +1370,7 @@
                             "line": 19,
                             "column": 36
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "closure-class.php"
                         }
                       },
                       "isYield": false,
@@ -1384,7 +1384,7 @@
                             "line": 19,
                             "column": 37
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                          "sourcefile": "closure-class.php"
                         }
                       },
                       "loc": {
@@ -1396,7 +1396,7 @@
                           "line": 19,
                           "column": 37
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                        "sourcefile": "closure-class.php"
                       }
                     }
                   ],
@@ -1411,7 +1411,7 @@
                         "line": 20,
                         "column": 10
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "closure-class.php"
                     }
                   },
                   "loc": {
@@ -1423,7 +1423,7 @@
                       "line": 20,
                       "column": 10
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "closure-class.php"
                   }
                 },
                 "alternative": null,
@@ -1437,7 +1437,7 @@
                       "line": 20,
                       "column": 10
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "closure-class.php"
                   }
                 },
                 "loc": {
@@ -1449,7 +1449,7 @@
                     "line": 20,
                     "column": 10
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "closure-class.php"
                 }
               },
               {
@@ -1468,7 +1468,7 @@
                         "line": 22,
                         "column": 20
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                      "sourcefile": "closure-class.php"
                     }
                   },
                   "loc": {
@@ -1480,7 +1480,7 @@
                       "line": 22,
                       "column": 20
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "closure-class.php"
                   }
                 },
                 "isYield": false,
@@ -1494,7 +1494,7 @@
                       "line": 22,
                       "column": 21
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                    "sourcefile": "closure-class.php"
                   }
                 },
                 "loc": {
@@ -1506,7 +1506,7 @@
                     "line": 22,
                     "column": 21
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                  "sourcefile": "closure-class.php"
                 }
               }
             ],
@@ -1521,7 +1521,7 @@
                   "line": 23,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+                "sourcefile": "closure-class.php"
               }
             },
             "loc": {
@@ -1533,7 +1533,7 @@
                 "line": 23,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "closure-class.php"
             }
           },
           "modifiers": [
@@ -1549,7 +1549,7 @@
                 "line": 23,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+              "sourcefile": "closure-class.php"
             }
           },
           "loc": {
@@ -1561,7 +1561,7 @@
               "line": 23,
               "column": 6
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+            "sourcefile": "closure-class.php"
           }
         }
       ],
@@ -1576,7 +1576,7 @@
             "line": 24,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+          "sourcefile": "closure-class.php"
         }
       },
       "loc": {
@@ -1588,13 +1588,13 @@
           "line": 24,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+        "sourcefile": "closure-class.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php",
+  "uri": "closure-class.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -1606,7 +1606,7 @@
         "line": 25,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+      "sourcefile": "closure-class.php"
     }
   },
   "loc": {
@@ -1618,6 +1618,6 @@
       "line": 25,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/closure-class.php"
+    "sourcefile": "closure-class.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/control-flow.php.json
+++ b/parser-PHP/tests/benchmark/base/control-flow.php.json
@@ -18,25 +18,7 @@
                 "line": 3,
                 "column": 8
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-            },
-            "origin": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 5,
-                  "offset": 12
-                },
-                "end": {
-                  "line": 3,
-                  "column": 7,
-                  "offset": 14
-                }
-              },
-              "name": "i",
-              "curly": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "loc": {
@@ -48,7 +30,7 @@
               "line": 3,
               "column": 8
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "right": {
@@ -65,24 +47,7 @@
                 "line": 3,
                 "column": 12
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-            },
-            "origin": {
-              "kind": "number",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 10,
-                  "offset": 17
-                },
-                "end": {
-                  "line": 3,
-                  "column": 11,
-                  "offset": 18
-                }
-              },
-              "value": "0"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "loc": {
@@ -94,7 +59,7 @@
               "line": 3,
               "column": 12
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "operator": "=",
@@ -109,59 +74,7 @@
               "line": 3,
               "column": 12
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-          },
-          "origin": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 5,
-                "offset": 12
-              },
-              "end": {
-                "line": 3,
-                "column": 11,
-                "offset": 18
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 5,
-                  "offset": 12
-                },
-                "end": {
-                  "line": 3,
-                  "column": 7,
-                  "offset": 14
-                }
-              },
-              "name": "i",
-              "curly": false
-            },
-            "right": {
-              "kind": "number",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 10,
-                  "offset": 17
-                },
-                "end": {
-                  "line": 3,
-                  "column": 11,
-                  "offset": 18
-                }
-              },
-              "value": "0"
-            },
-            "operator": "="
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -173,7 +86,7 @@
             "line": 3,
             "column": 12
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "test": {
@@ -192,25 +105,7 @@
                 "line": 3,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-            },
-            "origin": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 13,
-                  "offset": 20
-                },
-                "end": {
-                  "line": 3,
-                  "column": 15,
-                  "offset": 22
-                }
-              },
-              "name": "i",
-              "curly": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "loc": {
@@ -222,7 +117,7 @@
               "line": 3,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "right": {
@@ -239,24 +134,7 @@
                 "line": 3,
                 "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-            },
-            "origin": {
-              "kind": "number",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 18,
-                  "offset": 25
-                },
-                "end": {
-                  "line": 3,
-                  "column": 19,
-                  "offset": 26
-                }
-              },
-              "value": "3"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "loc": {
@@ -268,7 +146,7 @@
               "line": 3,
               "column": 20
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "_meta": {
@@ -281,59 +159,7 @@
               "line": 3,
               "column": 20
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-          },
-          "origin": {
-            "kind": "bin",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 13,
-                "offset": 20
-              },
-              "end": {
-                "line": 3,
-                "column": 19,
-                "offset": 26
-              }
-            },
-            "type": "<",
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 13,
-                  "offset": 20
-                },
-                "end": {
-                  "line": 3,
-                  "column": 15,
-                  "offset": 22
-                }
-              },
-              "name": "i",
-              "curly": false
-            },
-            "right": {
-              "kind": "number",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 18,
-                  "offset": 25
-                },
-                "end": {
-                  "line": 3,
-                  "column": 19,
-                  "offset": 26
-                }
-              },
-              "value": "3"
-            }
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -345,7 +171,7 @@
             "line": 3,
             "column": 20
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "update": {
@@ -364,25 +190,7 @@
                 "line": 3,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-            },
-            "origin": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 21,
-                  "offset": 28
-                },
-                "end": {
-                  "line": 3,
-                  "column": 23,
-                  "offset": 30
-                }
-              },
-              "name": "i",
-              "curly": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "loc": {
@@ -394,7 +202,7 @@
               "line": 3,
               "column": 24
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "isSuffix": true,
@@ -408,42 +216,7 @@
               "line": 3,
               "column": 26
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-          },
-          "origin": {
-            "kind": "post",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 21,
-                "offset": 28
-              },
-              "end": {
-                "line": 3,
-                "column": 25,
-                "offset": 32
-              }
-            },
-            "type": "+",
-            "what": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 21,
-                  "offset": 28
-                },
-                "end": {
-                  "line": 3,
-                  "column": 23,
-                  "offset": 30
-                }
-              },
-              "name": "i",
-              "curly": false
-            }
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -455,7 +228,7 @@
             "line": 3,
             "column": 26
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "body": {
@@ -484,25 +257,7 @@
                         "line": 4,
                         "column": 12
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                    },
-                    "origin": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 4,
-                          "column": 9,
-                          "offset": 45
-                        },
-                        "end": {
-                          "line": 4,
-                          "column": 11,
-                          "offset": 47
-                        }
-                      },
-                      "name": "i",
-                      "curly": false
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                     }
                   },
                   "loc": {
@@ -514,7 +269,7 @@
                       "line": 4,
                       "column": 12
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 }
               ],
@@ -528,44 +283,7 @@
                     "line": 4,
                     "column": 13
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                },
-                "origin": {
-                  "kind": "echo",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 4,
-                      "column": 4,
-                      "offset": 40
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 12,
-                      "offset": 48
-                    }
-                  },
-                  "shortForm": false,
-                  "expressions": [
-                    {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 4,
-                          "column": 9,
-                          "offset": 45
-                        },
-                        "end": {
-                          "line": 4,
-                          "column": 11,
-                          "offset": 47
-                        }
-                      },
-                      "name": "i",
-                      "curly": false
-                    }
-                  ]
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "loc": {
@@ -577,7 +295,7 @@
                   "line": 4,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "_meta": {
@@ -590,44 +308,7 @@
                   "line": 4,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-              },
-              "origin": {
-                "kind": "echo",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 4,
-                    "column": 4,
-                    "offset": 40
-                  },
-                  "end": {
-                    "line": 4,
-                    "column": 12,
-                    "offset": 48
-                  }
-                },
-                "shortForm": false,
-                "expressions": [
-                  {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 4,
-                        "column": 9,
-                        "offset": 45
-                      },
-                      "end": {
-                        "line": 4,
-                        "column": 11,
-                        "offset": 47
-                      }
-                    },
-                    "name": "i",
-                    "curly": false
-                  }
-                ]
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -639,7 +320,7 @@
                 "line": 4,
                 "column": 13
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           }
         ],
@@ -654,62 +335,7 @@
               "line": 5,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-          },
-          "origin": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 27,
-                "offset": 34
-              },
-              "end": {
-                "line": 5,
-                "column": 1,
-                "offset": 50
-              }
-            },
-            "children": [
-              {
-                "kind": "echo",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 4,
-                    "column": 4,
-                    "offset": 40
-                  },
-                  "end": {
-                    "line": 4,
-                    "column": 12,
-                    "offset": 48
-                  }
-                },
-                "shortForm": false,
-                "expressions": [
-                  {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 4,
-                        "column": 9,
-                        "offset": 45
-                      },
-                      "end": {
-                        "line": 4,
-                        "column": 11,
-                        "offset": 47
-                      }
-                    },
-                    "name": "i",
-                    "curly": false
-                  }
-                ]
-              }
-            ]
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -721,7 +347,7 @@
             "line": 5,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "_meta": {
@@ -734,224 +360,7 @@
             "line": 5,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-        },
-        "origin": {
-          "kind": "for",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 7
-            },
-            "end": {
-              "line": 5,
-              "column": 1,
-              "offset": 50
-            }
-          },
-          "init": [
-            {
-              "kind": "assign",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 5,
-                  "offset": 12
-                },
-                "end": {
-                  "line": 3,
-                  "column": 11,
-                  "offset": 18
-                }
-              },
-              "left": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 5,
-                    "offset": 12
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 7,
-                    "offset": 14
-                  }
-                },
-                "name": "i",
-                "curly": false
-              },
-              "right": {
-                "kind": "number",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 10,
-                    "offset": 17
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 11,
-                    "offset": 18
-                  }
-                },
-                "value": "0"
-              },
-              "operator": "="
-            }
-          ],
-          "test": [
-            {
-              "kind": "bin",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 13,
-                  "offset": 20
-                },
-                "end": {
-                  "line": 3,
-                  "column": 19,
-                  "offset": 26
-                }
-              },
-              "type": "<",
-              "left": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 13,
-                    "offset": 20
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 15,
-                    "offset": 22
-                  }
-                },
-                "name": "i",
-                "curly": false
-              },
-              "right": {
-                "kind": "number",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 18,
-                    "offset": 25
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 19,
-                    "offset": 26
-                  }
-                },
-                "value": "3"
-              }
-            }
-          ],
-          "increment": [
-            {
-              "kind": "post",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 21,
-                  "offset": 28
-                },
-                "end": {
-                  "line": 3,
-                  "column": 25,
-                  "offset": 32
-                }
-              },
-              "type": "+",
-              "what": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 21,
-                    "offset": 28
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 23,
-                    "offset": 30
-                  }
-                },
-                "name": "i",
-                "curly": false
-              }
-            }
-          ],
-          "shortForm": false,
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 27,
-                "offset": 34
-              },
-              "end": {
-                "line": 5,
-                "column": 1,
-                "offset": 50
-              }
-            },
-            "children": [
-              {
-                "kind": "echo",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 4,
-                    "column": 4,
-                    "offset": 40
-                  },
-                  "end": {
-                    "line": 4,
-                    "column": 12,
-                    "offset": 48
-                  }
-                },
-                "shortForm": false,
-                "expressions": [
-                  {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 4,
-                        "column": 9,
-                        "offset": 45
-                      },
-                      "end": {
-                        "line": 4,
-                        "column": 11,
-                        "offset": 47
-                      }
-                    },
-                    "name": "i",
-                    "curly": false
-                  }
-                ]
-              }
-            ]
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "loc": {
@@ -963,7 +372,7 @@
           "line": 5,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
       }
     },
     {
@@ -983,25 +392,7 @@
                 "line": 7,
                 "column": 22
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-            },
-            "origin": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 7,
-                  "column": 19,
-                  "offset": 71
-                },
-                "end": {
-                  "line": 7,
-                  "column": 21,
-                  "offset": 73
-                }
-              },
-              "name": "k",
-              "curly": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "loc": {
@@ -1013,7 +404,7 @@
               "line": 7,
               "column": 22
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "init": null,
@@ -1033,25 +424,7 @@
               "line": 7,
               "column": 22
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-          },
-          "origin": {
-            "kind": "variable",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 7,
-                "column": 19,
-                "offset": 71
-              },
-              "end": {
-                "line": 7,
-                "column": 21,
-                "offset": 73
-              }
-            },
-            "name": "k",
-            "curly": false
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -1063,7 +436,7 @@
             "line": 7,
             "column": 22
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "value": {
@@ -1081,25 +454,7 @@
                 "line": 7,
                 "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-            },
-            "origin": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 7,
-                  "column": 25,
-                  "offset": 77
-                },
-                "end": {
-                  "line": 7,
-                  "column": 27,
-                  "offset": 79
-                }
-              },
-              "name": "v",
-              "curly": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "loc": {
@@ -1111,7 +466,7 @@
               "line": 7,
               "column": 28
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "init": null,
@@ -1131,25 +486,7 @@
               "line": 7,
               "column": 28
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-          },
-          "origin": {
-            "kind": "variable",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 7,
-                "column": 25,
-                "offset": 77
-              },
-              "end": {
-                "line": 7,
-                "column": 27,
-                "offset": 79
-              }
-            },
-            "name": "v",
-            "curly": false
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -1161,7 +498,7 @@
             "line": 7,
             "column": 28
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "right": {
@@ -1177,25 +514,7 @@
               "line": 7,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-          },
-          "origin": {
-            "kind": "variable",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 7,
-                "column": 9,
-                "offset": 61
-              },
-              "end": {
-                "line": 7,
-                "column": 15,
-                "offset": 67
-              }
-            },
-            "name": "items",
-            "curly": false
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -1207,7 +526,7 @@
             "line": 7,
             "column": 16
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "body": {
@@ -1228,25 +547,7 @@
                     "line": 8,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                },
-                "origin": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 8,
-                      "offset": 91
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 10,
-                      "offset": 93
-                    }
-                  },
-                  "name": "v",
-                  "curly": false
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "loc": {
@@ -1258,7 +559,7 @@
                   "line": 8,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "consequent": {
@@ -1268,7 +569,6 @@
                   "type": "ContinueStatement",
                   "label": null,
                   "_meta": {
-                    "level": null,
                     "loc": {
                       "start": {
                         "line": 9,
@@ -1278,24 +578,7 @@
                         "line": 9,
                         "column": 18
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                    },
-                    "origin": {
-                      "kind": "continue",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 8,
-                          "offset": 105
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 17,
-                          "offset": 114
-                        }
-                      },
-                      "level": null
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                     }
                   },
                   "loc": {
@@ -1307,7 +590,7 @@
                       "line": 9,
                       "column": 18
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 }
               ],
@@ -1322,42 +605,7 @@
                     "line": 10,
                     "column": 6
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                },
-                "origin": {
-                  "kind": "block",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 12,
-                      "offset": 95
-                    },
-                    "end": {
-                      "line": 10,
-                      "column": 5,
-                      "offset": 120
-                    }
-                  },
-                  "children": [
-                    {
-                      "kind": "continue",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 8,
-                          "offset": 105
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 17,
-                          "offset": 114
-                        }
-                      },
-                      "level": null
-                    }
-                  ]
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "loc": {
@@ -1369,7 +617,7 @@
                   "line": 10,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "alternative": null,
@@ -1383,78 +631,7 @@
                   "line": 10,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-              },
-              "origin": {
-                "kind": "if",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 8,
-                    "column": 4,
-                    "offset": 87
-                  },
-                  "end": {
-                    "line": 10,
-                    "column": 5,
-                    "offset": 120
-                  }
-                },
-                "test": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 8,
-                      "offset": 91
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 10,
-                      "offset": 93
-                    }
-                  },
-                  "name": "v",
-                  "curly": false
-                },
-                "body": {
-                  "kind": "block",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 12,
-                      "offset": 95
-                    },
-                    "end": {
-                      "line": 10,
-                      "column": 5,
-                      "offset": 120
-                    }
-                  },
-                  "children": [
-                    {
-                      "kind": "continue",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 8,
-                          "offset": 105
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 17,
-                          "offset": 114
-                        }
-                      },
-                      "level": null
-                    }
-                  ]
-                },
-                "alternate": null,
-                "shortForm": false
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -1466,14 +643,13 @@
                 "line": 10,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           {
             "type": "BreakStatement",
             "label": null,
             "_meta": {
-              "level": null,
               "loc": {
                 "start": {
                   "line": 11,
@@ -1483,24 +659,7 @@
                   "line": 11,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-              },
-              "origin": {
-                "kind": "break",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 11,
-                    "column": 4,
-                    "offset": 125
-                  },
-                  "end": {
-                    "line": 11,
-                    "column": 10,
-                    "offset": 131
-                  }
-                },
-                "level": null
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -1512,7 +671,7 @@
                 "line": 11,
                 "column": 11
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           }
         ],
@@ -1527,113 +686,7 @@
               "line": 12,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-          },
-          "origin": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 7,
-                "column": 29,
-                "offset": 81
-              },
-              "end": {
-                "line": 12,
-                "column": 1,
-                "offset": 133
-              }
-            },
-            "children": [
-              {
-                "kind": "if",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 8,
-                    "column": 4,
-                    "offset": 87
-                  },
-                  "end": {
-                    "line": 10,
-                    "column": 5,
-                    "offset": 120
-                  }
-                },
-                "test": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 8,
-                      "offset": 91
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 10,
-                      "offset": 93
-                    }
-                  },
-                  "name": "v",
-                  "curly": false
-                },
-                "body": {
-                  "kind": "block",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 12,
-                      "offset": 95
-                    },
-                    "end": {
-                      "line": 10,
-                      "column": 5,
-                      "offset": 120
-                    }
-                  },
-                  "children": [
-                    {
-                      "kind": "continue",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 8,
-                          "offset": 105
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 17,
-                          "offset": 114
-                        }
-                      },
-                      "level": null
-                    }
-                  ]
-                },
-                "alternate": null,
-                "shortForm": false
-              },
-              {
-                "kind": "break",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 11,
-                    "column": 4,
-                    "offset": 125
-                  },
-                  "end": {
-                    "line": 11,
-                    "column": 10,
-                    "offset": 131
-                  }
-                },
-                "level": null
-              }
-            ]
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -1645,7 +698,7 @@
             "line": 12,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "_meta": {
@@ -1658,184 +711,7 @@
             "line": 12,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-        },
-        "origin": {
-          "kind": "foreach",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 7,
-              "column": 0,
-              "offset": 52
-            },
-            "end": {
-              "line": 12,
-              "column": 1,
-              "offset": 133
-            }
-          },
-          "source": {
-            "kind": "variable",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 7,
-                "column": 9,
-                "offset": 61
-              },
-              "end": {
-                "line": 7,
-                "column": 15,
-                "offset": 67
-              }
-            },
-            "name": "items",
-            "curly": false
-          },
-          "key": {
-            "kind": "variable",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 7,
-                "column": 19,
-                "offset": 71
-              },
-              "end": {
-                "line": 7,
-                "column": 21,
-                "offset": 73
-              }
-            },
-            "name": "k",
-            "curly": false
-          },
-          "value": {
-            "kind": "variable",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 7,
-                "column": 25,
-                "offset": 77
-              },
-              "end": {
-                "line": 7,
-                "column": 27,
-                "offset": 79
-              }
-            },
-            "name": "v",
-            "curly": false
-          },
-          "shortForm": false,
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 7,
-                "column": 29,
-                "offset": 81
-              },
-              "end": {
-                "line": 12,
-                "column": 1,
-                "offset": 133
-              }
-            },
-            "children": [
-              {
-                "kind": "if",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 8,
-                    "column": 4,
-                    "offset": 87
-                  },
-                  "end": {
-                    "line": 10,
-                    "column": 5,
-                    "offset": 120
-                  }
-                },
-                "test": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 8,
-                      "offset": 91
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 10,
-                      "offset": 93
-                    }
-                  },
-                  "name": "v",
-                  "curly": false
-                },
-                "body": {
-                  "kind": "block",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 12,
-                      "offset": 95
-                    },
-                    "end": {
-                      "line": 10,
-                      "column": 5,
-                      "offset": 120
-                    }
-                  },
-                  "children": [
-                    {
-                      "kind": "continue",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 8,
-                          "offset": 105
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 17,
-                          "offset": 114
-                        }
-                      },
-                      "level": null
-                    }
-                  ]
-                },
-                "alternate": null,
-                "shortForm": false
-              },
-              {
-                "kind": "break",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 11,
-                    "column": 4,
-                    "offset": 125
-                  },
-                  "end": {
-                    "line": 11,
-                    "column": 10,
-                    "offset": 131
-                  }
-                },
-                "level": null
-              }
-            ]
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "loc": {
@@ -1847,7 +723,7 @@
           "line": 12,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
       }
     },
     {
@@ -1865,25 +741,7 @@
               "line": 14,
               "column": 11
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-          },
-          "origin": {
-            "kind": "variable",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 14,
-                "column": 7,
-                "offset": 142
-              },
-              "end": {
-                "line": 14,
-                "column": 10,
-                "offset": 145
-              }
-            },
-            "name": "ok",
-            "curly": false
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -1895,7 +753,7 @@
             "line": 14,
             "column": 11
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "body": {
@@ -1918,25 +776,7 @@
                       "line": 15,
                       "column": 10
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                  },
-                  "origin": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 15,
-                        "column": 4,
-                        "offset": 153
-                      },
-                      "end": {
-                        "line": 15,
-                        "column": 9,
-                        "offset": 158
-                      }
-                    },
-                    "name": "risky",
-                    "resolution": "uqn"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "loc": {
@@ -1948,7 +788,7 @@
                     "line": 15,
                     "column": 10
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "arguments": [],
@@ -1960,44 +800,9 @@
                   },
                   "end": {
                     "line": 15,
-                    "column": 13
+                    "column": 12
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                },
-                "origin": {
-                  "kind": "call",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 15,
-                      "column": 4,
-                      "offset": 153
-                    },
-                    "end": {
-                      "line": 15,
-                      "column": 12,
-                      "offset": 161
-                    }
-                  },
-                  "what": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 15,
-                        "column": 4,
-                        "offset": 153
-                      },
-                      "end": {
-                        "line": 15,
-                        "column": 9,
-                        "offset": 158
-                      }
-                    },
-                    "name": "risky",
-                    "resolution": "uqn"
-                  },
-                  "arguments": []
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "loc": {
@@ -2007,9 +812,9 @@
                 },
                 "end": {
                   "line": 15,
-                  "column": 13
+                  "column": 12
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "_meta": {
@@ -2022,58 +827,7 @@
                   "line": 15,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-              },
-              "origin": {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 15,
-                    "column": 4,
-                    "offset": 153
-                  },
-                  "end": {
-                    "line": 15,
-                    "column": 12,
-                    "offset": 161
-                  }
-                },
-                "expression": {
-                  "kind": "call",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 15,
-                      "column": 4,
-                      "offset": 153
-                    },
-                    "end": {
-                      "line": 15,
-                      "column": 12,
-                      "offset": 161
-                    }
-                  },
-                  "what": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 15,
-                        "column": 4,
-                        "offset": 153
-                      },
-                      "end": {
-                        "line": 15,
-                        "column": 9,
-                        "offset": 158
-                      }
-                    },
-                    "name": "risky",
-                    "resolution": "uqn"
-                  },
-                  "arguments": []
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -2085,14 +839,13 @@
                 "line": 15,
                 "column": 13
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           {
             "type": "BreakStatement",
             "label": null,
             "_meta": {
-              "level": null,
               "loc": {
                 "start": {
                   "line": 16,
@@ -2102,24 +855,7 @@
                   "line": 16,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-              },
-              "origin": {
-                "kind": "break",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 16,
-                    "column": 4,
-                    "offset": 166
-                  },
-                  "end": {
-                    "line": 16,
-                    "column": 10,
-                    "offset": 172
-                  }
-                },
-                "level": null
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -2131,7 +867,7 @@
                 "line": 16,
                 "column": 11
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           }
         ],
@@ -2146,93 +882,7 @@
               "line": 17,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-          },
-          "origin": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 14,
-                "column": 12,
-                "offset": 147
-              },
-              "end": {
-                "line": 17,
-                "column": 1,
-                "offset": 174
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 15,
-                    "column": 4,
-                    "offset": 153
-                  },
-                  "end": {
-                    "line": 15,
-                    "column": 12,
-                    "offset": 161
-                  }
-                },
-                "expression": {
-                  "kind": "call",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 15,
-                      "column": 4,
-                      "offset": 153
-                    },
-                    "end": {
-                      "line": 15,
-                      "column": 12,
-                      "offset": 161
-                    }
-                  },
-                  "what": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 15,
-                        "column": 4,
-                        "offset": 153
-                      },
-                      "end": {
-                        "line": 15,
-                        "column": 9,
-                        "offset": 158
-                      }
-                    },
-                    "name": "risky",
-                    "resolution": "uqn"
-                  },
-                  "arguments": []
-                }
-              },
-              {
-                "kind": "break",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 16,
-                    "column": 4,
-                    "offset": 166
-                  },
-                  "end": {
-                    "line": 16,
-                    "column": 10,
-                    "offset": 172
-                  }
-                },
-                "level": null
-              }
-            ]
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -2244,7 +894,7 @@
             "line": 17,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "isPostTest": false,
@@ -2258,128 +908,7 @@
             "line": 17,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-        },
-        "origin": {
-          "kind": "while",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 14,
-              "column": 0,
-              "offset": 135
-            },
-            "end": {
-              "line": 17,
-              "column": 1,
-              "offset": 174
-            }
-          },
-          "test": {
-            "kind": "variable",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 14,
-                "column": 7,
-                "offset": 142
-              },
-              "end": {
-                "line": 14,
-                "column": 10,
-                "offset": 145
-              }
-            },
-            "name": "ok",
-            "curly": false
-          },
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 14,
-                "column": 12,
-                "offset": 147
-              },
-              "end": {
-                "line": 17,
-                "column": 1,
-                "offset": 174
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 15,
-                    "column": 4,
-                    "offset": 153
-                  },
-                  "end": {
-                    "line": 15,
-                    "column": 12,
-                    "offset": 161
-                  }
-                },
-                "expression": {
-                  "kind": "call",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 15,
-                      "column": 4,
-                      "offset": 153
-                    },
-                    "end": {
-                      "line": 15,
-                      "column": 12,
-                      "offset": 161
-                    }
-                  },
-                  "what": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 15,
-                        "column": 4,
-                        "offset": 153
-                      },
-                      "end": {
-                        "line": 15,
-                        "column": 9,
-                        "offset": 158
-                      }
-                    },
-                    "name": "risky",
-                    "resolution": "uqn"
-                  },
-                  "arguments": []
-                }
-              },
-              {
-                "kind": "break",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 16,
-                    "column": 4,
-                    "offset": 166
-                  },
-                  "end": {
-                    "line": 16,
-                    "column": 10,
-                    "offset": 172
-                  }
-                },
-                "level": null
-              }
-            ]
-          },
-          "shortForm": false
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "loc": {
@@ -2391,7 +920,7 @@
           "line": 17,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
       }
     },
     {
@@ -2409,25 +938,7 @@
               "line": 21,
               "column": 15
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-          },
-          "origin": {
-            "kind": "variable",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 21,
-                "column": 9,
-                "offset": 202
-              },
-              "end": {
-                "line": 21,
-                "column": 14,
-                "offset": 207
-              }
-            },
-            "name": "flag",
-            "curly": false
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -2439,7 +950,7 @@
             "line": 21,
             "column": 15
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "body": {
@@ -2462,25 +973,7 @@
                       "line": 20,
                       "column": 7
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                  },
-                  "origin": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 4,
-                        "offset": 185
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 6,
-                        "offset": 187
-                      }
-                    },
-                    "name": "x",
-                    "curly": false
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "loc": {
@@ -2492,7 +985,7 @@
                     "line": 20,
                     "column": 7
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "right": {
@@ -2509,24 +1002,7 @@
                       "line": 20,
                       "column": 11
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                  },
-                  "origin": {
-                    "kind": "number",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 9,
-                        "offset": 190
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 10,
-                        "offset": 191
-                      }
-                    },
-                    "value": "1"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "loc": {
@@ -2538,7 +1014,7 @@
                     "line": 20,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "operator": "=",
@@ -2551,61 +1027,9 @@
                   },
                   "end": {
                     "line": 20,
-                    "column": 12
+                    "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                },
-                "origin": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 20,
-                      "column": 4,
-                      "offset": 185
-                    },
-                    "end": {
-                      "line": 20,
-                      "column": 11,
-                      "offset": 192
-                    }
-                  },
-                  "left": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 4,
-                        "offset": 185
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 6,
-                        "offset": 187
-                      }
-                    },
-                    "name": "x",
-                    "curly": false
-                  },
-                  "right": {
-                    "kind": "number",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 9,
-                        "offset": 190
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 10,
-                        "offset": 191
-                      }
-                    },
-                    "value": "1"
-                  },
-                  "operator": "="
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "loc": {
@@ -2615,9 +1039,9 @@
                 },
                 "end": {
                   "line": 20,
-                  "column": 12
+                  "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "_meta": {
@@ -2630,75 +1054,7 @@
                   "line": 20,
                   "column": 12
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-              },
-              "origin": {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 20,
-                    "column": 4,
-                    "offset": 185
-                  },
-                  "end": {
-                    "line": 20,
-                    "column": 11,
-                    "offset": 192
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 20,
-                      "column": 4,
-                      "offset": 185
-                    },
-                    "end": {
-                      "line": 20,
-                      "column": 11,
-                      "offset": 192
-                    }
-                  },
-                  "left": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 4,
-                        "offset": 185
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 6,
-                        "offset": 187
-                      }
-                    },
-                    "name": "x",
-                    "curly": false
-                  },
-                  "right": {
-                    "kind": "number",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 9,
-                        "offset": 190
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 10,
-                        "offset": 191
-                      }
-                    },
-                    "value": "1"
-                  },
-                  "operator": "="
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -2710,7 +1066,7 @@
                 "line": 20,
                 "column": 12
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           }
         ],
@@ -2725,93 +1081,7 @@
               "line": 21,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-          },
-          "origin": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 19,
-                "column": 3,
-                "offset": 179
-              },
-              "end": {
-                "line": 21,
-                "column": 1,
-                "offset": 194
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 20,
-                    "column": 4,
-                    "offset": 185
-                  },
-                  "end": {
-                    "line": 20,
-                    "column": 11,
-                    "offset": 192
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 20,
-                      "column": 4,
-                      "offset": 185
-                    },
-                    "end": {
-                      "line": 20,
-                      "column": 11,
-                      "offset": 192
-                    }
-                  },
-                  "left": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 4,
-                        "offset": 185
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 6,
-                        "offset": 187
-                      }
-                    },
-                    "name": "x",
-                    "curly": false
-                  },
-                  "right": {
-                    "kind": "number",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 9,
-                        "offset": 190
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 10,
-                        "offset": 191
-                      }
-                    },
-                    "value": "1"
-                  },
-                  "operator": "="
-                }
-              }
-            ]
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -2823,7 +1093,7 @@
             "line": 21,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "isPostTest": true,
@@ -2837,127 +1107,7 @@
             "line": 21,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-        },
-        "origin": {
-          "kind": "do",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 19,
-              "column": 0,
-              "offset": 176
-            },
-            "end": {
-              "line": 21,
-              "column": 16,
-              "offset": 209
-            }
-          },
-          "test": {
-            "kind": "variable",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 21,
-                "column": 9,
-                "offset": 202
-              },
-              "end": {
-                "line": 21,
-                "column": 14,
-                "offset": 207
-              }
-            },
-            "name": "flag",
-            "curly": false
-          },
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 19,
-                "column": 3,
-                "offset": 179
-              },
-              "end": {
-                "line": 21,
-                "column": 1,
-                "offset": 194
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 20,
-                    "column": 4,
-                    "offset": 185
-                  },
-                  "end": {
-                    "line": 20,
-                    "column": 11,
-                    "offset": 192
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 20,
-                      "column": 4,
-                      "offset": 185
-                    },
-                    "end": {
-                      "line": 20,
-                      "column": 11,
-                      "offset": 192
-                    }
-                  },
-                  "left": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 4,
-                        "offset": 185
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 6,
-                        "offset": 187
-                      }
-                    },
-                    "name": "x",
-                    "curly": false
-                  },
-                  "right": {
-                    "kind": "number",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 9,
-                        "offset": 190
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 10,
-                        "offset": 191
-                      }
-                    },
-                    "value": "1"
-                  },
-                  "operator": "="
-                }
-              }
-            ]
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "loc": {
@@ -2969,7 +1119,7 @@
           "line": 21,
           "column": 17
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
       }
     },
     {
@@ -2987,25 +1137,7 @@
               "line": 23,
               "column": 11
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-          },
-          "origin": {
-            "kind": "variable",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 23,
-                "column": 8,
-                "offset": 219
-              },
-              "end": {
-                "line": 23,
-                "column": 10,
-                "offset": 221
-              }
-            },
-            "name": "x",
-            "curly": false
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -3017,7 +1149,7 @@
             "line": 23,
             "column": 11
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "cases": [
@@ -3037,24 +1169,7 @@
                   "line": 24,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-              },
-              "origin": {
-                "kind": "number",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 24,
-                    "column": 9,
-                    "offset": 234
-                  },
-                  "end": {
-                    "line": 24,
-                    "column": 10,
-                    "offset": 235
-                  }
-                },
-                "value": "1"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -3066,7 +1181,7 @@
                 "line": 24,
                 "column": 11
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "body": {
@@ -3089,25 +1204,7 @@
                           "line": 25,
                           "column": 12
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                      },
-                      "origin": {
-                        "kind": "name",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 8,
-                            "offset": 245
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 11,
-                            "offset": 248
-                          }
-                        },
-                        "name": "foo",
-                        "resolution": "uqn"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                       }
                     },
                     "loc": {
@@ -3119,7 +1216,7 @@
                         "line": 25,
                         "column": 12
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                     }
                   },
                   "arguments": [],
@@ -3131,44 +1228,9 @@
                       },
                       "end": {
                         "line": 25,
-                        "column": 15
+                        "column": 14
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                    },
-                    "origin": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 8,
-                          "offset": 245
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 14,
-                          "offset": 251
-                        }
-                      },
-                      "what": {
-                        "kind": "name",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 8,
-                            "offset": 245
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 11,
-                            "offset": 248
-                          }
-                        },
-                        "name": "foo",
-                        "resolution": "uqn"
-                      },
-                      "arguments": []
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                     }
                   },
                   "loc": {
@@ -3178,9 +1240,9 @@
                     },
                     "end": {
                       "line": 25,
-                      "column": 15
+                      "column": 14
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "_meta": {
@@ -3193,58 +1255,7 @@
                       "line": 25,
                       "column": 15
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                  },
-                  "origin": {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 25,
-                        "column": 8,
-                        "offset": 245
-                      },
-                      "end": {
-                        "line": 25,
-                        "column": 14,
-                        "offset": 251
-                      }
-                    },
-                    "expression": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 8,
-                          "offset": 245
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 14,
-                          "offset": 251
-                        }
-                      },
-                      "what": {
-                        "kind": "name",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 8,
-                            "offset": 245
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 11,
-                            "offset": 248
-                          }
-                        },
-                        "name": "foo",
-                        "resolution": "uqn"
-                      },
-                      "arguments": []
-                    }
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "loc": {
@@ -3256,14 +1267,13 @@
                     "line": 25,
                     "column": 15
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               {
                 "type": "BreakStatement",
                 "label": null,
                 "_meta": {
-                  "level": null,
                   "loc": {
                     "start": {
                       "line": 26,
@@ -3273,24 +1283,7 @@
                       "line": 26,
                       "column": 15
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                  },
-                  "origin": {
-                    "kind": "break",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 26,
-                        "column": 8,
-                        "offset": 260
-                      },
-                      "end": {
-                        "line": 26,
-                        "column": 14,
-                        "offset": 266
-                      }
-                    },
-                    "level": null
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "loc": {
@@ -3302,7 +1295,7 @@
                     "line": 26,
                     "column": 15
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               }
             ],
@@ -3310,112 +1303,26 @@
             "_meta": {
               "loc": {
                 "start": {
-                  "line": 25,
-                  "column": 9
+                  "line": 24,
+                  "column": 5
                 },
                 "end": {
                   "line": 26,
                   "column": 15
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-              },
-              "origin": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 25,
-                    "column": 8,
-                    "offset": 245
-                  },
-                  "end": {
-                    "line": 26,
-                    "column": 14,
-                    "offset": 266
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 25,
-                        "column": 8,
-                        "offset": 245
-                      },
-                      "end": {
-                        "line": 25,
-                        "column": 14,
-                        "offset": 251
-                      }
-                    },
-                    "expression": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 8,
-                          "offset": 245
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 14,
-                          "offset": 251
-                        }
-                      },
-                      "what": {
-                        "kind": "name",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 8,
-                            "offset": 245
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 11,
-                            "offset": 248
-                          }
-                        },
-                        "name": "foo",
-                        "resolution": "uqn"
-                      },
-                      "arguments": []
-                    }
-                  },
-                  {
-                    "kind": "break",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 26,
-                        "column": 8,
-                        "offset": 260
-                      },
-                      "end": {
-                        "line": 26,
-                        "column": 14,
-                        "offset": 266
-                      }
-                    },
-                    "level": null
-                  }
-                ]
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
               "start": {
-                "line": 25,
-                "column": 9
+                "line": 24,
+                "column": 5
               },
               "end": {
                 "line": 26,
                 "column": 15
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "_meta": {
@@ -3428,126 +1335,7 @@
                 "line": 26,
                 "column": 15
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-            },
-            "origin": {
-              "kind": "case",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 24,
-                  "column": 4,
-                  "offset": 229
-                },
-                "end": {
-                  "line": 26,
-                  "column": 14,
-                  "offset": 266
-                }
-              },
-              "test": {
-                "kind": "number",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 24,
-                    "column": 9,
-                    "offset": 234
-                  },
-                  "end": {
-                    "line": 24,
-                    "column": 10,
-                    "offset": 235
-                  }
-                },
-                "value": "1"
-              },
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 25,
-                    "column": 8,
-                    "offset": 245
-                  },
-                  "end": {
-                    "line": 26,
-                    "column": 14,
-                    "offset": 266
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 25,
-                        "column": 8,
-                        "offset": 245
-                      },
-                      "end": {
-                        "line": 25,
-                        "column": 14,
-                        "offset": 251
-                      }
-                    },
-                    "expression": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 8,
-                          "offset": 245
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 14,
-                          "offset": 251
-                        }
-                      },
-                      "what": {
-                        "kind": "name",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 8,
-                            "offset": 245
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 11,
-                            "offset": 248
-                          }
-                        },
-                        "name": "foo",
-                        "resolution": "uqn"
-                      },
-                      "arguments": []
-                    }
-                  },
-                  {
-                    "kind": "break",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 26,
-                        "column": 8,
-                        "offset": 260
-                      },
-                      "end": {
-                        "line": 26,
-                        "column": 14,
-                        "offset": 266
-                      }
-                    },
-                    "level": null
-                  }
-                ]
-              }
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "loc": {
@@ -3559,7 +1347,7 @@
               "line": 26,
               "column": 15
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         {
@@ -3585,25 +1373,7 @@
                           "line": 28,
                           "column": 12
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                      },
-                      "origin": {
-                        "kind": "name",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 28,
-                            "column": 8,
-                            "offset": 288
-                          },
-                          "end": {
-                            "line": 28,
-                            "column": 11,
-                            "offset": 291
-                          }
-                        },
-                        "name": "bar",
-                        "resolution": "uqn"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                       }
                     },
                     "loc": {
@@ -3615,7 +1385,7 @@
                         "line": 28,
                         "column": 12
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                     }
                   },
                   "arguments": [],
@@ -3627,44 +1397,9 @@
                       },
                       "end": {
                         "line": 28,
-                        "column": 15
+                        "column": 14
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                    },
-                    "origin": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 28,
-                          "column": 8,
-                          "offset": 288
-                        },
-                        "end": {
-                          "line": 28,
-                          "column": 14,
-                          "offset": 294
-                        }
-                      },
-                      "what": {
-                        "kind": "name",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 28,
-                            "column": 8,
-                            "offset": 288
-                          },
-                          "end": {
-                            "line": 28,
-                            "column": 11,
-                            "offset": 291
-                          }
-                        },
-                        "name": "bar",
-                        "resolution": "uqn"
-                      },
-                      "arguments": []
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                     }
                   },
                   "loc": {
@@ -3674,9 +1409,9 @@
                     },
                     "end": {
                       "line": 28,
-                      "column": 15
+                      "column": 14
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "_meta": {
@@ -3689,58 +1424,7 @@
                       "line": 28,
                       "column": 15
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                  },
-                  "origin": {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 28,
-                        "column": 8,
-                        "offset": 288
-                      },
-                      "end": {
-                        "line": 28,
-                        "column": 14,
-                        "offset": 294
-                      }
-                    },
-                    "expression": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 28,
-                          "column": 8,
-                          "offset": 288
-                        },
-                        "end": {
-                          "line": 28,
-                          "column": 14,
-                          "offset": 294
-                        }
-                      },
-                      "what": {
-                        "kind": "name",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 28,
-                            "column": 8,
-                            "offset": 288
-                          },
-                          "end": {
-                            "line": 28,
-                            "column": 11,
-                            "offset": 291
-                          }
-                        },
-                        "name": "bar",
-                        "resolution": "uqn"
-                      },
-                      "arguments": []
-                    }
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "loc": {
@@ -3752,7 +1436,7 @@
                     "line": 28,
                     "column": 15
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               }
             ],
@@ -3760,95 +1444,26 @@
             "_meta": {
               "loc": {
                 "start": {
-                  "line": 28,
-                  "column": 9
+                  "line": 27,
+                  "column": 5
                 },
                 "end": {
                   "line": 28,
                   "column": 15
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-              },
-              "origin": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 28,
-                    "column": 8,
-                    "offset": 288
-                  },
-                  "end": {
-                    "line": 28,
-                    "column": 14,
-                    "offset": 294
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 28,
-                        "column": 8,
-                        "offset": 288
-                      },
-                      "end": {
-                        "line": 28,
-                        "column": 14,
-                        "offset": 294
-                      }
-                    },
-                    "expression": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 28,
-                          "column": 8,
-                          "offset": 288
-                        },
-                        "end": {
-                          "line": 28,
-                          "column": 14,
-                          "offset": 294
-                        }
-                      },
-                      "what": {
-                        "kind": "name",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 28,
-                            "column": 8,
-                            "offset": 288
-                          },
-                          "end": {
-                            "line": 28,
-                            "column": 11,
-                            "offset": 291
-                          }
-                        },
-                        "name": "bar",
-                        "resolution": "uqn"
-                      },
-                      "arguments": []
-                    }
-                  }
-                ]
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
               "start": {
-                "line": 28,
-                "column": 9
+                "line": 27,
+                "column": 5
               },
               "end": {
                 "line": 28,
                 "column": 15
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "_meta": {
@@ -3861,93 +1476,7 @@
                 "line": 28,
                 "column": 15
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-            },
-            "origin": {
-              "kind": "case",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 27,
-                  "column": 4,
-                  "offset": 271
-                },
-                "end": {
-                  "line": 28,
-                  "column": 14,
-                  "offset": 294
-                }
-              },
-              "test": null,
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 28,
-                    "column": 8,
-                    "offset": 288
-                  },
-                  "end": {
-                    "line": 28,
-                    "column": 14,
-                    "offset": 294
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "expressionstatement",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 28,
-                        "column": 8,
-                        "offset": 288
-                      },
-                      "end": {
-                        "line": 28,
-                        "column": 14,
-                        "offset": 294
-                      }
-                    },
-                    "expression": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 28,
-                          "column": 8,
-                          "offset": 288
-                        },
-                        "end": {
-                          "line": 28,
-                          "column": 14,
-                          "offset": 294
-                        }
-                      },
-                      "what": {
-                        "kind": "name",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 28,
-                            "column": 8,
-                            "offset": 288
-                          },
-                          "end": {
-                            "line": 28,
-                            "column": 11,
-                            "offset": 291
-                          }
-                        },
-                        "name": "bar",
-                        "resolution": "uqn"
-                      },
-                      "arguments": []
-                    }
-                  }
-                ]
-              }
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "loc": {
@@ -3959,7 +1488,7 @@
               "line": 28,
               "column": 15
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         }
       ],
@@ -3973,265 +1502,7 @@
             "line": 29,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-        },
-        "origin": {
-          "kind": "switch",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 23,
-              "column": 0,
-              "offset": 211
-            },
-            "end": {
-              "line": 29,
-              "column": 1,
-              "offset": 296
-            }
-          },
-          "test": {
-            "kind": "variable",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 23,
-                "column": 8,
-                "offset": 219
-              },
-              "end": {
-                "line": 23,
-                "column": 10,
-                "offset": 221
-              }
-            },
-            "name": "x",
-            "curly": false
-          },
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 23,
-                "column": 12,
-                "offset": 223
-              },
-              "end": {
-                "line": 29,
-                "column": 1,
-                "offset": 296
-              }
-            },
-            "children": [
-              {
-                "kind": "case",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 24,
-                    "column": 4,
-                    "offset": 229
-                  },
-                  "end": {
-                    "line": 26,
-                    "column": 14,
-                    "offset": 266
-                  }
-                },
-                "test": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 24,
-                      "column": 9,
-                      "offset": 234
-                    },
-                    "end": {
-                      "line": 24,
-                      "column": 10,
-                      "offset": 235
-                    }
-                  },
-                  "value": "1"
-                },
-                "body": {
-                  "kind": "block",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 25,
-                      "column": 8,
-                      "offset": 245
-                    },
-                    "end": {
-                      "line": 26,
-                      "column": 14,
-                      "offset": 266
-                    }
-                  },
-                  "children": [
-                    {
-                      "kind": "expressionstatement",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 8,
-                          "offset": 245
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 14,
-                          "offset": 251
-                        }
-                      },
-                      "expression": {
-                        "kind": "call",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 8,
-                            "offset": 245
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 14,
-                            "offset": 251
-                          }
-                        },
-                        "what": {
-                          "kind": "name",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 25,
-                              "column": 8,
-                              "offset": 245
-                            },
-                            "end": {
-                              "line": 25,
-                              "column": 11,
-                              "offset": 248
-                            }
-                          },
-                          "name": "foo",
-                          "resolution": "uqn"
-                        },
-                        "arguments": []
-                      }
-                    },
-                    {
-                      "kind": "break",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 26,
-                          "column": 8,
-                          "offset": 260
-                        },
-                        "end": {
-                          "line": 26,
-                          "column": 14,
-                          "offset": 266
-                        }
-                      },
-                      "level": null
-                    }
-                  ]
-                }
-              },
-              {
-                "kind": "case",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 27,
-                    "column": 4,
-                    "offset": 271
-                  },
-                  "end": {
-                    "line": 28,
-                    "column": 14,
-                    "offset": 294
-                  }
-                },
-                "test": null,
-                "body": {
-                  "kind": "block",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 28,
-                      "column": 8,
-                      "offset": 288
-                    },
-                    "end": {
-                      "line": 28,
-                      "column": 14,
-                      "offset": 294
-                    }
-                  },
-                  "children": [
-                    {
-                      "kind": "expressionstatement",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 28,
-                          "column": 8,
-                          "offset": 288
-                        },
-                        "end": {
-                          "line": 28,
-                          "column": 14,
-                          "offset": 294
-                        }
-                      },
-                      "expression": {
-                        "kind": "call",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 28,
-                            "column": 8,
-                            "offset": 288
-                          },
-                          "end": {
-                            "line": 28,
-                            "column": 14,
-                            "offset": 294
-                          }
-                        },
-                        "what": {
-                          "kind": "name",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 28,
-                              "column": 8,
-                              "offset": 288
-                            },
-                            "end": {
-                              "line": 28,
-                              "column": 11,
-                              "offset": 291
-                            }
-                          },
-                          "name": "bar",
-                          "resolution": "uqn"
-                        },
-                        "arguments": []
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          "shortForm": false
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "loc": {
@@ -4243,7 +1514,7 @@
           "line": 29,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
       }
     },
     {
@@ -4268,25 +1539,7 @@
                       "line": 32,
                       "column": 10
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                  },
-                  "origin": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 32,
-                        "column": 4,
-                        "offset": 308
-                      },
-                      "end": {
-                        "line": 32,
-                        "column": 9,
-                        "offset": 313
-                      }
-                    },
-                    "name": "risky",
-                    "resolution": "uqn"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "loc": {
@@ -4298,7 +1551,7 @@
                     "line": 32,
                     "column": 10
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "arguments": [],
@@ -4310,44 +1563,9 @@
                   },
                   "end": {
                     "line": 32,
-                    "column": 13
+                    "column": 12
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                },
-                "origin": {
-                  "kind": "call",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 32,
-                      "column": 4,
-                      "offset": 308
-                    },
-                    "end": {
-                      "line": 32,
-                      "column": 12,
-                      "offset": 316
-                    }
-                  },
-                  "what": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 32,
-                        "column": 4,
-                        "offset": 308
-                      },
-                      "end": {
-                        "line": 32,
-                        "column": 9,
-                        "offset": 313
-                      }
-                    },
-                    "name": "risky",
-                    "resolution": "uqn"
-                  },
-                  "arguments": []
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "loc": {
@@ -4357,9 +1575,9 @@
                 },
                 "end": {
                   "line": 32,
-                  "column": 13
+                  "column": 12
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "_meta": {
@@ -4372,58 +1590,7 @@
                   "line": 32,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-              },
-              "origin": {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 32,
-                    "column": 4,
-                    "offset": 308
-                  },
-                  "end": {
-                    "line": 32,
-                    "column": 12,
-                    "offset": 316
-                  }
-                },
-                "expression": {
-                  "kind": "call",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 32,
-                      "column": 4,
-                      "offset": 308
-                    },
-                    "end": {
-                      "line": 32,
-                      "column": 12,
-                      "offset": 316
-                    }
-                  },
-                  "what": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 32,
-                        "column": 4,
-                        "offset": 308
-                      },
-                      "end": {
-                        "line": 32,
-                        "column": 9,
-                        "offset": 313
-                      }
-                    },
-                    "name": "risky",
-                    "resolution": "uqn"
-                  },
-                  "arguments": []
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -4435,7 +1602,7 @@
                 "line": 32,
                 "column": 13
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           }
         ],
@@ -4450,76 +1617,7 @@
               "line": 33,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-          },
-          "origin": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 31,
-                "column": 4,
-                "offset": 302
-              },
-              "end": {
-                "line": 33,
-                "column": 1,
-                "offset": 318
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 32,
-                    "column": 4,
-                    "offset": 308
-                  },
-                  "end": {
-                    "line": 32,
-                    "column": 12,
-                    "offset": 316
-                  }
-                },
-                "expression": {
-                  "kind": "call",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 32,
-                      "column": 4,
-                      "offset": 308
-                    },
-                    "end": {
-                      "line": 32,
-                      "column": 12,
-                      "offset": 316
-                    }
-                  },
-                  "what": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 32,
-                        "column": 4,
-                        "offset": 308
-                      },
-                      "end": {
-                        "line": 32,
-                        "column": 9,
-                        "offset": 313
-                      }
-                    },
-                    "name": "risky",
-                    "resolution": "uqn"
-                  },
-                  "arguments": []
-                }
-              }
-            ]
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -4531,7 +1629,7 @@
             "line": 33,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "handlers": [
@@ -4553,25 +1651,7 @@
                       "line": 33,
                       "column": 23
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                  },
-                  "origin": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 33,
-                        "column": 20,
-                        "offset": 337
-                      },
-                      "end": {
-                        "line": 33,
-                        "column": 22,
-                        "offset": 339
-                      }
-                    },
-                    "name": "e",
-                    "curly": false
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "loc": {
@@ -4583,7 +1663,7 @@
                     "line": 33,
                     "column": 23
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "init": null,
@@ -4594,35 +1674,6 @@
                 "_meta": {}
               },
               "_meta": {
-                "loc": {
-                  "start": {
-                    "line": 33,
-                    "column": 21
-                  },
-                  "end": {
-                    "line": 33,
-                    "column": 23
-                  },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                },
-                "origin": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 33,
-                      "column": 20,
-                      "offset": 337
-                    },
-                    "end": {
-                      "line": 33,
-                      "column": 22,
-                      "offset": 339
-                    }
-                  },
-                  "name": "e",
-                  "curly": false
-                },
                 "catchTypes": [
                   {
                     "type": "Identifier",
@@ -4637,25 +1688,7 @@
                           "line": 33,
                           "column": 20
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                      },
-                      "origin": {
-                        "kind": "name",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 33,
-                            "column": 9,
-                            "offset": 326
-                          },
-                          "end": {
-                            "line": 33,
-                            "column": 19,
-                            "offset": 336
-                          }
-                        },
-                        "name": "\\Exception",
-                        "resolution": "fqn"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                       }
                     },
                     "loc": {
@@ -4667,21 +1700,32 @@
                         "line": 33,
                         "column": 20
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                     }
                   }
-                ]
+                ],
+                "loc": {
+                  "start": {
+                    "line": 33,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 35,
+                    "column": 2
+                  },
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                }
               },
               "loc": {
                 "start": {
                   "line": 33,
-                  "column": 21
+                  "column": 3
                 },
                 "end": {
-                  "line": 33,
-                  "column": 23
+                  "line": 35,
+                  "column": 2
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             }
           ],
@@ -4703,25 +1747,7 @@
                         "line": 34,
                         "column": 13
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                    },
-                    "origin": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 34,
-                          "column": 10,
-                          "offset": 353
-                        },
-                        "end": {
-                          "line": 34,
-                          "column": 12,
-                          "offset": 355
-                        }
-                      },
-                      "name": "e",
-                      "curly": false
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                     }
                   },
                   "loc": {
@@ -4733,7 +1759,7 @@
                       "line": 34,
                       "column": 13
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "_meta": {
@@ -4746,41 +1772,7 @@
                       "line": 34,
                       "column": 14
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                  },
-                  "origin": {
-                    "kind": "throw",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 34,
-                        "column": 4,
-                        "offset": 347
-                      },
-                      "end": {
-                        "line": 34,
-                        "column": 13,
-                        "offset": 356
-                      }
-                    },
-                    "what": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 34,
-                          "column": 10,
-                          "offset": 353
-                        },
-                        "end": {
-                          "line": 34,
-                          "column": 12,
-                          "offset": 355
-                        }
-                      },
-                      "name": "e",
-                      "curly": false
-                    }
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "loc": {
@@ -4792,7 +1784,7 @@
                     "line": 34,
                     "column": 14
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               }
             ],
@@ -4807,59 +1799,7 @@
                   "line": 35,
                   "column": 2
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-              },
-              "origin": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 33,
-                    "column": 24,
-                    "offset": 341
-                  },
-                  "end": {
-                    "line": 35,
-                    "column": 1,
-                    "offset": 358
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "throw",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 34,
-                        "column": 4,
-                        "offset": 347
-                      },
-                      "end": {
-                        "line": 34,
-                        "column": 13,
-                        "offset": 356
-                      }
-                    },
-                    "what": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 34,
-                          "column": 10,
-                          "offset": 353
-                        },
-                        "end": {
-                          "line": 34,
-                          "column": 12,
-                          "offset": 355
-                        }
-                      },
-                      "name": "e",
-                      "curly": false
-                    }
-                  }
-                ]
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -4871,7 +1811,7 @@
                 "line": 35,
                 "column": 2
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "_meta": {
@@ -4884,113 +1824,7 @@
                 "line": 35,
                 "column": 2
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-            },
-            "origin": {
-              "kind": "catch",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 33,
-                  "column": 2,
-                  "offset": 319
-                },
-                "end": {
-                  "line": 35,
-                  "column": 1,
-                  "offset": 358
-                }
-              },
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 33,
-                    "column": 24,
-                    "offset": 341
-                  },
-                  "end": {
-                    "line": 35,
-                    "column": 1,
-                    "offset": 358
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "throw",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 34,
-                        "column": 4,
-                        "offset": 347
-                      },
-                      "end": {
-                        "line": 34,
-                        "column": 13,
-                        "offset": 356
-                      }
-                    },
-                    "what": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 34,
-                          "column": 10,
-                          "offset": 353
-                        },
-                        "end": {
-                          "line": 34,
-                          "column": 12,
-                          "offset": 355
-                        }
-                      },
-                      "name": "e",
-                      "curly": false
-                    }
-                  }
-                ]
-              },
-              "what": [
-                {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 33,
-                      "column": 9,
-                      "offset": 326
-                    },
-                    "end": {
-                      "line": 33,
-                      "column": 19,
-                      "offset": 336
-                    }
-                  },
-                  "name": "\\Exception",
-                  "resolution": "fqn"
-                }
-              ],
-              "variable": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 33,
-                    "column": 20,
-                    "offset": 337
-                  },
-                  "end": {
-                    "line": 33,
-                    "column": 22,
-                    "offset": 339
-                  }
-                },
-                "name": "e",
-                "curly": false
-              }
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "loc": {
@@ -5002,7 +1836,7 @@
               "line": 35,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         }
       ],
@@ -5026,25 +1860,7 @@
                       "line": 36,
                       "column": 12
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                  },
-                  "origin": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 36,
-                        "column": 4,
-                        "offset": 373
-                      },
-                      "end": {
-                        "line": 36,
-                        "column": 11,
-                        "offset": 380
-                      }
-                    },
-                    "name": "cleanup",
-                    "resolution": "uqn"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "loc": {
@@ -5056,7 +1872,7 @@
                     "line": 36,
                     "column": 12
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "arguments": [],
@@ -5068,44 +1884,9 @@
                   },
                   "end": {
                     "line": 36,
-                    "column": 15
+                    "column": 14
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-                },
-                "origin": {
-                  "kind": "call",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 36,
-                      "column": 4,
-                      "offset": 373
-                    },
-                    "end": {
-                      "line": 36,
-                      "column": 14,
-                      "offset": 383
-                    }
-                  },
-                  "what": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 36,
-                        "column": 4,
-                        "offset": 373
-                      },
-                      "end": {
-                        "line": 36,
-                        "column": 11,
-                        "offset": 380
-                      }
-                    },
-                    "name": "cleanup",
-                    "resolution": "uqn"
-                  },
-                  "arguments": []
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "loc": {
@@ -5115,9 +1896,9 @@
                 },
                 "end": {
                   "line": 36,
-                  "column": 15
+                  "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "_meta": {
@@ -5130,58 +1911,7 @@
                   "line": 36,
                   "column": 15
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-              },
-              "origin": {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 36,
-                    "column": 4,
-                    "offset": 373
-                  },
-                  "end": {
-                    "line": 36,
-                    "column": 14,
-                    "offset": 383
-                  }
-                },
-                "expression": {
-                  "kind": "call",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 36,
-                      "column": 4,
-                      "offset": 373
-                    },
-                    "end": {
-                      "line": 36,
-                      "column": 14,
-                      "offset": 383
-                    }
-                  },
-                  "what": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 36,
-                        "column": 4,
-                        "offset": 373
-                      },
-                      "end": {
-                        "line": 36,
-                        "column": 11,
-                        "offset": 380
-                      }
-                    },
-                    "name": "cleanup",
-                    "resolution": "uqn"
-                  },
-                  "arguments": []
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -5193,7 +1923,7 @@
                 "line": 36,
                 "column": 15
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           }
         ],
@@ -5208,76 +1938,7 @@
               "line": 37,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-          },
-          "origin": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 35,
-                "column": 10,
-                "offset": 367
-              },
-              "end": {
-                "line": 37,
-                "column": 1,
-                "offset": 385
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 36,
-                    "column": 4,
-                    "offset": 373
-                  },
-                  "end": {
-                    "line": 36,
-                    "column": 14,
-                    "offset": 383
-                  }
-                },
-                "expression": {
-                  "kind": "call",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 36,
-                      "column": 4,
-                      "offset": 373
-                    },
-                    "end": {
-                      "line": 36,
-                      "column": 14,
-                      "offset": 383
-                    }
-                  },
-                  "what": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 36,
-                        "column": 4,
-                        "offset": 373
-                      },
-                      "end": {
-                        "line": 36,
-                        "column": 11,
-                        "offset": 380
-                      }
-                    },
-                    "name": "cleanup",
-                    "resolution": "uqn"
-                  },
-                  "arguments": []
-                }
-              }
-            ]
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -5289,7 +1950,7 @@
             "line": 37,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "_meta": {
@@ -5302,269 +1963,7 @@
             "line": 37,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-        },
-        "origin": {
-          "kind": "try",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 31,
-              "column": 0,
-              "offset": 298
-            },
-            "end": {
-              "line": 37,
-              "column": 1,
-              "offset": 385
-            }
-          },
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 31,
-                "column": 4,
-                "offset": 302
-              },
-              "end": {
-                "line": 33,
-                "column": 1,
-                "offset": 318
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 32,
-                    "column": 4,
-                    "offset": 308
-                  },
-                  "end": {
-                    "line": 32,
-                    "column": 12,
-                    "offset": 316
-                  }
-                },
-                "expression": {
-                  "kind": "call",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 32,
-                      "column": 4,
-                      "offset": 308
-                    },
-                    "end": {
-                      "line": 32,
-                      "column": 12,
-                      "offset": 316
-                    }
-                  },
-                  "what": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 32,
-                        "column": 4,
-                        "offset": 308
-                      },
-                      "end": {
-                        "line": 32,
-                        "column": 9,
-                        "offset": 313
-                      }
-                    },
-                    "name": "risky",
-                    "resolution": "uqn"
-                  },
-                  "arguments": []
-                }
-              }
-            ]
-          },
-          "catches": [
-            {
-              "kind": "catch",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 33,
-                  "column": 2,
-                  "offset": 319
-                },
-                "end": {
-                  "line": 35,
-                  "column": 1,
-                  "offset": 358
-                }
-              },
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 33,
-                    "column": 24,
-                    "offset": 341
-                  },
-                  "end": {
-                    "line": 35,
-                    "column": 1,
-                    "offset": 358
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "throw",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 34,
-                        "column": 4,
-                        "offset": 347
-                      },
-                      "end": {
-                        "line": 34,
-                        "column": 13,
-                        "offset": 356
-                      }
-                    },
-                    "what": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 34,
-                          "column": 10,
-                          "offset": 353
-                        },
-                        "end": {
-                          "line": 34,
-                          "column": 12,
-                          "offset": 355
-                        }
-                      },
-                      "name": "e",
-                      "curly": false
-                    }
-                  }
-                ]
-              },
-              "what": [
-                {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 33,
-                      "column": 9,
-                      "offset": 326
-                    },
-                    "end": {
-                      "line": 33,
-                      "column": 19,
-                      "offset": 336
-                    }
-                  },
-                  "name": "\\Exception",
-                  "resolution": "fqn"
-                }
-              ],
-              "variable": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 33,
-                    "column": 20,
-                    "offset": 337
-                  },
-                  "end": {
-                    "line": 33,
-                    "column": 22,
-                    "offset": 339
-                  }
-                },
-                "name": "e",
-                "curly": false
-              }
-            }
-          ],
-          "always": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 35,
-                "column": 10,
-                "offset": 367
-              },
-              "end": {
-                "line": 37,
-                "column": 1,
-                "offset": 385
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 36,
-                    "column": 4,
-                    "offset": 373
-                  },
-                  "end": {
-                    "line": 36,
-                    "column": 14,
-                    "offset": 383
-                  }
-                },
-                "expression": {
-                  "kind": "call",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 36,
-                      "column": 4,
-                      "offset": 373
-                    },
-                    "end": {
-                      "line": 36,
-                      "column": 14,
-                      "offset": 383
-                    }
-                  },
-                  "what": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 36,
-                        "column": 4,
-                        "offset": 373
-                      },
-                      "end": {
-                        "line": 36,
-                        "column": 11,
-                        "offset": 380
-                      }
-                    },
-                    "name": "cleanup",
-                    "resolution": "uqn"
-                  },
-                  "arguments": []
-                }
-              }
-            ]
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "loc": {
@@ -5576,13 +1975,13 @@
           "line": 37,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -5594,1182 +1993,7 @@
         "line": 38,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
-    },
-    "origin": {
-      "kind": "program",
-      "loc": {
-        "source": null,
-        "start": {
-          "line": 1,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "line": 38,
-          "column": 0,
-          "offset": 386
-        }
-      },
-      "children": [
-        {
-          "kind": "for",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 7
-            },
-            "end": {
-              "line": 5,
-              "column": 1,
-              "offset": 50
-            }
-          },
-          "init": [
-            {
-              "kind": "assign",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 5,
-                  "offset": 12
-                },
-                "end": {
-                  "line": 3,
-                  "column": 11,
-                  "offset": 18
-                }
-              },
-              "left": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 5,
-                    "offset": 12
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 7,
-                    "offset": 14
-                  }
-                },
-                "name": "i",
-                "curly": false
-              },
-              "right": {
-                "kind": "number",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 10,
-                    "offset": 17
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 11,
-                    "offset": 18
-                  }
-                },
-                "value": "0"
-              },
-              "operator": "="
-            }
-          ],
-          "test": [
-            {
-              "kind": "bin",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 13,
-                  "offset": 20
-                },
-                "end": {
-                  "line": 3,
-                  "column": 19,
-                  "offset": 26
-                }
-              },
-              "type": "<",
-              "left": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 13,
-                    "offset": 20
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 15,
-                    "offset": 22
-                  }
-                },
-                "name": "i",
-                "curly": false
-              },
-              "right": {
-                "kind": "number",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 18,
-                    "offset": 25
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 19,
-                    "offset": 26
-                  }
-                },
-                "value": "3"
-              }
-            }
-          ],
-          "increment": [
-            {
-              "kind": "post",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 21,
-                  "offset": 28
-                },
-                "end": {
-                  "line": 3,
-                  "column": 25,
-                  "offset": 32
-                }
-              },
-              "type": "+",
-              "what": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 21,
-                    "offset": 28
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 23,
-                    "offset": 30
-                  }
-                },
-                "name": "i",
-                "curly": false
-              }
-            }
-          ],
-          "shortForm": false,
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 27,
-                "offset": 34
-              },
-              "end": {
-                "line": 5,
-                "column": 1,
-                "offset": 50
-              }
-            },
-            "children": [
-              {
-                "kind": "echo",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 4,
-                    "column": 4,
-                    "offset": 40
-                  },
-                  "end": {
-                    "line": 4,
-                    "column": 12,
-                    "offset": 48
-                  }
-                },
-                "shortForm": false,
-                "expressions": [
-                  {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 4,
-                        "column": 9,
-                        "offset": 45
-                      },
-                      "end": {
-                        "line": 4,
-                        "column": 11,
-                        "offset": 47
-                      }
-                    },
-                    "name": "i",
-                    "curly": false
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "kind": "foreach",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 7,
-              "column": 0,
-              "offset": 52
-            },
-            "end": {
-              "line": 12,
-              "column": 1,
-              "offset": 133
-            }
-          },
-          "source": {
-            "kind": "variable",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 7,
-                "column": 9,
-                "offset": 61
-              },
-              "end": {
-                "line": 7,
-                "column": 15,
-                "offset": 67
-              }
-            },
-            "name": "items",
-            "curly": false
-          },
-          "key": {
-            "kind": "variable",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 7,
-                "column": 19,
-                "offset": 71
-              },
-              "end": {
-                "line": 7,
-                "column": 21,
-                "offset": 73
-              }
-            },
-            "name": "k",
-            "curly": false
-          },
-          "value": {
-            "kind": "variable",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 7,
-                "column": 25,
-                "offset": 77
-              },
-              "end": {
-                "line": 7,
-                "column": 27,
-                "offset": 79
-              }
-            },
-            "name": "v",
-            "curly": false
-          },
-          "shortForm": false,
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 7,
-                "column": 29,
-                "offset": 81
-              },
-              "end": {
-                "line": 12,
-                "column": 1,
-                "offset": 133
-              }
-            },
-            "children": [
-              {
-                "kind": "if",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 8,
-                    "column": 4,
-                    "offset": 87
-                  },
-                  "end": {
-                    "line": 10,
-                    "column": 5,
-                    "offset": 120
-                  }
-                },
-                "test": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 8,
-                      "offset": 91
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 10,
-                      "offset": 93
-                    }
-                  },
-                  "name": "v",
-                  "curly": false
-                },
-                "body": {
-                  "kind": "block",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 12,
-                      "offset": 95
-                    },
-                    "end": {
-                      "line": 10,
-                      "column": 5,
-                      "offset": 120
-                    }
-                  },
-                  "children": [
-                    {
-                      "kind": "continue",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 8,
-                          "offset": 105
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 17,
-                          "offset": 114
-                        }
-                      },
-                      "level": null
-                    }
-                  ]
-                },
-                "alternate": null,
-                "shortForm": false
-              },
-              {
-                "kind": "break",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 11,
-                    "column": 4,
-                    "offset": 125
-                  },
-                  "end": {
-                    "line": 11,
-                    "column": 10,
-                    "offset": 131
-                  }
-                },
-                "level": null
-              }
-            ]
-          }
-        },
-        {
-          "kind": "while",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 14,
-              "column": 0,
-              "offset": 135
-            },
-            "end": {
-              "line": 17,
-              "column": 1,
-              "offset": 174
-            }
-          },
-          "test": {
-            "kind": "variable",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 14,
-                "column": 7,
-                "offset": 142
-              },
-              "end": {
-                "line": 14,
-                "column": 10,
-                "offset": 145
-              }
-            },
-            "name": "ok",
-            "curly": false
-          },
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 14,
-                "column": 12,
-                "offset": 147
-              },
-              "end": {
-                "line": 17,
-                "column": 1,
-                "offset": 174
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 15,
-                    "column": 4,
-                    "offset": 153
-                  },
-                  "end": {
-                    "line": 15,
-                    "column": 12,
-                    "offset": 161
-                  }
-                },
-                "expression": {
-                  "kind": "call",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 15,
-                      "column": 4,
-                      "offset": 153
-                    },
-                    "end": {
-                      "line": 15,
-                      "column": 12,
-                      "offset": 161
-                    }
-                  },
-                  "what": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 15,
-                        "column": 4,
-                        "offset": 153
-                      },
-                      "end": {
-                        "line": 15,
-                        "column": 9,
-                        "offset": 158
-                      }
-                    },
-                    "name": "risky",
-                    "resolution": "uqn"
-                  },
-                  "arguments": []
-                }
-              },
-              {
-                "kind": "break",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 16,
-                    "column": 4,
-                    "offset": 166
-                  },
-                  "end": {
-                    "line": 16,
-                    "column": 10,
-                    "offset": 172
-                  }
-                },
-                "level": null
-              }
-            ]
-          },
-          "shortForm": false
-        },
-        {
-          "kind": "do",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 19,
-              "column": 0,
-              "offset": 176
-            },
-            "end": {
-              "line": 21,
-              "column": 16,
-              "offset": 209
-            }
-          },
-          "test": {
-            "kind": "variable",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 21,
-                "column": 9,
-                "offset": 202
-              },
-              "end": {
-                "line": 21,
-                "column": 14,
-                "offset": 207
-              }
-            },
-            "name": "flag",
-            "curly": false
-          },
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 19,
-                "column": 3,
-                "offset": 179
-              },
-              "end": {
-                "line": 21,
-                "column": 1,
-                "offset": 194
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 20,
-                    "column": 4,
-                    "offset": 185
-                  },
-                  "end": {
-                    "line": 20,
-                    "column": 11,
-                    "offset": 192
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 20,
-                      "column": 4,
-                      "offset": 185
-                    },
-                    "end": {
-                      "line": 20,
-                      "column": 11,
-                      "offset": 192
-                    }
-                  },
-                  "left": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 4,
-                        "offset": 185
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 6,
-                        "offset": 187
-                      }
-                    },
-                    "name": "x",
-                    "curly": false
-                  },
-                  "right": {
-                    "kind": "number",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 9,
-                        "offset": 190
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 10,
-                        "offset": 191
-                      }
-                    },
-                    "value": "1"
-                  },
-                  "operator": "="
-                }
-              }
-            ]
-          }
-        },
-        {
-          "kind": "switch",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 23,
-              "column": 0,
-              "offset": 211
-            },
-            "end": {
-              "line": 29,
-              "column": 1,
-              "offset": 296
-            }
-          },
-          "test": {
-            "kind": "variable",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 23,
-                "column": 8,
-                "offset": 219
-              },
-              "end": {
-                "line": 23,
-                "column": 10,
-                "offset": 221
-              }
-            },
-            "name": "x",
-            "curly": false
-          },
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 23,
-                "column": 12,
-                "offset": 223
-              },
-              "end": {
-                "line": 29,
-                "column": 1,
-                "offset": 296
-              }
-            },
-            "children": [
-              {
-                "kind": "case",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 24,
-                    "column": 4,
-                    "offset": 229
-                  },
-                  "end": {
-                    "line": 26,
-                    "column": 14,
-                    "offset": 266
-                  }
-                },
-                "test": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 24,
-                      "column": 9,
-                      "offset": 234
-                    },
-                    "end": {
-                      "line": 24,
-                      "column": 10,
-                      "offset": 235
-                    }
-                  },
-                  "value": "1"
-                },
-                "body": {
-                  "kind": "block",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 25,
-                      "column": 8,
-                      "offset": 245
-                    },
-                    "end": {
-                      "line": 26,
-                      "column": 14,
-                      "offset": 266
-                    }
-                  },
-                  "children": [
-                    {
-                      "kind": "expressionstatement",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 8,
-                          "offset": 245
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 14,
-                          "offset": 251
-                        }
-                      },
-                      "expression": {
-                        "kind": "call",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 8,
-                            "offset": 245
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 14,
-                            "offset": 251
-                          }
-                        },
-                        "what": {
-                          "kind": "name",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 25,
-                              "column": 8,
-                              "offset": 245
-                            },
-                            "end": {
-                              "line": 25,
-                              "column": 11,
-                              "offset": 248
-                            }
-                          },
-                          "name": "foo",
-                          "resolution": "uqn"
-                        },
-                        "arguments": []
-                      }
-                    },
-                    {
-                      "kind": "break",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 26,
-                          "column": 8,
-                          "offset": 260
-                        },
-                        "end": {
-                          "line": 26,
-                          "column": 14,
-                          "offset": 266
-                        }
-                      },
-                      "level": null
-                    }
-                  ]
-                }
-              },
-              {
-                "kind": "case",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 27,
-                    "column": 4,
-                    "offset": 271
-                  },
-                  "end": {
-                    "line": 28,
-                    "column": 14,
-                    "offset": 294
-                  }
-                },
-                "test": null,
-                "body": {
-                  "kind": "block",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 28,
-                      "column": 8,
-                      "offset": 288
-                    },
-                    "end": {
-                      "line": 28,
-                      "column": 14,
-                      "offset": 294
-                    }
-                  },
-                  "children": [
-                    {
-                      "kind": "expressionstatement",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 28,
-                          "column": 8,
-                          "offset": 288
-                        },
-                        "end": {
-                          "line": 28,
-                          "column": 14,
-                          "offset": 294
-                        }
-                      },
-                      "expression": {
-                        "kind": "call",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 28,
-                            "column": 8,
-                            "offset": 288
-                          },
-                          "end": {
-                            "line": 28,
-                            "column": 14,
-                            "offset": 294
-                          }
-                        },
-                        "what": {
-                          "kind": "name",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 28,
-                              "column": 8,
-                              "offset": 288
-                            },
-                            "end": {
-                              "line": 28,
-                              "column": 11,
-                              "offset": 291
-                            }
-                          },
-                          "name": "bar",
-                          "resolution": "uqn"
-                        },
-                        "arguments": []
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          "shortForm": false
-        },
-        {
-          "kind": "try",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 31,
-              "column": 0,
-              "offset": 298
-            },
-            "end": {
-              "line": 37,
-              "column": 1,
-              "offset": 385
-            }
-          },
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 31,
-                "column": 4,
-                "offset": 302
-              },
-              "end": {
-                "line": 33,
-                "column": 1,
-                "offset": 318
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 32,
-                    "column": 4,
-                    "offset": 308
-                  },
-                  "end": {
-                    "line": 32,
-                    "column": 12,
-                    "offset": 316
-                  }
-                },
-                "expression": {
-                  "kind": "call",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 32,
-                      "column": 4,
-                      "offset": 308
-                    },
-                    "end": {
-                      "line": 32,
-                      "column": 12,
-                      "offset": 316
-                    }
-                  },
-                  "what": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 32,
-                        "column": 4,
-                        "offset": 308
-                      },
-                      "end": {
-                        "line": 32,
-                        "column": 9,
-                        "offset": 313
-                      }
-                    },
-                    "name": "risky",
-                    "resolution": "uqn"
-                  },
-                  "arguments": []
-                }
-              }
-            ]
-          },
-          "catches": [
-            {
-              "kind": "catch",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 33,
-                  "column": 2,
-                  "offset": 319
-                },
-                "end": {
-                  "line": 35,
-                  "column": 1,
-                  "offset": 358
-                }
-              },
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 33,
-                    "column": 24,
-                    "offset": 341
-                  },
-                  "end": {
-                    "line": 35,
-                    "column": 1,
-                    "offset": 358
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "throw",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 34,
-                        "column": 4,
-                        "offset": 347
-                      },
-                      "end": {
-                        "line": 34,
-                        "column": 13,
-                        "offset": 356
-                      }
-                    },
-                    "what": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 34,
-                          "column": 10,
-                          "offset": 353
-                        },
-                        "end": {
-                          "line": 34,
-                          "column": 12,
-                          "offset": 355
-                        }
-                      },
-                      "name": "e",
-                      "curly": false
-                    }
-                  }
-                ]
-              },
-              "what": [
-                {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 33,
-                      "column": 9,
-                      "offset": 326
-                    },
-                    "end": {
-                      "line": 33,
-                      "column": 19,
-                      "offset": 336
-                    }
-                  },
-                  "name": "\\Exception",
-                  "resolution": "fqn"
-                }
-              ],
-              "variable": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 33,
-                    "column": 20,
-                    "offset": 337
-                  },
-                  "end": {
-                    "line": 33,
-                    "column": 22,
-                    "offset": 339
-                  }
-                },
-                "name": "e",
-                "curly": false
-              }
-            }
-          ],
-          "always": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 35,
-                "column": 10,
-                "offset": 367
-              },
-              "end": {
-                "line": 37,
-                "column": 1,
-                "offset": 385
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 36,
-                    "column": 4,
-                    "offset": 373
-                  },
-                  "end": {
-                    "line": 36,
-                    "column": 14,
-                    "offset": 383
-                  }
-                },
-                "expression": {
-                  "kind": "call",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 36,
-                      "column": 4,
-                      "offset": 373
-                    },
-                    "end": {
-                      "line": 36,
-                      "column": 14,
-                      "offset": 383
-                    }
-                  },
-                  "what": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 36,
-                        "column": 4,
-                        "offset": 373
-                      },
-                      "end": {
-                        "line": 36,
-                        "column": 11,
-                        "offset": 380
-                      }
-                    },
-                    "name": "cleanup",
-                    "resolution": "uqn"
-                  },
-                  "arguments": []
-                }
-              }
-            ]
-          }
-        }
-      ],
-      "errors": [],
-      "comments": []
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
     }
   },
   "loc": {
@@ -6781,6 +2005,6 @@
       "line": 38,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/control-flow.php.json
+++ b/parser-PHP/tests/benchmark/base/control-flow.php.json
@@ -18,7 +18,7 @@
                 "line": 3,
                 "column": 8
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             },
             "origin": {
               "kind": "variable",
@@ -48,7 +48,7 @@
               "line": 3,
               "column": 8
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "right": {
@@ -65,7 +65,7 @@
                 "line": 3,
                 "column": 12
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             },
             "origin": {
               "kind": "number",
@@ -94,7 +94,7 @@
               "line": 3,
               "column": 12
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "operator": "=",
@@ -109,7 +109,7 @@
               "line": 3,
               "column": 12
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           },
           "origin": {
             "kind": "assign",
@@ -173,7 +173,7 @@
             "line": 3,
             "column": 12
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "test": {
@@ -192,7 +192,7 @@
                 "line": 3,
                 "column": 16
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             },
             "origin": {
               "kind": "variable",
@@ -222,7 +222,7 @@
               "line": 3,
               "column": 16
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "right": {
@@ -239,7 +239,7 @@
                 "line": 3,
                 "column": 20
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             },
             "origin": {
               "kind": "number",
@@ -268,7 +268,7 @@
               "line": 3,
               "column": 20
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "_meta": {
@@ -281,7 +281,7 @@
               "line": 3,
               "column": 20
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           },
           "origin": {
             "kind": "bin",
@@ -345,7 +345,7 @@
             "line": 3,
             "column": 20
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "update": {
@@ -364,7 +364,7 @@
                 "line": 3,
                 "column": 24
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             },
             "origin": {
               "kind": "variable",
@@ -394,7 +394,7 @@
               "line": 3,
               "column": 24
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "isSuffix": true,
@@ -408,7 +408,7 @@
               "line": 3,
               "column": 26
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           },
           "origin": {
             "kind": "post",
@@ -455,7 +455,7 @@
             "line": 3,
             "column": 26
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "body": {
@@ -484,7 +484,7 @@
                         "line": 4,
                         "column": 12
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                     },
                     "origin": {
                       "kind": "variable",
@@ -514,7 +514,7 @@
                       "line": 4,
                       "column": 12
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 }
               ],
@@ -528,7 +528,7 @@
                     "line": 4,
                     "column": 13
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 },
                 "origin": {
                   "kind": "echo",
@@ -577,7 +577,7 @@
                   "line": 4,
                   "column": 13
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "_meta": {
@@ -590,7 +590,7 @@
                   "line": 4,
                   "column": 13
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               },
               "origin": {
                 "kind": "echo",
@@ -639,7 +639,7 @@
                 "line": 4,
                 "column": 13
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           }
         ],
@@ -654,7 +654,7 @@
               "line": 5,
               "column": 2
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           },
           "origin": {
             "kind": "block",
@@ -721,7 +721,7 @@
             "line": 5,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "_meta": {
@@ -734,7 +734,7 @@
             "line": 5,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         },
         "origin": {
           "kind": "for",
@@ -963,7 +963,7 @@
           "line": 5,
           "column": 2
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
       }
     },
     {
@@ -983,7 +983,7 @@
                 "line": 7,
                 "column": 22
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             },
             "origin": {
               "kind": "variable",
@@ -1013,7 +1013,7 @@
               "line": 7,
               "column": 22
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "init": null,
@@ -1033,7 +1033,7 @@
               "line": 7,
               "column": 22
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           },
           "origin": {
             "kind": "variable",
@@ -1063,7 +1063,7 @@
             "line": 7,
             "column": 22
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "value": {
@@ -1081,7 +1081,7 @@
                 "line": 7,
                 "column": 28
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             },
             "origin": {
               "kind": "variable",
@@ -1111,7 +1111,7 @@
               "line": 7,
               "column": 28
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "init": null,
@@ -1131,7 +1131,7 @@
               "line": 7,
               "column": 28
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           },
           "origin": {
             "kind": "variable",
@@ -1161,7 +1161,7 @@
             "line": 7,
             "column": 28
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "right": {
@@ -1177,7 +1177,7 @@
               "line": 7,
               "column": 16
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           },
           "origin": {
             "kind": "variable",
@@ -1207,7 +1207,7 @@
             "line": 7,
             "column": 16
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "body": {
@@ -1228,7 +1228,7 @@
                     "line": 8,
                     "column": 11
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 },
                 "origin": {
                   "kind": "variable",
@@ -1258,7 +1258,7 @@
                   "line": 8,
                   "column": 11
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "consequent": {
@@ -1278,7 +1278,7 @@
                         "line": 9,
                         "column": 18
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                     },
                     "origin": {
                       "kind": "continue",
@@ -1307,7 +1307,7 @@
                       "line": 9,
                       "column": 18
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 }
               ],
@@ -1322,7 +1322,7 @@
                     "line": 10,
                     "column": 6
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 },
                 "origin": {
                   "kind": "block",
@@ -1369,7 +1369,7 @@
                   "line": 10,
                   "column": 6
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "alternative": null,
@@ -1383,7 +1383,7 @@
                   "line": 10,
                   "column": 6
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               },
               "origin": {
                 "kind": "if",
@@ -1466,7 +1466,7 @@
                 "line": 10,
                 "column": 6
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           {
@@ -1483,7 +1483,7 @@
                   "line": 11,
                   "column": 11
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               },
               "origin": {
                 "kind": "break",
@@ -1512,7 +1512,7 @@
                 "line": 11,
                 "column": 11
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           }
         ],
@@ -1527,7 +1527,7 @@
               "line": 12,
               "column": 2
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           },
           "origin": {
             "kind": "block",
@@ -1645,7 +1645,7 @@
             "line": 12,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "_meta": {
@@ -1658,7 +1658,7 @@
             "line": 12,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         },
         "origin": {
           "kind": "foreach",
@@ -1847,7 +1847,7 @@
           "line": 12,
           "column": 2
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
       }
     },
     {
@@ -1865,7 +1865,7 @@
               "line": 14,
               "column": 11
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           },
           "origin": {
             "kind": "variable",
@@ -1895,7 +1895,7 @@
             "line": 14,
             "column": 11
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "body": {
@@ -1918,7 +1918,7 @@
                       "line": 15,
                       "column": 10
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   },
                   "origin": {
                     "kind": "name",
@@ -1948,7 +1948,7 @@
                     "line": 15,
                     "column": 10
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "arguments": [],
@@ -1962,7 +1962,7 @@
                     "line": 15,
                     "column": 13
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 },
                 "origin": {
                   "kind": "call",
@@ -2009,7 +2009,7 @@
                   "line": 15,
                   "column": 13
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "_meta": {
@@ -2022,7 +2022,7 @@
                   "line": 15,
                   "column": 13
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               },
               "origin": {
                 "kind": "expressionstatement",
@@ -2085,7 +2085,7 @@
                 "line": 15,
                 "column": 13
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           {
@@ -2102,7 +2102,7 @@
                   "line": 16,
                   "column": 11
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               },
               "origin": {
                 "kind": "break",
@@ -2131,7 +2131,7 @@
                 "line": 16,
                 "column": 11
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           }
         ],
@@ -2146,7 +2146,7 @@
               "line": 17,
               "column": 2
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           },
           "origin": {
             "kind": "block",
@@ -2244,7 +2244,7 @@
             "line": 17,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "isPostTest": false,
@@ -2258,7 +2258,7 @@
             "line": 17,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         },
         "origin": {
           "kind": "while",
@@ -2391,7 +2391,7 @@
           "line": 17,
           "column": 2
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
       }
     },
     {
@@ -2409,7 +2409,7 @@
               "line": 21,
               "column": 15
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           },
           "origin": {
             "kind": "variable",
@@ -2439,7 +2439,7 @@
             "line": 21,
             "column": 15
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "body": {
@@ -2462,7 +2462,7 @@
                       "line": 20,
                       "column": 7
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   },
                   "origin": {
                     "kind": "variable",
@@ -2492,7 +2492,7 @@
                     "line": 20,
                     "column": 7
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "right": {
@@ -2509,7 +2509,7 @@
                       "line": 20,
                       "column": 11
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   },
                   "origin": {
                     "kind": "number",
@@ -2538,7 +2538,7 @@
                     "line": 20,
                     "column": 11
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "operator": "=",
@@ -2553,7 +2553,7 @@
                     "line": 20,
                     "column": 12
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 },
                 "origin": {
                   "kind": "assign",
@@ -2617,7 +2617,7 @@
                   "line": 20,
                   "column": 12
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "_meta": {
@@ -2630,7 +2630,7 @@
                   "line": 20,
                   "column": 12
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               },
               "origin": {
                 "kind": "expressionstatement",
@@ -2710,7 +2710,7 @@
                 "line": 20,
                 "column": 12
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           }
         ],
@@ -2725,7 +2725,7 @@
               "line": 21,
               "column": 2
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           },
           "origin": {
             "kind": "block",
@@ -2823,7 +2823,7 @@
             "line": 21,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "isPostTest": true,
@@ -2837,7 +2837,7 @@
             "line": 21,
             "column": 17
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         },
         "origin": {
           "kind": "do",
@@ -2969,7 +2969,7 @@
           "line": 21,
           "column": 17
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
       }
     },
     {
@@ -2987,7 +2987,7 @@
               "line": 23,
               "column": 11
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           },
           "origin": {
             "kind": "variable",
@@ -3017,7 +3017,7 @@
             "line": 23,
             "column": 11
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "cases": [
@@ -3037,7 +3037,7 @@
                   "line": 24,
                   "column": 11
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               },
               "origin": {
                 "kind": "number",
@@ -3066,7 +3066,7 @@
                 "line": 24,
                 "column": 11
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "body": {
@@ -3089,7 +3089,7 @@
                           "line": 25,
                           "column": 12
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                       },
                       "origin": {
                         "kind": "name",
@@ -3119,7 +3119,7 @@
                         "line": 25,
                         "column": 12
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                     }
                   },
                   "arguments": [],
@@ -3133,7 +3133,7 @@
                         "line": 25,
                         "column": 15
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                     },
                     "origin": {
                       "kind": "call",
@@ -3180,7 +3180,7 @@
                       "line": 25,
                       "column": 15
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "_meta": {
@@ -3193,7 +3193,7 @@
                       "line": 25,
                       "column": 15
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   },
                   "origin": {
                     "kind": "expressionstatement",
@@ -3256,7 +3256,7 @@
                     "line": 25,
                     "column": 15
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               {
@@ -3273,7 +3273,7 @@
                       "line": 26,
                       "column": 15
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   },
                   "origin": {
                     "kind": "break",
@@ -3302,7 +3302,7 @@
                     "line": 26,
                     "column": 15
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               }
             ],
@@ -3317,7 +3317,7 @@
                   "line": 26,
                   "column": 15
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               },
               "origin": {
                 "kind": "block",
@@ -3415,7 +3415,7 @@
                 "line": 26,
                 "column": 15
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "_meta": {
@@ -3428,7 +3428,7 @@
                 "line": 26,
                 "column": 15
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             },
             "origin": {
               "kind": "case",
@@ -3559,7 +3559,7 @@
               "line": 26,
               "column": 15
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         {
@@ -3585,7 +3585,7 @@
                           "line": 28,
                           "column": 12
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                       },
                       "origin": {
                         "kind": "name",
@@ -3615,7 +3615,7 @@
                         "line": 28,
                         "column": 12
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                     }
                   },
                   "arguments": [],
@@ -3629,7 +3629,7 @@
                         "line": 28,
                         "column": 15
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                     },
                     "origin": {
                       "kind": "call",
@@ -3676,7 +3676,7 @@
                       "line": 28,
                       "column": 15
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "_meta": {
@@ -3689,7 +3689,7 @@
                       "line": 28,
                       "column": 15
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   },
                   "origin": {
                     "kind": "expressionstatement",
@@ -3752,7 +3752,7 @@
                     "line": 28,
                     "column": 15
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               }
             ],
@@ -3767,7 +3767,7 @@
                   "line": 28,
                   "column": 15
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               },
               "origin": {
                 "kind": "block",
@@ -3848,7 +3848,7 @@
                 "line": 28,
                 "column": 15
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "_meta": {
@@ -3861,7 +3861,7 @@
                 "line": 28,
                 "column": 15
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             },
             "origin": {
               "kind": "case",
@@ -3959,7 +3959,7 @@
               "line": 28,
               "column": 15
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         }
       ],
@@ -3973,7 +3973,7 @@
             "line": 29,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         },
         "origin": {
           "kind": "switch",
@@ -4243,7 +4243,7 @@
           "line": 29,
           "column": 2
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
       }
     },
     {
@@ -4268,7 +4268,7 @@
                       "line": 32,
                       "column": 10
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   },
                   "origin": {
                     "kind": "name",
@@ -4298,7 +4298,7 @@
                     "line": 32,
                     "column": 10
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "arguments": [],
@@ -4312,7 +4312,7 @@
                     "line": 32,
                     "column": 13
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 },
                 "origin": {
                   "kind": "call",
@@ -4359,7 +4359,7 @@
                   "line": 32,
                   "column": 13
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "_meta": {
@@ -4372,7 +4372,7 @@
                   "line": 32,
                   "column": 13
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               },
               "origin": {
                 "kind": "expressionstatement",
@@ -4435,7 +4435,7 @@
                 "line": 32,
                 "column": 13
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           }
         ],
@@ -4450,7 +4450,7 @@
               "line": 33,
               "column": 2
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           },
           "origin": {
             "kind": "block",
@@ -4531,7 +4531,7 @@
             "line": 33,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "handlers": [
@@ -4553,7 +4553,7 @@
                       "line": 33,
                       "column": 23
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   },
                   "origin": {
                     "kind": "variable",
@@ -4583,7 +4583,7 @@
                     "line": 33,
                     "column": 23
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "init": null,
@@ -4603,7 +4603,7 @@
                     "line": 33,
                     "column": 23
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 },
                 "origin": {
                   "kind": "variable",
@@ -4637,7 +4637,7 @@
                           "line": 33,
                           "column": 20
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                       },
                       "origin": {
                         "kind": "name",
@@ -4667,7 +4667,7 @@
                         "line": 33,
                         "column": 20
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                     }
                   }
                 ]
@@ -4681,7 +4681,7 @@
                   "line": 33,
                   "column": 23
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             }
           ],
@@ -4703,7 +4703,7 @@
                         "line": 34,
                         "column": 13
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                     },
                     "origin": {
                       "kind": "variable",
@@ -4733,7 +4733,7 @@
                       "line": 34,
                       "column": 13
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "_meta": {
@@ -4746,7 +4746,7 @@
                       "line": 34,
                       "column": 14
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   },
                   "origin": {
                     "kind": "throw",
@@ -4792,7 +4792,7 @@
                     "line": 34,
                     "column": 14
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               }
             ],
@@ -4807,7 +4807,7 @@
                   "line": 35,
                   "column": 2
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               },
               "origin": {
                 "kind": "block",
@@ -4871,7 +4871,7 @@
                 "line": 35,
                 "column": 2
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "_meta": {
@@ -4884,7 +4884,7 @@
                 "line": 35,
                 "column": 2
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             },
             "origin": {
               "kind": "catch",
@@ -5002,7 +5002,7 @@
               "line": 35,
               "column": 2
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         }
       ],
@@ -5026,7 +5026,7 @@
                       "line": 36,
                       "column": 12
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   },
                   "origin": {
                     "kind": "name",
@@ -5056,7 +5056,7 @@
                     "line": 36,
                     "column": 12
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "arguments": [],
@@ -5070,7 +5070,7 @@
                     "line": 36,
                     "column": 15
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 },
                 "origin": {
                   "kind": "call",
@@ -5117,7 +5117,7 @@
                   "line": 36,
                   "column": 15
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "_meta": {
@@ -5130,7 +5130,7 @@
                   "line": 36,
                   "column": 15
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               },
               "origin": {
                 "kind": "expressionstatement",
@@ -5193,7 +5193,7 @@
                 "line": 36,
                 "column": 15
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           }
         ],
@@ -5208,7 +5208,7 @@
               "line": 37,
               "column": 2
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           },
           "origin": {
             "kind": "block",
@@ -5289,7 +5289,7 @@
             "line": 37,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "_meta": {
@@ -5302,7 +5302,7 @@
             "line": 37,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         },
         "origin": {
           "kind": "try",
@@ -5576,13 +5576,13 @@
           "line": 37,
           "column": 2
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -5594,7 +5594,7 @@
         "line": 38,
         "column": 1
       },
-      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
     },
     "origin": {
       "kind": "program",
@@ -6781,6 +6781,6 @@
       "line": 38,
       "column": 1
     },
-    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/control-flow.php.json
+++ b/parser-PHP/tests/benchmark/base/control-flow.php.json
@@ -18,7 +18,7 @@
                 "line": 3,
                 "column": 8
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           },
           "loc": {
@@ -30,7 +30,7 @@
               "line": 3,
               "column": 8
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "right": {
@@ -47,7 +47,7 @@
                 "line": 3,
                 "column": 12
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           },
           "loc": {
@@ -59,7 +59,7 @@
               "line": 3,
               "column": 12
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "operator": "=",
@@ -74,7 +74,7 @@
               "line": 3,
               "column": 12
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "loc": {
@@ -86,7 +86,7 @@
             "line": 3,
             "column": 12
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "test": {
@@ -105,7 +105,7 @@
                 "line": 3,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           },
           "loc": {
@@ -117,7 +117,7 @@
               "line": 3,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "right": {
@@ -134,7 +134,7 @@
                 "line": 3,
                 "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           },
           "loc": {
@@ -146,7 +146,7 @@
               "line": 3,
               "column": 20
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "_meta": {
@@ -159,7 +159,7 @@
               "line": 3,
               "column": 20
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "loc": {
@@ -171,7 +171,7 @@
             "line": 3,
             "column": 20
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "update": {
@@ -190,7 +190,7 @@
                 "line": 3,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           },
           "loc": {
@@ -202,7 +202,7 @@
               "line": 3,
               "column": 24
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "isSuffix": true,
@@ -216,7 +216,7 @@
               "line": 3,
               "column": 26
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "loc": {
@@ -228,7 +228,7 @@
             "line": 3,
             "column": 26
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "body": {
@@ -257,7 +257,7 @@
                         "line": 4,
                         "column": 12
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "control-flow.php"
                     }
                   },
                   "loc": {
@@ -269,7 +269,7 @@
                       "line": 4,
                       "column": 12
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "control-flow.php"
                   }
                 }
               ],
@@ -283,7 +283,7 @@
                     "line": 4,
                     "column": 13
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "control-flow.php"
                 }
               },
               "loc": {
@@ -295,7 +295,7 @@
                   "line": 4,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "control-flow.php"
               }
             },
             "_meta": {
@@ -308,7 +308,7 @@
                   "line": 4,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "control-flow.php"
               }
             },
             "loc": {
@@ -320,7 +320,7 @@
                 "line": 4,
                 "column": 13
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           }
         ],
@@ -335,7 +335,7 @@
               "line": 5,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "loc": {
@@ -347,7 +347,7 @@
             "line": 5,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "_meta": {
@@ -360,7 +360,7 @@
             "line": 5,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "loc": {
@@ -372,7 +372,7 @@
           "line": 5,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "control-flow.php"
       }
     },
     {
@@ -392,7 +392,7 @@
                 "line": 7,
                 "column": 22
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           },
           "loc": {
@@ -404,7 +404,7 @@
               "line": 7,
               "column": 22
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "init": null,
@@ -424,7 +424,7 @@
               "line": 7,
               "column": 22
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "loc": {
@@ -436,7 +436,7 @@
             "line": 7,
             "column": 22
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "value": {
@@ -454,7 +454,7 @@
                 "line": 7,
                 "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           },
           "loc": {
@@ -466,7 +466,7 @@
               "line": 7,
               "column": 28
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "init": null,
@@ -486,7 +486,7 @@
               "line": 7,
               "column": 28
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "loc": {
@@ -498,7 +498,7 @@
             "line": 7,
             "column": 28
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "right": {
@@ -514,7 +514,7 @@
               "line": 7,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "loc": {
@@ -526,7 +526,7 @@
             "line": 7,
             "column": 16
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "body": {
@@ -547,7 +547,7 @@
                     "line": 8,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "control-flow.php"
                 }
               },
               "loc": {
@@ -559,7 +559,7 @@
                   "line": 8,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "control-flow.php"
               }
             },
             "consequent": {
@@ -578,7 +578,7 @@
                         "line": 9,
                         "column": 18
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "control-flow.php"
                     }
                   },
                   "loc": {
@@ -590,7 +590,7 @@
                       "line": 9,
                       "column": 18
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "control-flow.php"
                   }
                 }
               ],
@@ -605,7 +605,7 @@
                     "line": 10,
                     "column": 6
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "control-flow.php"
                 }
               },
               "loc": {
@@ -617,7 +617,7 @@
                   "line": 10,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "control-flow.php"
               }
             },
             "alternative": null,
@@ -631,7 +631,7 @@
                   "line": 10,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "control-flow.php"
               }
             },
             "loc": {
@@ -643,7 +643,7 @@
                 "line": 10,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           },
           {
@@ -659,7 +659,7 @@
                   "line": 11,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "control-flow.php"
               }
             },
             "loc": {
@@ -671,7 +671,7 @@
                 "line": 11,
                 "column": 11
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           }
         ],
@@ -686,7 +686,7 @@
               "line": 12,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "loc": {
@@ -698,7 +698,7 @@
             "line": 12,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "_meta": {
@@ -711,7 +711,7 @@
             "line": 12,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "loc": {
@@ -723,7 +723,7 @@
           "line": 12,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "control-flow.php"
       }
     },
     {
@@ -741,7 +741,7 @@
               "line": 14,
               "column": 11
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "loc": {
@@ -753,7 +753,7 @@
             "line": 14,
             "column": 11
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "body": {
@@ -776,7 +776,7 @@
                       "line": 15,
                       "column": 10
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "control-flow.php"
                   }
                 },
                 "loc": {
@@ -788,7 +788,7 @@
                     "line": 15,
                     "column": 10
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "control-flow.php"
                 }
               },
               "arguments": [],
@@ -802,7 +802,7 @@
                     "line": 15,
                     "column": 12
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "control-flow.php"
                 }
               },
               "loc": {
@@ -814,7 +814,7 @@
                   "line": 15,
                   "column": 12
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "control-flow.php"
               }
             },
             "_meta": {
@@ -827,7 +827,7 @@
                   "line": 15,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "control-flow.php"
               }
             },
             "loc": {
@@ -839,7 +839,7 @@
                 "line": 15,
                 "column": 13
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           },
           {
@@ -855,7 +855,7 @@
                   "line": 16,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "control-flow.php"
               }
             },
             "loc": {
@@ -867,7 +867,7 @@
                 "line": 16,
                 "column": 11
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           }
         ],
@@ -882,7 +882,7 @@
               "line": 17,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "loc": {
@@ -894,7 +894,7 @@
             "line": 17,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "isPostTest": false,
@@ -908,7 +908,7 @@
             "line": 17,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "loc": {
@@ -920,7 +920,7 @@
           "line": 17,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "control-flow.php"
       }
     },
     {
@@ -938,7 +938,7 @@
               "line": 21,
               "column": 15
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "loc": {
@@ -950,7 +950,7 @@
             "line": 21,
             "column": 15
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "body": {
@@ -973,7 +973,7 @@
                       "line": 20,
                       "column": 7
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "control-flow.php"
                   }
                 },
                 "loc": {
@@ -985,7 +985,7 @@
                     "line": 20,
                     "column": 7
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "control-flow.php"
                 }
               },
               "right": {
@@ -1002,7 +1002,7 @@
                       "line": 20,
                       "column": 11
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "control-flow.php"
                   }
                 },
                 "loc": {
@@ -1014,7 +1014,7 @@
                     "line": 20,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "control-flow.php"
                 }
               },
               "operator": "=",
@@ -1029,7 +1029,7 @@
                     "line": 20,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "control-flow.php"
                 }
               },
               "loc": {
@@ -1041,7 +1041,7 @@
                   "line": 20,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "control-flow.php"
               }
             },
             "_meta": {
@@ -1054,7 +1054,7 @@
                   "line": 20,
                   "column": 12
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "control-flow.php"
               }
             },
             "loc": {
@@ -1066,7 +1066,7 @@
                 "line": 20,
                 "column": 12
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           }
         ],
@@ -1081,7 +1081,7 @@
               "line": 21,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "loc": {
@@ -1093,7 +1093,7 @@
             "line": 21,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "isPostTest": true,
@@ -1107,7 +1107,7 @@
             "line": 21,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "loc": {
@@ -1119,7 +1119,7 @@
           "line": 21,
           "column": 17
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "control-flow.php"
       }
     },
     {
@@ -1137,7 +1137,7 @@
               "line": 23,
               "column": 11
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "loc": {
@@ -1149,7 +1149,7 @@
             "line": 23,
             "column": 11
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "cases": [
@@ -1169,7 +1169,7 @@
                   "line": 24,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "control-flow.php"
               }
             },
             "loc": {
@@ -1181,7 +1181,7 @@
                 "line": 24,
                 "column": 11
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           },
           "body": {
@@ -1204,7 +1204,7 @@
                           "line": 25,
                           "column": 12
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                        "sourcefile": "control-flow.php"
                       }
                     },
                     "loc": {
@@ -1216,7 +1216,7 @@
                         "line": 25,
                         "column": 12
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "control-flow.php"
                     }
                   },
                   "arguments": [],
@@ -1230,7 +1230,7 @@
                         "line": 25,
                         "column": 14
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "control-flow.php"
                     }
                   },
                   "loc": {
@@ -1242,7 +1242,7 @@
                       "line": 25,
                       "column": 14
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "control-flow.php"
                   }
                 },
                 "_meta": {
@@ -1255,7 +1255,7 @@
                       "line": 25,
                       "column": 15
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "control-flow.php"
                   }
                 },
                 "loc": {
@@ -1267,7 +1267,7 @@
                     "line": 25,
                     "column": 15
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "control-flow.php"
                 }
               },
               {
@@ -1283,7 +1283,7 @@
                       "line": 26,
                       "column": 15
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "control-flow.php"
                   }
                 },
                 "loc": {
@@ -1295,7 +1295,7 @@
                     "line": 26,
                     "column": 15
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "control-flow.php"
                 }
               }
             ],
@@ -1310,7 +1310,7 @@
                   "line": 26,
                   "column": 15
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "control-flow.php"
               }
             },
             "loc": {
@@ -1322,7 +1322,7 @@
                 "line": 26,
                 "column": 15
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           },
           "_meta": {
@@ -1335,7 +1335,7 @@
                 "line": 26,
                 "column": 15
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           },
           "loc": {
@@ -1347,7 +1347,7 @@
               "line": 26,
               "column": 15
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         {
@@ -1373,7 +1373,7 @@
                           "line": 28,
                           "column": 12
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                        "sourcefile": "control-flow.php"
                       }
                     },
                     "loc": {
@@ -1385,7 +1385,7 @@
                         "line": 28,
                         "column": 12
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "control-flow.php"
                     }
                   },
                   "arguments": [],
@@ -1399,7 +1399,7 @@
                         "line": 28,
                         "column": 14
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "control-flow.php"
                     }
                   },
                   "loc": {
@@ -1411,7 +1411,7 @@
                       "line": 28,
                       "column": 14
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "control-flow.php"
                   }
                 },
                 "_meta": {
@@ -1424,7 +1424,7 @@
                       "line": 28,
                       "column": 15
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "control-flow.php"
                   }
                 },
                 "loc": {
@@ -1436,7 +1436,7 @@
                     "line": 28,
                     "column": 15
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "control-flow.php"
                 }
               }
             ],
@@ -1451,7 +1451,7 @@
                   "line": 28,
                   "column": 15
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "control-flow.php"
               }
             },
             "loc": {
@@ -1463,7 +1463,7 @@
                 "line": 28,
                 "column": 15
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           },
           "_meta": {
@@ -1476,7 +1476,7 @@
                 "line": 28,
                 "column": 15
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           },
           "loc": {
@@ -1488,7 +1488,7 @@
               "line": 28,
               "column": 15
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         }
       ],
@@ -1502,7 +1502,7 @@
             "line": 29,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "loc": {
@@ -1514,7 +1514,7 @@
           "line": 29,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "control-flow.php"
       }
     },
     {
@@ -1539,7 +1539,7 @@
                       "line": 32,
                       "column": 10
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "control-flow.php"
                   }
                 },
                 "loc": {
@@ -1551,7 +1551,7 @@
                     "line": 32,
                     "column": 10
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "control-flow.php"
                 }
               },
               "arguments": [],
@@ -1565,7 +1565,7 @@
                     "line": 32,
                     "column": 12
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "control-flow.php"
                 }
               },
               "loc": {
@@ -1577,7 +1577,7 @@
                   "line": 32,
                   "column": 12
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "control-flow.php"
               }
             },
             "_meta": {
@@ -1590,7 +1590,7 @@
                   "line": 32,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "control-flow.php"
               }
             },
             "loc": {
@@ -1602,7 +1602,7 @@
                 "line": 32,
                 "column": 13
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           }
         ],
@@ -1617,7 +1617,7 @@
               "line": 33,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "loc": {
@@ -1629,7 +1629,7 @@
             "line": 33,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "handlers": [
@@ -1651,7 +1651,7 @@
                       "line": 33,
                       "column": 23
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "control-flow.php"
                   }
                 },
                 "loc": {
@@ -1663,7 +1663,7 @@
                     "line": 33,
                     "column": 23
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "control-flow.php"
                 }
               },
               "init": null,
@@ -1688,7 +1688,7 @@
                           "line": 33,
                           "column": 20
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                        "sourcefile": "control-flow.php"
                       }
                     },
                     "loc": {
@@ -1700,7 +1700,7 @@
                         "line": 33,
                         "column": 20
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "control-flow.php"
                     }
                   }
                 ],
@@ -1713,7 +1713,7 @@
                     "line": 35,
                     "column": 2
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "control-flow.php"
                 }
               },
               "loc": {
@@ -1725,7 +1725,7 @@
                   "line": 35,
                   "column": 2
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "control-flow.php"
               }
             }
           ],
@@ -1747,7 +1747,7 @@
                         "line": 34,
                         "column": 13
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "control-flow.php"
                     }
                   },
                   "loc": {
@@ -1759,7 +1759,7 @@
                       "line": 34,
                       "column": 13
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "control-flow.php"
                   }
                 },
                 "_meta": {
@@ -1772,7 +1772,7 @@
                       "line": 34,
                       "column": 14
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "control-flow.php"
                   }
                 },
                 "loc": {
@@ -1784,7 +1784,7 @@
                     "line": 34,
                     "column": 14
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "control-flow.php"
                 }
               }
             ],
@@ -1799,7 +1799,7 @@
                   "line": 35,
                   "column": 2
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "control-flow.php"
               }
             },
             "loc": {
@@ -1811,7 +1811,7 @@
                 "line": 35,
                 "column": 2
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           },
           "_meta": {
@@ -1824,7 +1824,7 @@
                 "line": 35,
                 "column": 2
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           },
           "loc": {
@@ -1836,7 +1836,7 @@
               "line": 35,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         }
       ],
@@ -1860,7 +1860,7 @@
                       "line": 36,
                       "column": 12
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "control-flow.php"
                   }
                 },
                 "loc": {
@@ -1872,7 +1872,7 @@
                     "line": 36,
                     "column": 12
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "control-flow.php"
                 }
               },
               "arguments": [],
@@ -1886,7 +1886,7 @@
                     "line": 36,
                     "column": 14
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "control-flow.php"
                 }
               },
               "loc": {
@@ -1898,7 +1898,7 @@
                   "line": 36,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "control-flow.php"
               }
             },
             "_meta": {
@@ -1911,7 +1911,7 @@
                   "line": 36,
                   "column": 15
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "control-flow.php"
               }
             },
             "loc": {
@@ -1923,7 +1923,7 @@
                 "line": 36,
                 "column": 15
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "control-flow.php"
             }
           }
         ],
@@ -1938,7 +1938,7 @@
               "line": 37,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "control-flow.php"
           }
         },
         "loc": {
@@ -1950,7 +1950,7 @@
             "line": 37,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "_meta": {
@@ -1963,7 +1963,7 @@
             "line": 37,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "control-flow.php"
         }
       },
       "loc": {
@@ -1975,13 +1975,13 @@
           "line": 37,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "control-flow.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php",
+  "uri": "control-flow.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -1993,7 +1993,7 @@
         "line": 38,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+      "sourcefile": "control-flow.php"
     }
   },
   "loc": {
@@ -2005,6 +2005,6 @@
       "line": 38,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
+    "sourcefile": "control-flow.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/control-flow.php.json
+++ b/parser-PHP/tests/benchmark/base/control-flow.php.json
@@ -18,7 +18,7 @@
                 "line": 3,
                 "column": 8
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "loc": {
@@ -30,7 +30,7 @@
               "line": 3,
               "column": 8
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "right": {
@@ -47,7 +47,7 @@
                 "line": 3,
                 "column": 12
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "loc": {
@@ -59,7 +59,7 @@
               "line": 3,
               "column": 12
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "operator": "=",
@@ -74,7 +74,7 @@
               "line": 3,
               "column": 12
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -86,7 +86,7 @@
             "line": 3,
             "column": 12
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "test": {
@@ -105,7 +105,7 @@
                 "line": 3,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "loc": {
@@ -117,7 +117,7 @@
               "line": 3,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "right": {
@@ -134,7 +134,7 @@
                 "line": 3,
                 "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "loc": {
@@ -146,7 +146,7 @@
               "line": 3,
               "column": 20
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "_meta": {
@@ -159,7 +159,7 @@
               "line": 3,
               "column": 20
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -171,7 +171,7 @@
             "line": 3,
             "column": 20
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "update": {
@@ -190,7 +190,7 @@
                 "line": 3,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "loc": {
@@ -202,7 +202,7 @@
               "line": 3,
               "column": 24
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "isSuffix": true,
@@ -216,7 +216,7 @@
               "line": 3,
               "column": 26
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -228,7 +228,7 @@
             "line": 3,
             "column": 26
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "body": {
@@ -257,7 +257,7 @@
                         "line": 4,
                         "column": 12
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                     }
                   },
                   "loc": {
@@ -269,7 +269,7 @@
                       "line": 4,
                       "column": 12
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 }
               ],
@@ -283,7 +283,7 @@
                     "line": 4,
                     "column": 13
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "loc": {
@@ -295,7 +295,7 @@
                   "line": 4,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "_meta": {
@@ -308,7 +308,7 @@
                   "line": 4,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -320,7 +320,7 @@
                 "line": 4,
                 "column": 13
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           }
         ],
@@ -335,7 +335,7 @@
               "line": 5,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -347,7 +347,7 @@
             "line": 5,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "_meta": {
@@ -360,7 +360,7 @@
             "line": 5,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "loc": {
@@ -372,7 +372,7 @@
           "line": 5,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
       }
     },
     {
@@ -392,7 +392,7 @@
                 "line": 7,
                 "column": 22
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "loc": {
@@ -404,7 +404,7 @@
               "line": 7,
               "column": 22
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "init": null,
@@ -424,7 +424,7 @@
               "line": 7,
               "column": 22
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -436,7 +436,7 @@
             "line": 7,
             "column": 22
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "value": {
@@ -454,7 +454,7 @@
                 "line": 7,
                 "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "loc": {
@@ -466,7 +466,7 @@
               "line": 7,
               "column": 28
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "init": null,
@@ -486,7 +486,7 @@
               "line": 7,
               "column": 28
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -498,7 +498,7 @@
             "line": 7,
             "column": 28
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "right": {
@@ -514,7 +514,7 @@
               "line": 7,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -526,7 +526,7 @@
             "line": 7,
             "column": 16
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "body": {
@@ -547,7 +547,7 @@
                     "line": 8,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "loc": {
@@ -559,7 +559,7 @@
                   "line": 8,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "consequent": {
@@ -578,7 +578,7 @@
                         "line": 9,
                         "column": 18
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                     }
                   },
                   "loc": {
@@ -590,7 +590,7 @@
                       "line": 9,
                       "column": 18
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 }
               ],
@@ -605,7 +605,7 @@
                     "line": 10,
                     "column": 6
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "loc": {
@@ -617,7 +617,7 @@
                   "line": 10,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "alternative": null,
@@ -631,7 +631,7 @@
                   "line": 10,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -643,7 +643,7 @@
                 "line": 10,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           {
@@ -659,7 +659,7 @@
                   "line": 11,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -671,7 +671,7 @@
                 "line": 11,
                 "column": 11
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           }
         ],
@@ -686,7 +686,7 @@
               "line": 12,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -698,7 +698,7 @@
             "line": 12,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "_meta": {
@@ -711,7 +711,7 @@
             "line": 12,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "loc": {
@@ -723,7 +723,7 @@
           "line": 12,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
       }
     },
     {
@@ -741,7 +741,7 @@
               "line": 14,
               "column": 11
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -753,7 +753,7 @@
             "line": 14,
             "column": 11
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "body": {
@@ -776,7 +776,7 @@
                       "line": 15,
                       "column": 10
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "loc": {
@@ -788,7 +788,7 @@
                     "line": 15,
                     "column": 10
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "arguments": [],
@@ -802,7 +802,7 @@
                     "line": 15,
                     "column": 12
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "loc": {
@@ -814,7 +814,7 @@
                   "line": 15,
                   "column": 12
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "_meta": {
@@ -827,7 +827,7 @@
                   "line": 15,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -839,7 +839,7 @@
                 "line": 15,
                 "column": 13
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           {
@@ -855,7 +855,7 @@
                   "line": 16,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -867,7 +867,7 @@
                 "line": 16,
                 "column": 11
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           }
         ],
@@ -882,7 +882,7 @@
               "line": 17,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -894,7 +894,7 @@
             "line": 17,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "isPostTest": false,
@@ -908,7 +908,7 @@
             "line": 17,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "loc": {
@@ -920,7 +920,7 @@
           "line": 17,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
       }
     },
     {
@@ -938,7 +938,7 @@
               "line": 21,
               "column": 15
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -950,7 +950,7 @@
             "line": 21,
             "column": 15
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "body": {
@@ -973,7 +973,7 @@
                       "line": 20,
                       "column": 7
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "loc": {
@@ -985,7 +985,7 @@
                     "line": 20,
                     "column": 7
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "right": {
@@ -1002,7 +1002,7 @@
                       "line": 20,
                       "column": 11
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "loc": {
@@ -1014,7 +1014,7 @@
                     "line": 20,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "operator": "=",
@@ -1029,7 +1029,7 @@
                     "line": 20,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "loc": {
@@ -1041,7 +1041,7 @@
                   "line": 20,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "_meta": {
@@ -1054,7 +1054,7 @@
                   "line": 20,
                   "column": 12
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -1066,7 +1066,7 @@
                 "line": 20,
                 "column": 12
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           }
         ],
@@ -1081,7 +1081,7 @@
               "line": 21,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -1093,7 +1093,7 @@
             "line": 21,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "isPostTest": true,
@@ -1107,7 +1107,7 @@
             "line": 21,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "loc": {
@@ -1119,7 +1119,7 @@
           "line": 21,
           "column": 17
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
       }
     },
     {
@@ -1137,7 +1137,7 @@
               "line": 23,
               "column": 11
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -1149,7 +1149,7 @@
             "line": 23,
             "column": 11
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "cases": [
@@ -1169,7 +1169,7 @@
                   "line": 24,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -1181,7 +1181,7 @@
                 "line": 24,
                 "column": 11
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "body": {
@@ -1204,7 +1204,7 @@
                           "line": 25,
                           "column": 12
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                       }
                     },
                     "loc": {
@@ -1216,7 +1216,7 @@
                         "line": 25,
                         "column": 12
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                     }
                   },
                   "arguments": [],
@@ -1230,7 +1230,7 @@
                         "line": 25,
                         "column": 14
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                     }
                   },
                   "loc": {
@@ -1242,7 +1242,7 @@
                       "line": 25,
                       "column": 14
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "_meta": {
@@ -1255,7 +1255,7 @@
                       "line": 25,
                       "column": 15
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "loc": {
@@ -1267,7 +1267,7 @@
                     "line": 25,
                     "column": 15
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               {
@@ -1283,7 +1283,7 @@
                       "line": 26,
                       "column": 15
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "loc": {
@@ -1295,7 +1295,7 @@
                     "line": 26,
                     "column": 15
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               }
             ],
@@ -1310,7 +1310,7 @@
                   "line": 26,
                   "column": 15
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -1322,7 +1322,7 @@
                 "line": 26,
                 "column": 15
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "_meta": {
@@ -1335,7 +1335,7 @@
                 "line": 26,
                 "column": 15
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "loc": {
@@ -1347,7 +1347,7 @@
               "line": 26,
               "column": 15
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         {
@@ -1373,7 +1373,7 @@
                           "line": 28,
                           "column": 12
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                       }
                     },
                     "loc": {
@@ -1385,7 +1385,7 @@
                         "line": 28,
                         "column": 12
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                     }
                   },
                   "arguments": [],
@@ -1399,7 +1399,7 @@
                         "line": 28,
                         "column": 14
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                     }
                   },
                   "loc": {
@@ -1411,7 +1411,7 @@
                       "line": 28,
                       "column": 14
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "_meta": {
@@ -1424,7 +1424,7 @@
                       "line": 28,
                       "column": 15
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "loc": {
@@ -1436,7 +1436,7 @@
                     "line": 28,
                     "column": 15
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               }
             ],
@@ -1451,7 +1451,7 @@
                   "line": 28,
                   "column": 15
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -1463,7 +1463,7 @@
                 "line": 28,
                 "column": 15
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "_meta": {
@@ -1476,7 +1476,7 @@
                 "line": 28,
                 "column": 15
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "loc": {
@@ -1488,7 +1488,7 @@
               "line": 28,
               "column": 15
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         }
       ],
@@ -1502,7 +1502,7 @@
             "line": 29,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "loc": {
@@ -1514,7 +1514,7 @@
           "line": 29,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
       }
     },
     {
@@ -1539,7 +1539,7 @@
                       "line": 32,
                       "column": 10
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "loc": {
@@ -1551,7 +1551,7 @@
                     "line": 32,
                     "column": 10
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "arguments": [],
@@ -1565,7 +1565,7 @@
                     "line": 32,
                     "column": 12
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "loc": {
@@ -1577,7 +1577,7 @@
                   "line": 32,
                   "column": 12
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "_meta": {
@@ -1590,7 +1590,7 @@
                   "line": 32,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -1602,7 +1602,7 @@
                 "line": 32,
                 "column": 13
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           }
         ],
@@ -1617,7 +1617,7 @@
               "line": 33,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -1629,7 +1629,7 @@
             "line": 33,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "handlers": [
@@ -1651,7 +1651,7 @@
                       "line": 33,
                       "column": 23
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "loc": {
@@ -1663,7 +1663,7 @@
                     "line": 33,
                     "column": 23
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "init": null,
@@ -1688,7 +1688,7 @@
                           "line": 33,
                           "column": 20
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                       }
                     },
                     "loc": {
@@ -1700,7 +1700,7 @@
                         "line": 33,
                         "column": 20
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                     }
                   }
                 ],
@@ -1713,7 +1713,7 @@
                     "line": 35,
                     "column": 2
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "loc": {
@@ -1725,7 +1725,7 @@
                   "line": 35,
                   "column": 2
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             }
           ],
@@ -1747,7 +1747,7 @@
                         "line": 34,
                         "column": 13
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                     }
                   },
                   "loc": {
@@ -1759,7 +1759,7 @@
                       "line": 34,
                       "column": 13
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "_meta": {
@@ -1772,7 +1772,7 @@
                       "line": 34,
                       "column": 14
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "loc": {
@@ -1784,7 +1784,7 @@
                     "line": 34,
                     "column": 14
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               }
             ],
@@ -1799,7 +1799,7 @@
                   "line": 35,
                   "column": 2
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -1811,7 +1811,7 @@
                 "line": 35,
                 "column": 2
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "_meta": {
@@ -1824,7 +1824,7 @@
                 "line": 35,
                 "column": 2
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           },
           "loc": {
@@ -1836,7 +1836,7 @@
               "line": 35,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         }
       ],
@@ -1860,7 +1860,7 @@
                       "line": 36,
                       "column": 12
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                   }
                 },
                 "loc": {
@@ -1872,7 +1872,7 @@
                     "line": 36,
                     "column": 12
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "arguments": [],
@@ -1886,7 +1886,7 @@
                     "line": 36,
                     "column": 14
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
                 }
               },
               "loc": {
@@ -1898,7 +1898,7 @@
                   "line": 36,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "_meta": {
@@ -1911,7 +1911,7 @@
                   "line": 36,
                   "column": 15
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
               }
             },
             "loc": {
@@ -1923,7 +1923,7 @@
                 "line": 36,
                 "column": 15
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
             }
           }
         ],
@@ -1938,7 +1938,7 @@
               "line": 37,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
           }
         },
         "loc": {
@@ -1950,7 +1950,7 @@
             "line": 37,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "_meta": {
@@ -1963,7 +1963,7 @@
             "line": 37,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
         }
       },
       "loc": {
@@ -1975,13 +1975,13 @@
           "line": 37,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -1993,7 +1993,7 @@
         "line": 38,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
     }
   },
   "loc": {
@@ -2005,6 +2005,6 @@
       "line": 38,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/control-flow.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/control-flow.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/enum-trait-adapt.php.json
+++ b/parser-PHP/tests/benchmark/base/enum-trait-adapt.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "enum-trait-adapt.php"
           }
         },
         "loc": {
@@ -28,7 +28,7 @@
             "line": 3,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "enum-trait-adapt.php"
         }
       },
       "body": [
@@ -47,7 +47,7 @@
                   "line": 5,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -59,7 +59,7 @@
                 "line": 5,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "enum-trait-adapt.php"
             }
           },
           "parameters": [],
@@ -95,7 +95,7 @@
                             "line": 7,
                             "column": 17
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                          "sourcefile": "enum-trait-adapt.php"
                         },
                         "encapsed": true
                       },
@@ -108,7 +108,7 @@
                           "line": 7,
                           "column": 17
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                        "sourcefile": "enum-trait-adapt.php"
                       }
                     }
                   ],
@@ -122,7 +122,7 @@
                         "line": 7,
                         "column": 18
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                      "sourcefile": "enum-trait-adapt.php"
                     }
                   },
                   "loc": {
@@ -134,7 +134,7 @@
                       "line": 7,
                       "column": 18
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "enum-trait-adapt.php"
                   }
                 },
                 "_meta": {
@@ -147,7 +147,7 @@
                       "line": 7,
                       "column": 18
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "enum-trait-adapt.php"
                   }
                 },
                 "loc": {
@@ -159,7 +159,7 @@
                     "line": 7,
                     "column": 18
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                  "sourcefile": "enum-trait-adapt.php"
                 }
               }
             ],
@@ -174,7 +174,7 @@
                   "line": 8,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -186,7 +186,7 @@
                 "line": 8,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "enum-trait-adapt.php"
             }
           },
           "modifiers": [
@@ -202,7 +202,7 @@
                 "line": 8,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "enum-trait-adapt.php"
             }
           },
           "loc": {
@@ -214,7 +214,7 @@
               "line": 8,
               "column": 6
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "enum-trait-adapt.php"
           }
         }
       ],
@@ -230,7 +230,7 @@
             "line": 9,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "enum-trait-adapt.php"
         }
       },
       "loc": {
@@ -242,7 +242,7 @@
           "line": 9,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+        "sourcefile": "enum-trait-adapt.php"
       }
     },
     {
@@ -260,7 +260,7 @@
               "line": 11,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "enum-trait-adapt.php"
           }
         },
         "loc": {
@@ -272,7 +272,7 @@
             "line": 11,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "enum-trait-adapt.php"
         }
       },
       "body": [
@@ -291,7 +291,7 @@
                   "line": 13,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -303,7 +303,7 @@
                 "line": 13,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "enum-trait-adapt.php"
             }
           },
           "parameters": [],
@@ -339,7 +339,7 @@
                             "line": 15,
                             "column": 17
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                          "sourcefile": "enum-trait-adapt.php"
                         },
                         "encapsed": true
                       },
@@ -352,7 +352,7 @@
                           "line": 15,
                           "column": 17
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                        "sourcefile": "enum-trait-adapt.php"
                       }
                     }
                   ],
@@ -366,7 +366,7 @@
                         "line": 15,
                         "column": 18
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                      "sourcefile": "enum-trait-adapt.php"
                     }
                   },
                   "loc": {
@@ -378,7 +378,7 @@
                       "line": 15,
                       "column": 18
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "enum-trait-adapt.php"
                   }
                 },
                 "_meta": {
@@ -391,7 +391,7 @@
                       "line": 15,
                       "column": 18
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "enum-trait-adapt.php"
                   }
                 },
                 "loc": {
@@ -403,7 +403,7 @@
                     "line": 15,
                     "column": 18
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                  "sourcefile": "enum-trait-adapt.php"
                 }
               }
             ],
@@ -418,7 +418,7 @@
                   "line": 16,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -430,7 +430,7 @@
                 "line": 16,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "enum-trait-adapt.php"
             }
           },
           "modifiers": [
@@ -446,7 +446,7 @@
                 "line": 16,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "enum-trait-adapt.php"
             }
           },
           "loc": {
@@ -458,7 +458,7 @@
               "line": 16,
               "column": 6
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "enum-trait-adapt.php"
           }
         }
       ],
@@ -474,7 +474,7 @@
             "line": 17,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "enum-trait-adapt.php"
         }
       },
       "loc": {
@@ -486,7 +486,7 @@
           "line": 17,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+        "sourcefile": "enum-trait-adapt.php"
       }
     },
     {
@@ -504,7 +504,7 @@
               "line": 19,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "enum-trait-adapt.php"
           }
         },
         "loc": {
@@ -516,7 +516,7 @@
             "line": 19,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "enum-trait-adapt.php"
         }
       },
       "body": [
@@ -543,7 +543,7 @@
                       "line": 21,
                       "column": 16
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "enum-trait-adapt.php"
                   }
                 },
                 "loc": {
@@ -555,7 +555,7 @@
                     "line": 21,
                     "column": 16
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                  "sourcefile": "enum-trait-adapt.php"
                 }
               },
               {
@@ -571,7 +571,7 @@
                       "line": 21,
                       "column": 25
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "enum-trait-adapt.php"
                   }
                 },
                 "loc": {
@@ -583,7 +583,7 @@
                     "line": 21,
                     "column": 25
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                  "sourcefile": "enum-trait-adapt.php"
                 }
               },
               {
@@ -598,7 +598,7 @@
                       "line": 24,
                       "column": 6
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "enum-trait-adapt.php"
                   }
                 },
                 "loc": {
@@ -610,7 +610,7 @@
                     "line": 24,
                     "column": 6
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                  "sourcefile": "enum-trait-adapt.php"
                 }
               }
             ],
@@ -625,7 +625,7 @@
                   "line": 24,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -637,7 +637,7 @@
                 "line": 24,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "enum-trait-adapt.php"
             }
           },
           "_meta": {
@@ -650,7 +650,7 @@
                 "line": 24,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "enum-trait-adapt.php"
             }
           },
           "loc": {
@@ -662,7 +662,7 @@
               "line": 24,
               "column": 6
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "enum-trait-adapt.php"
           }
         }
       ],
@@ -677,7 +677,7 @@
             "line": 25,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "enum-trait-adapt.php"
         }
       },
       "loc": {
@@ -689,7 +689,7 @@
           "line": 25,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+        "sourcefile": "enum-trait-adapt.php"
       }
     },
     {
@@ -707,7 +707,7 @@
               "line": 27,
               "column": 12
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "enum-trait-adapt.php"
           }
         },
         "loc": {
@@ -719,7 +719,7 @@
             "line": 27,
             "column": 12
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "enum-trait-adapt.php"
         }
       },
       "body": [
@@ -738,7 +738,7 @@
                   "line": 29,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -750,7 +750,7 @@
                 "line": 29,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "enum-trait-adapt.php"
             }
           },
           "init": {
@@ -767,7 +767,7 @@
                   "line": 29,
                   "column": 23
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -779,7 +779,7 @@
                 "line": 29,
                 "column": 23
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "enum-trait-adapt.php"
             }
           },
           "cloned": false,
@@ -799,7 +799,7 @@
                 "line": 29,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "enum-trait-adapt.php"
             }
           },
           "loc": {
@@ -811,7 +811,7 @@
               "line": 29,
               "column": 24
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "enum-trait-adapt.php"
           }
         },
         {
@@ -829,7 +829,7 @@
                   "line": 30,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -841,7 +841,7 @@
                 "line": 30,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "enum-trait-adapt.php"
             }
           },
           "init": {
@@ -858,7 +858,7 @@
                   "line": 30,
                   "column": 27
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -870,7 +870,7 @@
                 "line": 30,
                 "column": 27
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "enum-trait-adapt.php"
             }
           },
           "cloned": false,
@@ -890,7 +890,7 @@
                 "line": 30,
                 "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "enum-trait-adapt.php"
             }
           },
           "loc": {
@@ -902,7 +902,7 @@
               "line": 30,
               "column": 28
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "enum-trait-adapt.php"
           }
         }
       ],
@@ -918,7 +918,7 @@
             "line": 31,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "enum-trait-adapt.php"
         }
       },
       "loc": {
@@ -930,13 +930,13 @@
           "line": 31,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+        "sourcefile": "enum-trait-adapt.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php",
+  "uri": "enum-trait-adapt.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -948,7 +948,7 @@
         "line": 32,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+      "sourcefile": "enum-trait-adapt.php"
     }
   },
   "loc": {
@@ -960,6 +960,6 @@
       "line": 32,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+    "sourcefile": "enum-trait-adapt.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/enum-trait-adapt.php.json
+++ b/parser-PHP/tests/benchmark/base/enum-trait-adapt.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         },
         "loc": {
@@ -28,7 +28,7 @@
             "line": 3,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         }
       },
       "body": [
@@ -47,7 +47,7 @@
                   "line": 5,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -59,7 +59,7 @@
                 "line": 5,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "parameters": [],
@@ -95,7 +95,7 @@
                             "line": 7,
                             "column": 17
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                         },
                         "encapsed": true
                       },
@@ -108,7 +108,7 @@
                           "line": 7,
                           "column": 17
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                       }
                     }
                   ],
@@ -122,7 +122,7 @@
                         "line": 7,
                         "column": 18
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                     }
                   },
                   "loc": {
@@ -134,7 +134,7 @@
                       "line": 7,
                       "column": 18
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   }
                 },
                 "_meta": {
@@ -147,7 +147,7 @@
                       "line": 7,
                       "column": 18
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   }
                 },
                 "loc": {
@@ -159,7 +159,7 @@
                     "line": 7,
                     "column": 18
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                 }
               }
             ],
@@ -174,7 +174,7 @@
                   "line": 8,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -186,7 +186,7 @@
                 "line": 8,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "modifiers": [
@@ -202,7 +202,7 @@
                 "line": 8,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "loc": {
@@ -214,7 +214,7 @@
               "line": 8,
               "column": 6
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         }
       ],
@@ -230,7 +230,7 @@
             "line": 9,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         }
       },
       "loc": {
@@ -242,7 +242,7 @@
           "line": 9,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
       }
     },
     {
@@ -260,7 +260,7 @@
               "line": 11,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         },
         "loc": {
@@ -272,7 +272,7 @@
             "line": 11,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         }
       },
       "body": [
@@ -291,7 +291,7 @@
                   "line": 13,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -303,7 +303,7 @@
                 "line": 13,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "parameters": [],
@@ -339,7 +339,7 @@
                             "line": 15,
                             "column": 17
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                         },
                         "encapsed": true
                       },
@@ -352,7 +352,7 @@
                           "line": 15,
                           "column": 17
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                       }
                     }
                   ],
@@ -366,7 +366,7 @@
                         "line": 15,
                         "column": 18
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                     }
                   },
                   "loc": {
@@ -378,7 +378,7 @@
                       "line": 15,
                       "column": 18
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   }
                 },
                 "_meta": {
@@ -391,7 +391,7 @@
                       "line": 15,
                       "column": 18
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   }
                 },
                 "loc": {
@@ -403,7 +403,7 @@
                     "line": 15,
                     "column": 18
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                 }
               }
             ],
@@ -418,7 +418,7 @@
                   "line": 16,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -430,7 +430,7 @@
                 "line": 16,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "modifiers": [
@@ -446,7 +446,7 @@
                 "line": 16,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "loc": {
@@ -458,7 +458,7 @@
               "line": 16,
               "column": 6
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         }
       ],
@@ -474,7 +474,7 @@
             "line": 17,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         }
       },
       "loc": {
@@ -486,7 +486,7 @@
           "line": 17,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
       }
     },
     {
@@ -504,7 +504,7 @@
               "line": 19,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         },
         "loc": {
@@ -516,7 +516,7 @@
             "line": 19,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         }
       },
       "body": [
@@ -543,7 +543,7 @@
                       "line": 21,
                       "column": 16
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   }
                 },
                 "loc": {
@@ -555,7 +555,7 @@
                     "line": 21,
                     "column": 16
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                 }
               },
               {
@@ -571,7 +571,7 @@
                       "line": 21,
                       "column": 25
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   }
                 },
                 "loc": {
@@ -583,7 +583,7 @@
                     "line": 21,
                     "column": 25
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                 }
               },
               {
@@ -598,7 +598,7 @@
                       "line": 24,
                       "column": 6
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   }
                 },
                 "loc": {
@@ -610,7 +610,7 @@
                     "line": 24,
                     "column": 6
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                 }
               }
             ],
@@ -625,7 +625,7 @@
                   "line": 24,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -637,7 +637,7 @@
                 "line": 24,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "_meta": {
@@ -650,7 +650,7 @@
                 "line": 24,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "loc": {
@@ -662,7 +662,7 @@
               "line": 24,
               "column": 6
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         }
       ],
@@ -677,7 +677,7 @@
             "line": 25,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         }
       },
       "loc": {
@@ -689,7 +689,7 @@
           "line": 25,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
       }
     },
     {
@@ -707,7 +707,7 @@
               "line": 27,
               "column": 12
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         },
         "loc": {
@@ -719,7 +719,7 @@
             "line": 27,
             "column": 12
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         }
       },
       "body": [
@@ -738,7 +738,7 @@
                   "line": 29,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -750,7 +750,7 @@
                 "line": 29,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "init": {
@@ -767,7 +767,7 @@
                   "line": 29,
                   "column": 23
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -779,7 +779,7 @@
                 "line": 29,
                 "column": 23
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "cloned": false,
@@ -799,7 +799,7 @@
                 "line": 29,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "loc": {
@@ -811,7 +811,7 @@
               "line": 29,
               "column": 24
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         },
         {
@@ -829,7 +829,7 @@
                   "line": 30,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -841,7 +841,7 @@
                 "line": 30,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "init": {
@@ -858,7 +858,7 @@
                   "line": 30,
                   "column": 27
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -870,7 +870,7 @@
                 "line": 30,
                 "column": 27
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "cloned": false,
@@ -890,7 +890,7 @@
                 "line": 30,
                 "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "loc": {
@@ -902,7 +902,7 @@
               "line": 30,
               "column": 28
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         }
       ],
@@ -918,7 +918,7 @@
             "line": 31,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         }
       },
       "loc": {
@@ -930,13 +930,13 @@
           "line": 31,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -948,7 +948,7 @@
         "line": 32,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
     }
   },
   "loc": {
@@ -960,6 +960,6 @@
       "line": 32,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/enum-trait-adapt.php.json
+++ b/parser-PHP/tests/benchmark/base/enum-trait-adapt.php.json
@@ -16,24 +16,7 @@
               "line": 3,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-          },
-          "origin": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 6,
-                "offset": 13
-              },
-              "end": {
-                "line": 3,
-                "column": 13,
-                "offset": 20
-              }
-            },
-            "name": "LoggerA"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         },
         "loc": {
@@ -45,7 +28,7 @@
             "line": 3,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         }
       },
       "body": [
@@ -64,24 +47,7 @@
                   "line": 5,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 20,
-                    "offset": 43
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 23,
-                    "offset": 46
-                  }
-                },
-                "name": "log"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -93,7 +59,7 @@
                 "line": 5,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "parameters": [],
@@ -129,28 +95,9 @@
                             "line": 7,
                             "column": 17
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                         },
-                        "origin": {
-                          "kind": "string",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 7,
-                              "column": 13,
-                              "offset": 68
-                            },
-                            "end": {
-                              "line": 7,
-                              "column": 16,
-                              "offset": 71
-                            }
-                          },
-                          "value": "A",
-                          "raw": "\"A\"",
-                          "unicode": false,
-                          "isDoubleQuote": true
-                        }
+                        "encapsed": true
                       },
                       "loc": {
                         "start": {
@@ -161,7 +108,7 @@
                           "line": 7,
                           "column": 17
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                       }
                     }
                   ],
@@ -175,46 +122,7 @@
                         "line": 7,
                         "column": 18
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-                    },
-                    "origin": {
-                      "kind": "echo",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 7,
-                          "column": 8,
-                          "offset": 63
-                        },
-                        "end": {
-                          "line": 7,
-                          "column": 17,
-                          "offset": 72
-                        }
-                      },
-                      "shortForm": false,
-                      "expressions": [
-                        {
-                          "kind": "string",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 7,
-                              "column": 13,
-                              "offset": 68
-                            },
-                            "end": {
-                              "line": 7,
-                              "column": 16,
-                              "offset": 71
-                            }
-                          },
-                          "value": "A",
-                          "raw": "\"A\"",
-                          "unicode": false,
-                          "isDoubleQuote": true
-                        }
-                      ]
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                     }
                   },
                   "loc": {
@@ -226,7 +134,7 @@
                       "line": 7,
                       "column": 18
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   }
                 },
                 "_meta": {
@@ -239,46 +147,7 @@
                       "line": 7,
                       "column": 18
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-                  },
-                  "origin": {
-                    "kind": "echo",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 7,
-                        "column": 8,
-                        "offset": 63
-                      },
-                      "end": {
-                        "line": 7,
-                        "column": 17,
-                        "offset": 72
-                      }
-                    },
-                    "shortForm": false,
-                    "expressions": [
-                      {
-                        "kind": "string",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 7,
-                            "column": 13,
-                            "offset": 68
-                          },
-                          "end": {
-                            "line": 7,
-                            "column": 16,
-                            "offset": 71
-                          }
-                        },
-                        "value": "A",
-                        "raw": "\"A\"",
-                        "unicode": false,
-                        "isDoubleQuote": true
-                      }
-                    ]
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   }
                 },
                 "loc": {
@@ -290,7 +159,7 @@
                     "line": 7,
                     "column": 18
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                 }
               }
             ],
@@ -305,64 +174,7 @@
                   "line": 8,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-              },
-              "origin": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 4,
-                    "offset": 53
-                  },
-                  "end": {
-                    "line": 8,
-                    "column": 5,
-                    "offset": 78
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "echo",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 7,
-                        "column": 8,
-                        "offset": 63
-                      },
-                      "end": {
-                        "line": 7,
-                        "column": 17,
-                        "offset": 72
-                      }
-                    },
-                    "shortForm": false,
-                    "expressions": [
-                      {
-                        "kind": "string",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 7,
-                            "column": 13,
-                            "offset": 68
-                          },
-                          "end": {
-                            "line": 7,
-                            "column": 16,
-                            "offset": 71
-                          }
-                        },
-                        "value": "A",
-                        "raw": "\"A\"",
-                        "unicode": false,
-                        "isDoubleQuote": true
-                      }
-                    ]
-                  }
-                ]
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -374,14 +186,13 @@
                 "line": 8,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "modifiers": [
             "public"
           ],
           "_meta": {
-            "attributes": [],
             "loc": {
               "start": {
                 "line": 5,
@@ -391,107 +202,7 @@
                 "line": 8,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-            },
-            "origin": {
-              "kind": "method",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 5,
-                  "column": 4,
-                  "offset": 27
-                },
-                "end": {
-                  "line": 8,
-                  "column": 5,
-                  "offset": 78
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 20,
-                    "offset": 43
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 23,
-                    "offset": 46
-                  }
-                },
-                "name": "log"
-              },
-              "arguments": [],
-              "byref": false,
-              "type": null,
-              "nullable": false,
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 4,
-                    "offset": 53
-                  },
-                  "end": {
-                    "line": 8,
-                    "column": 5,
-                    "offset": 78
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "echo",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 7,
-                        "column": 8,
-                        "offset": 63
-                      },
-                      "end": {
-                        "line": 7,
-                        "column": 17,
-                        "offset": 72
-                      }
-                    },
-                    "shortForm": false,
-                    "expressions": [
-                      {
-                        "kind": "string",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 7,
-                            "column": 13,
-                            "offset": 68
-                          },
-                          "end": {
-                            "line": 7,
-                            "column": 16,
-                            "offset": 71
-                          }
-                        },
-                        "value": "A",
-                        "raw": "\"A\"",
-                        "unicode": false,
-                        "isDoubleQuote": true
-                      }
-                    ]
-                  }
-                ]
-              },
-              "attrGroups": [],
-              "isAbstract": false,
-              "isFinal": false,
-              "isReadonly": false,
-              "visibility": "public",
-              "isStatic": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "loc": {
@@ -503,14 +214,13 @@
               "line": 8,
               "column": 6
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         }
       ],
       "supers": [],
       "_meta": {
-        "structureKind": "trait",
-        "attributes": [],
+        "kind": "trait",
         "loc": {
           "start": {
             "line": 3,
@@ -520,142 +230,7 @@
             "line": 9,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-        },
-        "origin": {
-          "kind": "trait",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 7
-            },
-            "end": {
-              "line": 9,
-              "column": 1,
-              "offset": 80
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 6,
-                "offset": 13
-              },
-              "end": {
-                "line": 3,
-                "column": 13,
-                "offset": 20
-              }
-            },
-            "name": "LoggerA"
-          },
-          "body": [
-            {
-              "kind": "method",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 5,
-                  "column": 4,
-                  "offset": 27
-                },
-                "end": {
-                  "line": 8,
-                  "column": 5,
-                  "offset": 78
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 20,
-                    "offset": 43
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 23,
-                    "offset": 46
-                  }
-                },
-                "name": "log"
-              },
-              "arguments": [],
-              "byref": false,
-              "type": null,
-              "nullable": false,
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 4,
-                    "offset": 53
-                  },
-                  "end": {
-                    "line": 8,
-                    "column": 5,
-                    "offset": 78
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "echo",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 7,
-                        "column": 8,
-                        "offset": 63
-                      },
-                      "end": {
-                        "line": 7,
-                        "column": 17,
-                        "offset": 72
-                      }
-                    },
-                    "shortForm": false,
-                    "expressions": [
-                      {
-                        "kind": "string",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 7,
-                            "column": 13,
-                            "offset": 68
-                          },
-                          "end": {
-                            "line": 7,
-                            "column": 16,
-                            "offset": 71
-                          }
-                        },
-                        "value": "A",
-                        "raw": "\"A\"",
-                        "unicode": false,
-                        "isDoubleQuote": true
-                      }
-                    ]
-                  }
-                ]
-              },
-              "attrGroups": [],
-              "isAbstract": false,
-              "isFinal": false,
-              "isReadonly": false,
-              "visibility": "public",
-              "isStatic": false
-            }
-          ]
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         }
       },
       "loc": {
@@ -667,7 +242,7 @@
           "line": 9,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
       }
     },
     {
@@ -685,24 +260,7 @@
               "line": 11,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-          },
-          "origin": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 11,
-                "column": 6,
-                "offset": 88
-              },
-              "end": {
-                "line": 11,
-                "column": 13,
-                "offset": 95
-              }
-            },
-            "name": "LoggerB"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         },
         "loc": {
@@ -714,7 +272,7 @@
             "line": 11,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         }
       },
       "body": [
@@ -733,24 +291,7 @@
                   "line": 13,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 13,
-                    "column": 20,
-                    "offset": 118
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 23,
-                    "offset": 121
-                  }
-                },
-                "name": "log"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -762,7 +303,7 @@
                 "line": 13,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "parameters": [],
@@ -798,28 +339,9 @@
                             "line": 15,
                             "column": 17
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                         },
-                        "origin": {
-                          "kind": "string",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 15,
-                              "column": 13,
-                              "offset": 143
-                            },
-                            "end": {
-                              "line": 15,
-                              "column": 16,
-                              "offset": 146
-                            }
-                          },
-                          "value": "B",
-                          "raw": "\"B\"",
-                          "unicode": false,
-                          "isDoubleQuote": true
-                        }
+                        "encapsed": true
                       },
                       "loc": {
                         "start": {
@@ -830,7 +352,7 @@
                           "line": 15,
                           "column": 17
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                       }
                     }
                   ],
@@ -844,46 +366,7 @@
                         "line": 15,
                         "column": 18
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-                    },
-                    "origin": {
-                      "kind": "echo",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 15,
-                          "column": 8,
-                          "offset": 138
-                        },
-                        "end": {
-                          "line": 15,
-                          "column": 17,
-                          "offset": 147
-                        }
-                      },
-                      "shortForm": false,
-                      "expressions": [
-                        {
-                          "kind": "string",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 15,
-                              "column": 13,
-                              "offset": 143
-                            },
-                            "end": {
-                              "line": 15,
-                              "column": 16,
-                              "offset": 146
-                            }
-                          },
-                          "value": "B",
-                          "raw": "\"B\"",
-                          "unicode": false,
-                          "isDoubleQuote": true
-                        }
-                      ]
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                     }
                   },
                   "loc": {
@@ -895,7 +378,7 @@
                       "line": 15,
                       "column": 18
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   }
                 },
                 "_meta": {
@@ -908,46 +391,7 @@
                       "line": 15,
                       "column": 18
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-                  },
-                  "origin": {
-                    "kind": "echo",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 15,
-                        "column": 8,
-                        "offset": 138
-                      },
-                      "end": {
-                        "line": 15,
-                        "column": 17,
-                        "offset": 147
-                      }
-                    },
-                    "shortForm": false,
-                    "expressions": [
-                      {
-                        "kind": "string",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 15,
-                            "column": 13,
-                            "offset": 143
-                          },
-                          "end": {
-                            "line": 15,
-                            "column": 16,
-                            "offset": 146
-                          }
-                        },
-                        "value": "B",
-                        "raw": "\"B\"",
-                        "unicode": false,
-                        "isDoubleQuote": true
-                      }
-                    ]
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   }
                 },
                 "loc": {
@@ -959,7 +403,7 @@
                     "line": 15,
                     "column": 18
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                 }
               }
             ],
@@ -974,64 +418,7 @@
                   "line": 16,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-              },
-              "origin": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 14,
-                    "column": 4,
-                    "offset": 128
-                  },
-                  "end": {
-                    "line": 16,
-                    "column": 5,
-                    "offset": 153
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "echo",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 15,
-                        "column": 8,
-                        "offset": 138
-                      },
-                      "end": {
-                        "line": 15,
-                        "column": 17,
-                        "offset": 147
-                      }
-                    },
-                    "shortForm": false,
-                    "expressions": [
-                      {
-                        "kind": "string",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 15,
-                            "column": 13,
-                            "offset": 143
-                          },
-                          "end": {
-                            "line": 15,
-                            "column": 16,
-                            "offset": 146
-                          }
-                        },
-                        "value": "B",
-                        "raw": "\"B\"",
-                        "unicode": false,
-                        "isDoubleQuote": true
-                      }
-                    ]
-                  }
-                ]
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -1043,14 +430,13 @@
                 "line": 16,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "modifiers": [
             "public"
           ],
           "_meta": {
-            "attributes": [],
             "loc": {
               "start": {
                 "line": 13,
@@ -1060,107 +446,7 @@
                 "line": 16,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-            },
-            "origin": {
-              "kind": "method",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 13,
-                  "column": 4,
-                  "offset": 102
-                },
-                "end": {
-                  "line": 16,
-                  "column": 5,
-                  "offset": 153
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 13,
-                    "column": 20,
-                    "offset": 118
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 23,
-                    "offset": 121
-                  }
-                },
-                "name": "log"
-              },
-              "arguments": [],
-              "byref": false,
-              "type": null,
-              "nullable": false,
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 14,
-                    "column": 4,
-                    "offset": 128
-                  },
-                  "end": {
-                    "line": 16,
-                    "column": 5,
-                    "offset": 153
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "echo",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 15,
-                        "column": 8,
-                        "offset": 138
-                      },
-                      "end": {
-                        "line": 15,
-                        "column": 17,
-                        "offset": 147
-                      }
-                    },
-                    "shortForm": false,
-                    "expressions": [
-                      {
-                        "kind": "string",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 15,
-                            "column": 13,
-                            "offset": 143
-                          },
-                          "end": {
-                            "line": 15,
-                            "column": 16,
-                            "offset": 146
-                          }
-                        },
-                        "value": "B",
-                        "raw": "\"B\"",
-                        "unicode": false,
-                        "isDoubleQuote": true
-                      }
-                    ]
-                  }
-                ]
-              },
-              "attrGroups": [],
-              "isAbstract": false,
-              "isFinal": false,
-              "isReadonly": false,
-              "visibility": "public",
-              "isStatic": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "loc": {
@@ -1172,14 +458,13 @@
               "line": 16,
               "column": 6
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         }
       ],
       "supers": [],
       "_meta": {
-        "structureKind": "trait",
-        "attributes": [],
+        "kind": "trait",
         "loc": {
           "start": {
             "line": 11,
@@ -1189,142 +474,7 @@
             "line": 17,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-        },
-        "origin": {
-          "kind": "trait",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 11,
-              "column": 0,
-              "offset": 82
-            },
-            "end": {
-              "line": 17,
-              "column": 1,
-              "offset": 155
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 11,
-                "column": 6,
-                "offset": 88
-              },
-              "end": {
-                "line": 11,
-                "column": 13,
-                "offset": 95
-              }
-            },
-            "name": "LoggerB"
-          },
-          "body": [
-            {
-              "kind": "method",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 13,
-                  "column": 4,
-                  "offset": 102
-                },
-                "end": {
-                  "line": 16,
-                  "column": 5,
-                  "offset": 153
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 13,
-                    "column": 20,
-                    "offset": 118
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 23,
-                    "offset": 121
-                  }
-                },
-                "name": "log"
-              },
-              "arguments": [],
-              "byref": false,
-              "type": null,
-              "nullable": false,
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 14,
-                    "column": 4,
-                    "offset": 128
-                  },
-                  "end": {
-                    "line": 16,
-                    "column": 5,
-                    "offset": 153
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "echo",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 15,
-                        "column": 8,
-                        "offset": 138
-                      },
-                      "end": {
-                        "line": 15,
-                        "column": 17,
-                        "offset": 147
-                      }
-                    },
-                    "shortForm": false,
-                    "expressions": [
-                      {
-                        "kind": "string",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 15,
-                            "column": 13,
-                            "offset": 143
-                          },
-                          "end": {
-                            "line": 15,
-                            "column": 16,
-                            "offset": 146
-                          }
-                        },
-                        "value": "B",
-                        "raw": "\"B\"",
-                        "unicode": false,
-                        "isDoubleQuote": true
-                      }
-                    ]
-                  }
-                ]
-              },
-              "attrGroups": [],
-              "isAbstract": false,
-              "isFinal": false,
-              "isReadonly": false,
-              "visibility": "public",
-              "isStatic": false
-            }
-          ]
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         }
       },
       "loc": {
@@ -1336,7 +486,7 @@
           "line": 17,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
       }
     },
     {
@@ -1354,24 +504,7 @@
               "line": 19,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-          },
-          "origin": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 19,
-                "column": 6,
-                "offset": 163
-              },
-              "end": {
-                "line": 19,
-                "column": 13,
-                "offset": 170
-              }
-            },
-            "name": "Service"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         },
         "loc": {
@@ -1383,7 +516,7 @@
             "line": 19,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         }
       },
       "body": [
@@ -1410,25 +543,7 @@
                       "line": 21,
                       "column": 16
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-                  },
-                  "origin": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 21,
-                        "column": 8,
-                        "offset": 181
-                      },
-                      "end": {
-                        "line": 21,
-                        "column": 15,
-                        "offset": 188
-                      }
-                    },
-                    "name": "LoggerA",
-                    "resolution": "uqn"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   }
                 },
                 "loc": {
@@ -1440,7 +555,7 @@
                     "line": 21,
                     "column": 16
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                 }
               },
               {
@@ -1456,25 +571,7 @@
                       "line": 21,
                       "column": 25
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-                  },
-                  "origin": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 21,
-                        "column": 17,
-                        "offset": 190
-                      },
-                      "end": {
-                        "line": 21,
-                        "column": 24,
-                        "offset": 197
-                      }
-                    },
-                    "name": "LoggerB",
-                    "resolution": "uqn"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   }
                 },
                 "loc": {
@@ -1486,7 +583,34 @@
                     "line": 21,
                     "column": 25
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                }
+              },
+              {
+                "type": "Noop",
+                "_meta": {
+                  "loc": {
+                    "start": {
+                      "line": 21,
+                      "column": 26
+                    },
+                    "end": {
+                      "line": 24,
+                      "column": 6
+                    },
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                  }
+                },
+                "loc": {
+                  "start": {
+                    "line": 21,
+                    "column": 26
+                  },
+                  "end": {
+                    "line": 24,
+                    "column": 6
+                  },
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                 }
               }
             ],
@@ -1501,203 +625,7 @@
                   "line": 24,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-              },
-              "origin": {
-                "kind": "traituse",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 21,
-                    "column": 4,
-                    "offset": 177
-                  },
-                  "end": {
-                    "line": 24,
-                    "column": 5,
-                    "offset": 287
-                  }
-                },
-                "traits": [
-                  {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 21,
-                        "column": 8,
-                        "offset": 181
-                      },
-                      "end": {
-                        "line": 21,
-                        "column": 15,
-                        "offset": 188
-                      }
-                    },
-                    "name": "LoggerA",
-                    "resolution": "uqn"
-                  },
-                  {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 21,
-                        "column": 17,
-                        "offset": 190
-                      },
-                      "end": {
-                        "line": 21,
-                        "column": 24,
-                        "offset": 197
-                      }
-                    },
-                    "name": "LoggerB",
-                    "resolution": "uqn"
-                  }
-                ],
-                "adaptations": [
-                  {
-                    "kind": "traitprecedence",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 8,
-                        "offset": 208
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 38,
-                        "offset": 238
-                      }
-                    },
-                    "trait": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 22,
-                          "column": 8,
-                          "offset": 208
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 15,
-                          "offset": 215
-                        }
-                      },
-                      "name": "LoggerA",
-                      "resolution": "uqn"
-                    },
-                    "method": {
-                      "kind": "identifier",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 22,
-                          "column": 17,
-                          "offset": 217
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 20,
-                          "offset": 220
-                        }
-                      },
-                      "name": "log"
-                    },
-                    "instead": [
-                      {
-                        "kind": "name",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 22,
-                            "column": 31,
-                            "offset": 231
-                          },
-                          "end": {
-                            "line": 22,
-                            "column": 38,
-                            "offset": 238
-                          }
-                        },
-                        "name": "LoggerB",
-                        "resolution": "uqn"
-                      }
-                    ]
-                  },
-                  {
-                    "kind": "traitalias",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 8,
-                        "offset": 248
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 40,
-                        "offset": 280
-                      }
-                    },
-                    "trait": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 23,
-                          "column": 8,
-                          "offset": 248
-                        },
-                        "end": {
-                          "line": 23,
-                          "column": 15,
-                          "offset": 255
-                        }
-                      },
-                      "name": "LoggerB",
-                      "resolution": "uqn"
-                    },
-                    "method": {
-                      "kind": "identifier",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 23,
-                          "column": 17,
-                          "offset": 257
-                        },
-                        "end": {
-                          "line": 23,
-                          "column": 20,
-                          "offset": 260
-                        }
-                      },
-                      "name": "log"
-                    },
-                    "as": {
-                      "kind": "identifier",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 23,
-                          "column": 32,
-                          "offset": 272
-                        },
-                        "end": {
-                          "line": 23,
-                          "column": 40,
-                          "offset": 280
-                        }
-                      },
-                      "name": "logFromB"
-                    },
-                    "visibility": "private"
-                  }
-                ]
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -1709,7 +637,7 @@
                 "line": 24,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "_meta": {
@@ -1722,488 +650,8 @@
                 "line": 24,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-            },
-            "origin": {
-              "kind": "traituse",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 21,
-                  "column": 4,
-                  "offset": 177
-                },
-                "end": {
-                  "line": 24,
-                  "column": 5,
-                  "offset": 287
-                }
-              },
-              "traits": [
-                {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 21,
-                      "column": 8,
-                      "offset": 181
-                    },
-                    "end": {
-                      "line": 21,
-                      "column": 15,
-                      "offset": 188
-                    }
-                  },
-                  "name": "LoggerA",
-                  "resolution": "uqn"
-                },
-                {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 21,
-                      "column": 17,
-                      "offset": 190
-                    },
-                    "end": {
-                      "line": 21,
-                      "column": 24,
-                      "offset": 197
-                    }
-                  },
-                  "name": "LoggerB",
-                  "resolution": "uqn"
-                }
-              ],
-              "adaptations": [
-                {
-                  "kind": "traitprecedence",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 22,
-                      "column": 8,
-                      "offset": 208
-                    },
-                    "end": {
-                      "line": 22,
-                      "column": 38,
-                      "offset": 238
-                    }
-                  },
-                  "trait": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 8,
-                        "offset": 208
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 15,
-                        "offset": 215
-                      }
-                    },
-                    "name": "LoggerA",
-                    "resolution": "uqn"
-                  },
-                  "method": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 17,
-                        "offset": 217
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 20,
-                        "offset": 220
-                      }
-                    },
-                    "name": "log"
-                  },
-                  "instead": [
-                    {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 22,
-                          "column": 31,
-                          "offset": 231
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 38,
-                          "offset": 238
-                        }
-                      },
-                      "name": "LoggerB",
-                      "resolution": "uqn"
-                    }
-                  ]
-                },
-                {
-                  "kind": "traitalias",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 23,
-                      "column": 8,
-                      "offset": 248
-                    },
-                    "end": {
-                      "line": 23,
-                      "column": 40,
-                      "offset": 280
-                    }
-                  },
-                  "trait": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 8,
-                        "offset": 248
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 15,
-                        "offset": 255
-                      }
-                    },
-                    "name": "LoggerB",
-                    "resolution": "uqn"
-                  },
-                  "method": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 17,
-                        "offset": 257
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 20,
-                        "offset": 260
-                      }
-                    },
-                    "name": "log"
-                  },
-                  "as": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 32,
-                        "offset": 272
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 40,
-                        "offset": 280
-                      }
-                    },
-                    "name": "logFromB"
-                  },
-                  "visibility": "private"
-                }
-              ]
-            },
-            "adaptations": [
-              {
-                "kind": "traitprecedence",
-                "trait": {
-                  "type": "Identifier",
-                  "name": "LoggerA",
-                  "_meta": {
-                    "loc": {
-                      "start": {
-                        "line": 22,
-                        "column": 9
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 16
-                      },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-                    },
-                    "origin": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 22,
-                          "column": 8,
-                          "offset": 208
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 15,
-                          "offset": 215
-                        }
-                      },
-                      "name": "LoggerA",
-                      "resolution": "uqn"
-                    }
-                  },
-                  "loc": {
-                    "start": {
-                      "line": 22,
-                      "column": 9
-                    },
-                    "end": {
-                      "line": 22,
-                      "column": 16
-                    },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-                  }
-                },
-                "method": {
-                  "type": "Identifier",
-                  "name": "log",
-                  "_meta": {
-                    "loc": {
-                      "start": {
-                        "line": 22,
-                        "column": 18
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 21
-                      },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-                    },
-                    "origin": {
-                      "kind": "identifier",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 22,
-                          "column": 17,
-                          "offset": 217
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 20,
-                          "offset": 220
-                        }
-                      },
-                      "name": "log"
-                    }
-                  },
-                  "loc": {
-                    "start": {
-                      "line": 22,
-                      "column": 18
-                    },
-                    "end": {
-                      "line": 22,
-                      "column": 21
-                    },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-                  }
-                },
-                "instead": [
-                  {
-                    "type": "Identifier",
-                    "name": "LoggerB",
-                    "_meta": {
-                      "loc": {
-                        "start": {
-                          "line": 22,
-                          "column": 32
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 39
-                        },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-                      },
-                      "origin": {
-                        "kind": "name",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 22,
-                            "column": 31,
-                            "offset": 231
-                          },
-                          "end": {
-                            "line": 22,
-                            "column": 38,
-                            "offset": 238
-                          }
-                        },
-                        "name": "LoggerB",
-                        "resolution": "uqn"
-                      }
-                    },
-                    "loc": {
-                      "start": {
-                        "line": 22,
-                        "column": 32
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 39
-                      },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-                    }
-                  }
-                ]
-              },
-              {
-                "kind": "traitalias",
-                "trait": {
-                  "type": "Identifier",
-                  "name": "LoggerB",
-                  "_meta": {
-                    "loc": {
-                      "start": {
-                        "line": 23,
-                        "column": 9
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 16
-                      },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-                    },
-                    "origin": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 23,
-                          "column": 8,
-                          "offset": 248
-                        },
-                        "end": {
-                          "line": 23,
-                          "column": 15,
-                          "offset": 255
-                        }
-                      },
-                      "name": "LoggerB",
-                      "resolution": "uqn"
-                    }
-                  },
-                  "loc": {
-                    "start": {
-                      "line": 23,
-                      "column": 9
-                    },
-                    "end": {
-                      "line": 23,
-                      "column": 16
-                    },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-                  }
-                },
-                "method": {
-                  "type": "Identifier",
-                  "name": "log",
-                  "_meta": {
-                    "loc": {
-                      "start": {
-                        "line": 23,
-                        "column": 18
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 21
-                      },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-                    },
-                    "origin": {
-                      "kind": "identifier",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 23,
-                          "column": 17,
-                          "offset": 257
-                        },
-                        "end": {
-                          "line": 23,
-                          "column": 20,
-                          "offset": 260
-                        }
-                      },
-                      "name": "log"
-                    }
-                  },
-                  "loc": {
-                    "start": {
-                      "line": 23,
-                      "column": 18
-                    },
-                    "end": {
-                      "line": 23,
-                      "column": 21
-                    },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-                  }
-                },
-                "as": {
-                  "type": "Identifier",
-                  "name": "logFromB",
-                  "_meta": {
-                    "loc": {
-                      "start": {
-                        "line": 23,
-                        "column": 33
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 41
-                      },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-                    },
-                    "origin": {
-                      "kind": "identifier",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 23,
-                          "column": 32,
-                          "offset": 272
-                        },
-                        "end": {
-                          "line": 23,
-                          "column": 40,
-                          "offset": 280
-                        }
-                      },
-                      "name": "logFromB"
-                    }
-                  },
-                  "loc": {
-                    "start": {
-                      "line": 23,
-                      "column": 33
-                    },
-                    "end": {
-                      "line": 23,
-                      "column": 41
-                    },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-                  }
-                },
-                "visibility": "private"
-              }
-            ]
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            }
           },
           "loc": {
             "start": {
@@ -2214,17 +662,12 @@
               "line": 24,
               "column": 6
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         }
       ],
       "supers": [],
       "_meta": {
-        "implements": [],
-        "isAbstract": false,
-        "isFinal": false,
-        "isReadonly": false,
-        "attributes": [],
         "loc": {
           "start": {
             "line": 19,
@@ -2234,245 +677,7 @@
             "line": 25,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-        },
-        "origin": {
-          "kind": "class",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 19,
-              "column": 0,
-              "offset": 157
-            },
-            "end": {
-              "line": 25,
-              "column": 1,
-              "offset": 289
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 19,
-                "column": 6,
-                "offset": 163
-              },
-              "end": {
-                "line": 19,
-                "column": 13,
-                "offset": 170
-              }
-            },
-            "name": "Service"
-          },
-          "isAnonymous": false,
-          "extends": null,
-          "implements": null,
-          "body": [
-            {
-              "kind": "traituse",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 21,
-                  "column": 4,
-                  "offset": 177
-                },
-                "end": {
-                  "line": 24,
-                  "column": 5,
-                  "offset": 287
-                }
-              },
-              "traits": [
-                {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 21,
-                      "column": 8,
-                      "offset": 181
-                    },
-                    "end": {
-                      "line": 21,
-                      "column": 15,
-                      "offset": 188
-                    }
-                  },
-                  "name": "LoggerA",
-                  "resolution": "uqn"
-                },
-                {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 21,
-                      "column": 17,
-                      "offset": 190
-                    },
-                    "end": {
-                      "line": 21,
-                      "column": 24,
-                      "offset": 197
-                    }
-                  },
-                  "name": "LoggerB",
-                  "resolution": "uqn"
-                }
-              ],
-              "adaptations": [
-                {
-                  "kind": "traitprecedence",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 22,
-                      "column": 8,
-                      "offset": 208
-                    },
-                    "end": {
-                      "line": 22,
-                      "column": 38,
-                      "offset": 238
-                    }
-                  },
-                  "trait": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 8,
-                        "offset": 208
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 15,
-                        "offset": 215
-                      }
-                    },
-                    "name": "LoggerA",
-                    "resolution": "uqn"
-                  },
-                  "method": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 17,
-                        "offset": 217
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 20,
-                        "offset": 220
-                      }
-                    },
-                    "name": "log"
-                  },
-                  "instead": [
-                    {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 22,
-                          "column": 31,
-                          "offset": 231
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 38,
-                          "offset": 238
-                        }
-                      },
-                      "name": "LoggerB",
-                      "resolution": "uqn"
-                    }
-                  ]
-                },
-                {
-                  "kind": "traitalias",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 23,
-                      "column": 8,
-                      "offset": 248
-                    },
-                    "end": {
-                      "line": 23,
-                      "column": 40,
-                      "offset": 280
-                    }
-                  },
-                  "trait": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 8,
-                        "offset": 248
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 15,
-                        "offset": 255
-                      }
-                    },
-                    "name": "LoggerB",
-                    "resolution": "uqn"
-                  },
-                  "method": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 17,
-                        "offset": 257
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 20,
-                        "offset": 260
-                      }
-                    },
-                    "name": "log"
-                  },
-                  "as": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 32,
-                        "offset": 272
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 40,
-                        "offset": 280
-                      }
-                    },
-                    "name": "logFromB"
-                  },
-                  "visibility": "private"
-                }
-              ]
-            }
-          ],
-          "attrGroups": [],
-          "isAbstract": false,
-          "isFinal": false,
-          "isReadonly": false
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         }
       },
       "loc": {
@@ -2484,7 +689,7 @@
           "line": 25,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
       }
     },
     {
@@ -2502,24 +707,7 @@
               "line": 27,
               "column": 12
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-          },
-          "origin": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 27,
-                "column": 5,
-                "offset": 296
-              },
-              "end": {
-                "line": 27,
-                "column": 11,
-                "offset": 302
-              }
-            },
-            "name": "Status"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         },
         "loc": {
@@ -2531,7 +719,7 @@
             "line": 27,
             "column": 12
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         }
       },
       "body": [
@@ -2544,42 +732,25 @@
               "loc": {
                 "start": {
                   "line": 29,
-                  "column": 5
+                  "column": 10
                 },
                 "end": {
                   "line": 29,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 29,
-                    "column": 4,
-                    "offset": 317
-                  },
-                  "end": {
-                    "line": 29,
-                    "column": 13,
-                    "offset": 326
-                  }
-                },
-                "name": "Open"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               }
             },
             "loc": {
               "start": {
                 "line": 29,
-                "column": 5
+                "column": 10
               },
               "end": {
                 "line": 29,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "init": {
@@ -2596,27 +767,7 @@
                   "line": 29,
                   "column": 23
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-              },
-              "origin": {
-                "kind": "string",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 29,
-                    "column": 16,
-                    "offset": 329
-                  },
-                  "end": {
-                    "line": 29,
-                    "column": 22,
-                    "offset": 335
-                  }
-                },
-                "value": "open",
-                "raw": "'open'",
-                "unicode": false,
-                "isDoubleQuote": false
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -2628,7 +779,7 @@
                 "line": 29,
                 "column": 23
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "cloned": false,
@@ -2638,6 +789,7 @@
             "_meta": {}
           },
           "_meta": {
+            "enumCase": true,
             "loc": {
               "start": {
                 "line": 29,
@@ -2645,64 +797,10 @@
               },
               "end": {
                 "line": 29,
-                "column": 23
+                "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-            },
-            "origin": {
-              "kind": "enumcase",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 29,
-                  "column": 4,
-                  "offset": 317
-                },
-                "end": {
-                  "line": 29,
-                  "column": 22,
-                  "offset": 335
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 29,
-                    "column": 4,
-                    "offset": 317
-                  },
-                  "end": {
-                    "line": 29,
-                    "column": 13,
-                    "offset": 326
-                  }
-                },
-                "name": "Open"
-              },
-              "value": {
-                "kind": "string",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 29,
-                    "column": 16,
-                    "offset": 329
-                  },
-                  "end": {
-                    "line": 29,
-                    "column": 22,
-                    "offset": 335
-                  }
-                },
-                "value": "open",
-                "raw": "'open'",
-                "unicode": false,
-                "isDoubleQuote": false
-              }
-            },
-            "enumCase": true
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            }
           },
           "loc": {
             "start": {
@@ -2711,9 +809,9 @@
             },
             "end": {
               "line": 29,
-              "column": 23
+              "column": 24
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         },
         {
@@ -2725,42 +823,25 @@
               "loc": {
                 "start": {
                   "line": 30,
-                  "column": 5
+                  "column": 10
                 },
                 "end": {
                   "line": 30,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 30,
-                    "column": 4,
-                    "offset": 341
-                  },
-                  "end": {
-                    "line": 30,
-                    "column": 15,
-                    "offset": 352
-                  }
-                },
-                "name": "Closed"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               }
             },
             "loc": {
               "start": {
                 "line": 30,
-                "column": 5
+                "column": 10
               },
               "end": {
                 "line": 30,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "init": {
@@ -2777,27 +858,7 @@
                   "line": 30,
                   "column": 27
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-              },
-              "origin": {
-                "kind": "string",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 30,
-                    "column": 18,
-                    "offset": 355
-                  },
-                  "end": {
-                    "line": 30,
-                    "column": 26,
-                    "offset": 363
-                  }
-                },
-                "value": "closed",
-                "raw": "'closed'",
-                "unicode": false,
-                "isDoubleQuote": false
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               }
             },
             "loc": {
@@ -2809,7 +870,7 @@
                 "line": 30,
                 "column": 27
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "cloned": false,
@@ -2819,6 +880,7 @@
             "_meta": {}
           },
           "_meta": {
+            "enumCase": true,
             "loc": {
               "start": {
                 "line": 30,
@@ -2826,64 +888,10 @@
               },
               "end": {
                 "line": 30,
-                "column": 27
+                "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-            },
-            "origin": {
-              "kind": "enumcase",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 30,
-                  "column": 4,
-                  "offset": 341
-                },
-                "end": {
-                  "line": 30,
-                  "column": 26,
-                  "offset": 363
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 30,
-                    "column": 4,
-                    "offset": 341
-                  },
-                  "end": {
-                    "line": 30,
-                    "column": 15,
-                    "offset": 352
-                  }
-                },
-                "name": "Closed"
-              },
-              "value": {
-                "kind": "string",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 30,
-                    "column": 18,
-                    "offset": 355
-                  },
-                  "end": {
-                    "line": 30,
-                    "column": 26,
-                    "offset": 363
-                  }
-                },
-                "value": "closed",
-                "raw": "'closed'",
-                "unicode": false,
-                "isDoubleQuote": false
-              }
-            },
-            "enumCase": true
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            }
           },
           "loc": {
             "start": {
@@ -2892,63 +900,15 @@
             },
             "end": {
               "line": 30,
-              "column": 27
+              "column": 28
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         }
       ],
       "supers": [],
       "_meta": {
-        "structureKind": "enum",
-        "valueType": {
-          "type": "Identifier",
-          "name": "string",
-          "_meta": {
-            "loc": {
-              "start": {
-                "line": 27,
-                "column": 14
-              },
-              "end": {
-                "line": 27,
-                "column": 20
-              },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-            },
-            "origin": {
-              "kind": "name",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 27,
-                  "column": 13,
-                  "offset": 304
-                },
-                "end": {
-                  "line": 27,
-                  "column": 19,
-                  "offset": 310
-                }
-              },
-              "name": "string",
-              "resolution": "uqn"
-            }
-          },
-          "loc": {
-            "start": {
-              "line": 27,
-              "column": 14
-            },
-            "end": {
-              "line": 27,
-              "column": 20
-            },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-          }
-        },
-        "implements": [],
-        "attributes": [],
+        "kind": "enum",
         "loc": {
           "start": {
             "line": 27,
@@ -2958,168 +918,7 @@
             "line": 31,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-        },
-        "origin": {
-          "kind": "enum",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 27,
-              "column": 0,
-              "offset": 291
-            },
-            "end": {
-              "line": 31,
-              "column": 1,
-              "offset": 366
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 27,
-                "column": 5,
-                "offset": 296
-              },
-              "end": {
-                "line": 27,
-                "column": 11,
-                "offset": 302
-              }
-            },
-            "name": "Status"
-          },
-          "valueType": {
-            "kind": "name",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 27,
-                "column": 13,
-                "offset": 304
-              },
-              "end": {
-                "line": 27,
-                "column": 19,
-                "offset": 310
-              }
-            },
-            "name": "string",
-            "resolution": "uqn"
-          },
-          "implements": null,
-          "body": [
-            {
-              "kind": "enumcase",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 29,
-                  "column": 4,
-                  "offset": 317
-                },
-                "end": {
-                  "line": 29,
-                  "column": 22,
-                  "offset": 335
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 29,
-                    "column": 4,
-                    "offset": 317
-                  },
-                  "end": {
-                    "line": 29,
-                    "column": 13,
-                    "offset": 326
-                  }
-                },
-                "name": "Open"
-              },
-              "value": {
-                "kind": "string",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 29,
-                    "column": 16,
-                    "offset": 329
-                  },
-                  "end": {
-                    "line": 29,
-                    "column": 22,
-                    "offset": 335
-                  }
-                },
-                "value": "open",
-                "raw": "'open'",
-                "unicode": false,
-                "isDoubleQuote": false
-              }
-            },
-            {
-              "kind": "enumcase",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 30,
-                  "column": 4,
-                  "offset": 341
-                },
-                "end": {
-                  "line": 30,
-                  "column": 26,
-                  "offset": 363
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 30,
-                    "column": 4,
-                    "offset": 341
-                  },
-                  "end": {
-                    "line": 30,
-                    "column": 15,
-                    "offset": 352
-                  }
-                },
-                "name": "Closed"
-              },
-              "value": {
-                "kind": "string",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 30,
-                    "column": 18,
-                    "offset": 355
-                  },
-                  "end": {
-                    "line": 30,
-                    "column": 26,
-                    "offset": 363
-                  }
-                },
-                "value": "closed",
-                "raw": "'closed'",
-                "unicode": false,
-                "isDoubleQuote": false
-              }
-            }
-          ],
-          "attrGroups": []
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         }
       },
       "loc": {
@@ -3131,13 +930,13 @@
           "line": 31,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -3149,696 +948,7 @@
         "line": 32,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
-    },
-    "origin": {
-      "kind": "program",
-      "loc": {
-        "source": null,
-        "start": {
-          "line": 1,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "line": 32,
-          "column": 0,
-          "offset": 367
-        }
-      },
-      "children": [
-        {
-          "kind": "trait",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 7
-            },
-            "end": {
-              "line": 9,
-              "column": 1,
-              "offset": 80
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 6,
-                "offset": 13
-              },
-              "end": {
-                "line": 3,
-                "column": 13,
-                "offset": 20
-              }
-            },
-            "name": "LoggerA"
-          },
-          "body": [
-            {
-              "kind": "method",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 5,
-                  "column": 4,
-                  "offset": 27
-                },
-                "end": {
-                  "line": 8,
-                  "column": 5,
-                  "offset": 78
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 20,
-                    "offset": 43
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 23,
-                    "offset": 46
-                  }
-                },
-                "name": "log"
-              },
-              "arguments": [],
-              "byref": false,
-              "type": null,
-              "nullable": false,
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 4,
-                    "offset": 53
-                  },
-                  "end": {
-                    "line": 8,
-                    "column": 5,
-                    "offset": 78
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "echo",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 7,
-                        "column": 8,
-                        "offset": 63
-                      },
-                      "end": {
-                        "line": 7,
-                        "column": 17,
-                        "offset": 72
-                      }
-                    },
-                    "shortForm": false,
-                    "expressions": [
-                      {
-                        "kind": "string",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 7,
-                            "column": 13,
-                            "offset": 68
-                          },
-                          "end": {
-                            "line": 7,
-                            "column": 16,
-                            "offset": 71
-                          }
-                        },
-                        "value": "A",
-                        "raw": "\"A\"",
-                        "unicode": false,
-                        "isDoubleQuote": true
-                      }
-                    ]
-                  }
-                ]
-              },
-              "attrGroups": [],
-              "isAbstract": false,
-              "isFinal": false,
-              "isReadonly": false,
-              "visibility": "public",
-              "isStatic": false
-            }
-          ]
-        },
-        {
-          "kind": "trait",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 11,
-              "column": 0,
-              "offset": 82
-            },
-            "end": {
-              "line": 17,
-              "column": 1,
-              "offset": 155
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 11,
-                "column": 6,
-                "offset": 88
-              },
-              "end": {
-                "line": 11,
-                "column": 13,
-                "offset": 95
-              }
-            },
-            "name": "LoggerB"
-          },
-          "body": [
-            {
-              "kind": "method",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 13,
-                  "column": 4,
-                  "offset": 102
-                },
-                "end": {
-                  "line": 16,
-                  "column": 5,
-                  "offset": 153
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 13,
-                    "column": 20,
-                    "offset": 118
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 23,
-                    "offset": 121
-                  }
-                },
-                "name": "log"
-              },
-              "arguments": [],
-              "byref": false,
-              "type": null,
-              "nullable": false,
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 14,
-                    "column": 4,
-                    "offset": 128
-                  },
-                  "end": {
-                    "line": 16,
-                    "column": 5,
-                    "offset": 153
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "echo",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 15,
-                        "column": 8,
-                        "offset": 138
-                      },
-                      "end": {
-                        "line": 15,
-                        "column": 17,
-                        "offset": 147
-                      }
-                    },
-                    "shortForm": false,
-                    "expressions": [
-                      {
-                        "kind": "string",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 15,
-                            "column": 13,
-                            "offset": 143
-                          },
-                          "end": {
-                            "line": 15,
-                            "column": 16,
-                            "offset": 146
-                          }
-                        },
-                        "value": "B",
-                        "raw": "\"B\"",
-                        "unicode": false,
-                        "isDoubleQuote": true
-                      }
-                    ]
-                  }
-                ]
-              },
-              "attrGroups": [],
-              "isAbstract": false,
-              "isFinal": false,
-              "isReadonly": false,
-              "visibility": "public",
-              "isStatic": false
-            }
-          ]
-        },
-        {
-          "kind": "class",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 19,
-              "column": 0,
-              "offset": 157
-            },
-            "end": {
-              "line": 25,
-              "column": 1,
-              "offset": 289
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 19,
-                "column": 6,
-                "offset": 163
-              },
-              "end": {
-                "line": 19,
-                "column": 13,
-                "offset": 170
-              }
-            },
-            "name": "Service"
-          },
-          "isAnonymous": false,
-          "extends": null,
-          "implements": null,
-          "body": [
-            {
-              "kind": "traituse",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 21,
-                  "column": 4,
-                  "offset": 177
-                },
-                "end": {
-                  "line": 24,
-                  "column": 5,
-                  "offset": 287
-                }
-              },
-              "traits": [
-                {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 21,
-                      "column": 8,
-                      "offset": 181
-                    },
-                    "end": {
-                      "line": 21,
-                      "column": 15,
-                      "offset": 188
-                    }
-                  },
-                  "name": "LoggerA",
-                  "resolution": "uqn"
-                },
-                {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 21,
-                      "column": 17,
-                      "offset": 190
-                    },
-                    "end": {
-                      "line": 21,
-                      "column": 24,
-                      "offset": 197
-                    }
-                  },
-                  "name": "LoggerB",
-                  "resolution": "uqn"
-                }
-              ],
-              "adaptations": [
-                {
-                  "kind": "traitprecedence",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 22,
-                      "column": 8,
-                      "offset": 208
-                    },
-                    "end": {
-                      "line": 22,
-                      "column": 38,
-                      "offset": 238
-                    }
-                  },
-                  "trait": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 8,
-                        "offset": 208
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 15,
-                        "offset": 215
-                      }
-                    },
-                    "name": "LoggerA",
-                    "resolution": "uqn"
-                  },
-                  "method": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 17,
-                        "offset": 217
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 20,
-                        "offset": 220
-                      }
-                    },
-                    "name": "log"
-                  },
-                  "instead": [
-                    {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 22,
-                          "column": 31,
-                          "offset": 231
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 38,
-                          "offset": 238
-                        }
-                      },
-                      "name": "LoggerB",
-                      "resolution": "uqn"
-                    }
-                  ]
-                },
-                {
-                  "kind": "traitalias",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 23,
-                      "column": 8,
-                      "offset": 248
-                    },
-                    "end": {
-                      "line": 23,
-                      "column": 40,
-                      "offset": 280
-                    }
-                  },
-                  "trait": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 8,
-                        "offset": 248
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 15,
-                        "offset": 255
-                      }
-                    },
-                    "name": "LoggerB",
-                    "resolution": "uqn"
-                  },
-                  "method": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 17,
-                        "offset": 257
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 20,
-                        "offset": 260
-                      }
-                    },
-                    "name": "log"
-                  },
-                  "as": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 32,
-                        "offset": 272
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 40,
-                        "offset": 280
-                      }
-                    },
-                    "name": "logFromB"
-                  },
-                  "visibility": "private"
-                }
-              ]
-            }
-          ],
-          "attrGroups": [],
-          "isAbstract": false,
-          "isFinal": false,
-          "isReadonly": false
-        },
-        {
-          "kind": "enum",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 27,
-              "column": 0,
-              "offset": 291
-            },
-            "end": {
-              "line": 31,
-              "column": 1,
-              "offset": 366
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 27,
-                "column": 5,
-                "offset": 296
-              },
-              "end": {
-                "line": 27,
-                "column": 11,
-                "offset": 302
-              }
-            },
-            "name": "Status"
-          },
-          "valueType": {
-            "kind": "name",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 27,
-                "column": 13,
-                "offset": 304
-              },
-              "end": {
-                "line": 27,
-                "column": 19,
-                "offset": 310
-              }
-            },
-            "name": "string",
-            "resolution": "uqn"
-          },
-          "implements": null,
-          "body": [
-            {
-              "kind": "enumcase",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 29,
-                  "column": 4,
-                  "offset": 317
-                },
-                "end": {
-                  "line": 29,
-                  "column": 22,
-                  "offset": 335
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 29,
-                    "column": 4,
-                    "offset": 317
-                  },
-                  "end": {
-                    "line": 29,
-                    "column": 13,
-                    "offset": 326
-                  }
-                },
-                "name": "Open"
-              },
-              "value": {
-                "kind": "string",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 29,
-                    "column": 16,
-                    "offset": 329
-                  },
-                  "end": {
-                    "line": 29,
-                    "column": 22,
-                    "offset": 335
-                  }
-                },
-                "value": "open",
-                "raw": "'open'",
-                "unicode": false,
-                "isDoubleQuote": false
-              }
-            },
-            {
-              "kind": "enumcase",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 30,
-                  "column": 4,
-                  "offset": 341
-                },
-                "end": {
-                  "line": 30,
-                  "column": 26,
-                  "offset": 363
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 30,
-                    "column": 4,
-                    "offset": 341
-                  },
-                  "end": {
-                    "line": 30,
-                    "column": 15,
-                    "offset": 352
-                  }
-                },
-                "name": "Closed"
-              },
-              "value": {
-                "kind": "string",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 30,
-                    "column": 18,
-                    "offset": 355
-                  },
-                  "end": {
-                    "line": 30,
-                    "column": 26,
-                    "offset": 363
-                  }
-                },
-                "value": "closed",
-                "raw": "'closed'",
-                "unicode": false,
-                "isDoubleQuote": false
-              }
-            }
-          ],
-          "attrGroups": []
-        }
-      ],
-      "errors": [],
-      "comments": []
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
     }
   },
   "loc": {
@@ -3850,6 +960,6 @@
       "line": 32,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/enum-trait-adapt.php.json
+++ b/parser-PHP/tests/benchmark/base/enum-trait-adapt.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 14
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           },
           "origin": {
             "kind": "identifier",
@@ -45,7 +45,7 @@
             "line": 3,
             "column": 14
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         }
       },
       "body": [
@@ -64,7 +64,7 @@
                   "line": 5,
                   "column": 24
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -93,7 +93,7 @@
                 "line": 5,
                 "column": 24
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "parameters": [],
@@ -129,7 +129,7 @@
                             "line": 7,
                             "column": 17
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                         },
                         "origin": {
                           "kind": "string",
@@ -161,7 +161,7 @@
                           "line": 7,
                           "column": 17
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                       }
                     }
                   ],
@@ -175,7 +175,7 @@
                         "line": 7,
                         "column": 18
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                     },
                     "origin": {
                       "kind": "echo",
@@ -226,7 +226,7 @@
                       "line": 7,
                       "column": 18
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   }
                 },
                 "_meta": {
@@ -239,7 +239,7 @@
                       "line": 7,
                       "column": 18
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   },
                   "origin": {
                     "kind": "echo",
@@ -290,7 +290,7 @@
                     "line": 7,
                     "column": 18
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                 }
               }
             ],
@@ -305,7 +305,7 @@
                   "line": 8,
                   "column": 6
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               },
               "origin": {
                 "kind": "block",
@@ -374,7 +374,7 @@
                 "line": 8,
                 "column": 6
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "modifiers": [
@@ -391,7 +391,7 @@
                 "line": 8,
                 "column": 6
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             },
             "origin": {
               "kind": "method",
@@ -503,7 +503,7 @@
               "line": 8,
               "column": 6
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         }
       ],
@@ -520,7 +520,7 @@
             "line": 9,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         },
         "origin": {
           "kind": "trait",
@@ -667,7 +667,7 @@
           "line": 9,
           "column": 2
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
       }
     },
     {
@@ -685,7 +685,7 @@
               "line": 11,
               "column": 14
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           },
           "origin": {
             "kind": "identifier",
@@ -714,7 +714,7 @@
             "line": 11,
             "column": 14
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         }
       },
       "body": [
@@ -733,7 +733,7 @@
                   "line": 13,
                   "column": 24
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -762,7 +762,7 @@
                 "line": 13,
                 "column": 24
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "parameters": [],
@@ -798,7 +798,7 @@
                             "line": 15,
                             "column": 17
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                         },
                         "origin": {
                           "kind": "string",
@@ -830,7 +830,7 @@
                           "line": 15,
                           "column": 17
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                       }
                     }
                   ],
@@ -844,7 +844,7 @@
                         "line": 15,
                         "column": 18
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                     },
                     "origin": {
                       "kind": "echo",
@@ -895,7 +895,7 @@
                       "line": 15,
                       "column": 18
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   }
                 },
                 "_meta": {
@@ -908,7 +908,7 @@
                       "line": 15,
                       "column": 18
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   },
                   "origin": {
                     "kind": "echo",
@@ -959,7 +959,7 @@
                     "line": 15,
                     "column": 18
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                 }
               }
             ],
@@ -974,7 +974,7 @@
                   "line": 16,
                   "column": 6
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               },
               "origin": {
                 "kind": "block",
@@ -1043,7 +1043,7 @@
                 "line": 16,
                 "column": 6
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "modifiers": [
@@ -1060,7 +1060,7 @@
                 "line": 16,
                 "column": 6
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             },
             "origin": {
               "kind": "method",
@@ -1172,7 +1172,7 @@
               "line": 16,
               "column": 6
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         }
       ],
@@ -1189,7 +1189,7 @@
             "line": 17,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         },
         "origin": {
           "kind": "trait",
@@ -1336,7 +1336,7 @@
           "line": 17,
           "column": 2
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
       }
     },
     {
@@ -1354,7 +1354,7 @@
               "line": 19,
               "column": 14
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           },
           "origin": {
             "kind": "identifier",
@@ -1383,7 +1383,7 @@
             "line": 19,
             "column": 14
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         }
       },
       "body": [
@@ -1410,7 +1410,7 @@
                       "line": 21,
                       "column": 16
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   },
                   "origin": {
                     "kind": "name",
@@ -1440,7 +1440,7 @@
                     "line": 21,
                     "column": 16
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                 }
               },
               {
@@ -1456,7 +1456,7 @@
                       "line": 21,
                       "column": 25
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   },
                   "origin": {
                     "kind": "name",
@@ -1486,7 +1486,7 @@
                     "line": 21,
                     "column": 25
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                 }
               }
             ],
@@ -1501,7 +1501,7 @@
                   "line": 24,
                   "column": 6
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               },
               "origin": {
                 "kind": "traituse",
@@ -1709,7 +1709,7 @@
                 "line": 24,
                 "column": 6
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "_meta": {
@@ -1722,7 +1722,7 @@
                 "line": 24,
                 "column": 6
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             },
             "origin": {
               "kind": "traituse",
@@ -1936,7 +1936,7 @@
                         "line": 22,
                         "column": 16
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                     },
                     "origin": {
                       "kind": "name",
@@ -1966,7 +1966,7 @@
                       "line": 22,
                       "column": 16
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   }
                 },
                 "method": {
@@ -1982,7 +1982,7 @@
                         "line": 22,
                         "column": 21
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                     },
                     "origin": {
                       "kind": "identifier",
@@ -2011,7 +2011,7 @@
                       "line": 22,
                       "column": 21
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   }
                 },
                 "instead": [
@@ -2028,7 +2028,7 @@
                           "line": 22,
                           "column": 39
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                       },
                       "origin": {
                         "kind": "name",
@@ -2058,7 +2058,7 @@
                         "line": 22,
                         "column": 39
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                     }
                   }
                 ]
@@ -2078,7 +2078,7 @@
                         "line": 23,
                         "column": 16
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                     },
                     "origin": {
                       "kind": "name",
@@ -2108,7 +2108,7 @@
                       "line": 23,
                       "column": 16
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   }
                 },
                 "method": {
@@ -2124,7 +2124,7 @@
                         "line": 23,
                         "column": 21
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                     },
                     "origin": {
                       "kind": "identifier",
@@ -2153,7 +2153,7 @@
                       "line": 23,
                       "column": 21
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   }
                 },
                 "as": {
@@ -2169,7 +2169,7 @@
                         "line": 23,
                         "column": 41
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                     },
                     "origin": {
                       "kind": "identifier",
@@ -2198,7 +2198,7 @@
                       "line": 23,
                       "column": 41
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
                   }
                 },
                 "visibility": "private"
@@ -2214,7 +2214,7 @@
               "line": 24,
               "column": 6
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         }
       ],
@@ -2234,7 +2234,7 @@
             "line": 25,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         },
         "origin": {
           "kind": "class",
@@ -2484,7 +2484,7 @@
           "line": 25,
           "column": 2
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
       }
     },
     {
@@ -2502,7 +2502,7 @@
               "line": 27,
               "column": 12
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           },
           "origin": {
             "kind": "identifier",
@@ -2531,7 +2531,7 @@
             "line": 27,
             "column": 12
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         }
       },
       "body": [
@@ -2550,7 +2550,7 @@
                   "line": 29,
                   "column": 14
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -2579,7 +2579,7 @@
                 "line": 29,
                 "column": 14
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "init": {
@@ -2596,7 +2596,7 @@
                   "line": 29,
                   "column": 23
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               },
               "origin": {
                 "kind": "string",
@@ -2628,7 +2628,7 @@
                 "line": 29,
                 "column": 23
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "cloned": false,
@@ -2647,7 +2647,7 @@
                 "line": 29,
                 "column": 23
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             },
             "origin": {
               "kind": "enumcase",
@@ -2713,7 +2713,7 @@
               "line": 29,
               "column": 23
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         },
         {
@@ -2731,7 +2731,7 @@
                   "line": 30,
                   "column": 16
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -2760,7 +2760,7 @@
                 "line": 30,
                 "column": 16
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "init": {
@@ -2777,7 +2777,7 @@
                   "line": 30,
                   "column": 27
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
               },
               "origin": {
                 "kind": "string",
@@ -2809,7 +2809,7 @@
                 "line": 30,
                 "column": 27
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             }
           },
           "cloned": false,
@@ -2828,7 +2828,7 @@
                 "line": 30,
                 "column": 27
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             },
             "origin": {
               "kind": "enumcase",
@@ -2894,7 +2894,7 @@
               "line": 30,
               "column": 27
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         }
       ],
@@ -2914,7 +2914,7 @@
                 "line": 27,
                 "column": 20
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
             },
             "origin": {
               "kind": "name",
@@ -2944,7 +2944,7 @@
               "line": 27,
               "column": 20
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
           }
         },
         "implements": [],
@@ -2958,7 +2958,7 @@
             "line": 31,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
         },
         "origin": {
           "kind": "enum",
@@ -3131,13 +3131,13 @@
           "line": 31,
           "column": 2
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -3149,7 +3149,7 @@
         "line": 32,
         "column": 1
       },
-      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
     },
     "origin": {
       "kind": "program",
@@ -3850,6 +3850,6 @@
       "line": 32,
       "column": 1
     },
-    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/enum-trait-adapt.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/exprs.php.json
+++ b/parser-PHP/tests/benchmark/base/exprs.php.json
@@ -18,7 +18,7 @@
                 "line": 2,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "exprs.php"
             }
           },
           "loc": {
@@ -30,7 +30,7 @@
               "line": 2,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "exprs.php"
           }
         },
         "right": {
@@ -52,7 +52,7 @@
                     "line": 2,
                     "column": 8
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "exprs.php"
                 }
               },
               "loc": {
@@ -64,7 +64,7 @@
                   "line": 2,
                   "column": 8
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "exprs.php"
               }
             },
             "right": {
@@ -81,7 +81,7 @@
                     "line": 2,
                     "column": 14
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "exprs.php"
                 },
                 "encapsed": true
               },
@@ -94,7 +94,7 @@
                   "line": 2,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "exprs.php"
               }
             },
             "_meta": {
@@ -107,7 +107,7 @@
                   "line": 2,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "exprs.php"
               }
             },
             "loc": {
@@ -119,7 +119,7 @@
                 "line": 2,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "exprs.php"
             }
           },
           "right": {
@@ -137,7 +137,7 @@
                     "line": 2,
                     "column": 20
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "exprs.php"
                 }
               },
               "loc": {
@@ -149,7 +149,7 @@
                   "line": 2,
                   "column": 20
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "exprs.php"
               }
             },
             "consequent": {
@@ -166,7 +166,7 @@
                     "line": 2,
                     "column": 24
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "exprs.php"
                 }
               },
               "loc": {
@@ -178,7 +178,7 @@
                   "line": 2,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "exprs.php"
               }
             },
             "alternative": {
@@ -195,7 +195,7 @@
                     "line": 2,
                     "column": 28
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "exprs.php"
                 }
               },
               "loc": {
@@ -207,7 +207,7 @@
                   "line": 2,
                   "column": 28
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "exprs.php"
               }
             },
             "_meta": {
@@ -220,7 +220,7 @@
                   "line": 2,
                   "column": 28
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "exprs.php"
               }
             },
             "loc": {
@@ -232,7 +232,7 @@
                 "line": 2,
                 "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "exprs.php"
             }
           },
           "_meta": {
@@ -245,7 +245,7 @@
                 "line": 2,
                 "column": 29
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "exprs.php"
             }
           },
           "loc": {
@@ -257,7 +257,7 @@
               "line": 2,
               "column": 29
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "exprs.php"
           }
         },
         "operator": "=",
@@ -272,7 +272,7 @@
               "line": 2,
               "column": 29
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "exprs.php"
           }
         },
         "loc": {
@@ -284,7 +284,7 @@
             "line": 2,
             "column": 29
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "exprs.php"
         }
       },
       "_meta": {
@@ -297,7 +297,7 @@
             "line": 2,
             "column": 30
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "exprs.php"
         }
       },
       "loc": {
@@ -309,7 +309,7 @@
           "line": 2,
           "column": 30
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+        "sourcefile": "exprs.php"
       }
     },
     {
@@ -329,7 +329,7 @@
                 "line": 3,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "exprs.php"
             }
           },
           "loc": {
@@ -341,7 +341,7 @@
               "line": 3,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "exprs.php"
           }
         },
         "right": {
@@ -360,7 +360,7 @@
                   "line": 3,
                   "column": 12
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "exprs.php"
               }
             },
             "loc": {
@@ -372,7 +372,7 @@
                 "line": 3,
                 "column": 12
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "exprs.php"
             }
           },
           "isSuffix": false,
@@ -386,7 +386,7 @@
                 "line": 3,
                 "column": 12
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "exprs.php"
             }
           },
           "loc": {
@@ -398,7 +398,7 @@
               "line": 3,
               "column": 12
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "exprs.php"
           }
         },
         "operator": "=",
@@ -413,7 +413,7 @@
               "line": 3,
               "column": 12
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "exprs.php"
           }
         },
         "loc": {
@@ -425,7 +425,7 @@
             "line": 3,
             "column": 12
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "exprs.php"
         }
       },
       "_meta": {
@@ -438,7 +438,7 @@
             "line": 3,
             "column": 13
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "exprs.php"
         }
       },
       "loc": {
@@ -450,7 +450,7 @@
           "line": 3,
           "column": 13
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+        "sourcefile": "exprs.php"
       }
     },
     {
@@ -470,7 +470,7 @@
                 "line": 4,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "exprs.php"
             }
           },
           "loc": {
@@ -482,7 +482,7 @@
               "line": 4,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "exprs.php"
           }
         },
         "right": {
@@ -504,7 +504,7 @@
                       "line": 4,
                       "column": 11
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                    "sourcefile": "exprs.php"
                   }
                 },
                 "loc": {
@@ -516,7 +516,7 @@
                     "line": 4,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "exprs.php"
                 }
               },
               "init": null,
@@ -537,7 +537,7 @@
                     "line": 4,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "exprs.php"
                 }
               },
               "loc": {
@@ -549,7 +549,7 @@
                   "line": 4,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "exprs.php"
               }
             }
           ],
@@ -579,7 +579,7 @@
                           "line": 4,
                           "column": 18
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                        "sourcefile": "exprs.php"
                       }
                     },
                     "loc": {
@@ -591,7 +591,7 @@
                         "line": 4,
                         "column": 18
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                      "sourcefile": "exprs.php"
                     }
                   },
                   "right": {
@@ -608,7 +608,7 @@
                           "line": 4,
                           "column": 22
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                        "sourcefile": "exprs.php"
                       }
                     },
                     "loc": {
@@ -620,7 +620,7 @@
                         "line": 4,
                         "column": 22
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                      "sourcefile": "exprs.php"
                     }
                   },
                   "_meta": {
@@ -633,7 +633,7 @@
                         "line": 4,
                         "column": 22
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                      "sourcefile": "exprs.php"
                     }
                   },
                   "loc": {
@@ -645,7 +645,7 @@
                       "line": 4,
                       "column": 22
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                    "sourcefile": "exprs.php"
                   }
                 },
                 "isYield": false,
@@ -659,7 +659,7 @@
                       "line": 4,
                       "column": 22
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                    "sourcefile": "exprs.php"
                   }
                 },
                 "loc": {
@@ -671,7 +671,7 @@
                     "line": 4,
                     "column": 22
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "exprs.php"
                 }
               }
             ],
@@ -686,7 +686,7 @@
                   "line": 4,
                   "column": 22
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "exprs.php"
               }
             },
             "loc": {
@@ -698,7 +698,7 @@
                 "line": 4,
                 "column": 22
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "exprs.php"
             }
           },
           "modifiers": [],
@@ -712,7 +712,7 @@
                 "line": 4,
                 "column": 22
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "exprs.php"
             }
           },
           "loc": {
@@ -724,7 +724,7 @@
               "line": 4,
               "column": 22
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "exprs.php"
           }
         },
         "operator": "=",
@@ -739,7 +739,7 @@
               "line": 4,
               "column": 22
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "exprs.php"
           }
         },
         "loc": {
@@ -751,7 +751,7 @@
             "line": 4,
             "column": 22
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "exprs.php"
         }
       },
       "_meta": {
@@ -764,7 +764,7 @@
             "line": 4,
             "column": 23
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "exprs.php"
         }
       },
       "loc": {
@@ -776,13 +776,13 @@
           "line": 4,
           "column": 23
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+        "sourcefile": "exprs.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php",
+  "uri": "exprs.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -794,7 +794,7 @@
         "line": 5,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+      "sourcefile": "exprs.php"
     }
   },
   "loc": {
@@ -806,6 +806,6 @@
       "line": 5,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+    "sourcefile": "exprs.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/exprs.php.json
+++ b/parser-PHP/tests/benchmark/base/exprs.php.json
@@ -18,7 +18,7 @@
                 "line": 2,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "loc": {
@@ -30,7 +30,7 @@
               "line": 2,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "right": {
@@ -52,7 +52,7 @@
                     "line": 2,
                     "column": 8
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                 }
               },
               "loc": {
@@ -64,7 +64,7 @@
                   "line": 2,
                   "column": 8
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "right": {
@@ -81,7 +81,7 @@
                     "line": 2,
                     "column": 14
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                 },
                 "encapsed": true
               },
@@ -94,7 +94,7 @@
                   "line": 2,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "_meta": {
@@ -107,7 +107,7 @@
                   "line": 2,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "loc": {
@@ -119,7 +119,7 @@
                 "line": 2,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "right": {
@@ -137,7 +137,7 @@
                     "line": 2,
                     "column": 20
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                 }
               },
               "loc": {
@@ -149,7 +149,7 @@
                   "line": 2,
                   "column": 20
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "consequent": {
@@ -166,7 +166,7 @@
                     "line": 2,
                     "column": 24
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                 }
               },
               "loc": {
@@ -178,7 +178,7 @@
                   "line": 2,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "alternative": {
@@ -195,7 +195,7 @@
                     "line": 2,
                     "column": 28
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                 }
               },
               "loc": {
@@ -207,7 +207,7 @@
                   "line": 2,
                   "column": 28
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "_meta": {
@@ -220,7 +220,7 @@
                   "line": 2,
                   "column": 28
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "loc": {
@@ -232,7 +232,7 @@
                 "line": 2,
                 "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "_meta": {
@@ -245,7 +245,7 @@
                 "line": 2,
                 "column": 29
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "loc": {
@@ -257,7 +257,7 @@
               "line": 2,
               "column": 29
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "operator": "=",
@@ -272,7 +272,7 @@
               "line": 2,
               "column": 29
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "loc": {
@@ -284,7 +284,7 @@
             "line": 2,
             "column": 29
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
         }
       },
       "_meta": {
@@ -297,7 +297,7 @@
             "line": 2,
             "column": 30
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
         }
       },
       "loc": {
@@ -309,7 +309,7 @@
           "line": 2,
           "column": 30
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
       }
     },
     {
@@ -329,7 +329,7 @@
                 "line": 3,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "loc": {
@@ -341,7 +341,7 @@
               "line": 3,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "right": {
@@ -360,7 +360,7 @@
                   "line": 3,
                   "column": 12
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "loc": {
@@ -372,7 +372,7 @@
                 "line": 3,
                 "column": 12
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "isSuffix": false,
@@ -386,7 +386,7 @@
                 "line": 3,
                 "column": 12
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "loc": {
@@ -398,7 +398,7 @@
               "line": 3,
               "column": 12
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "operator": "=",
@@ -413,7 +413,7 @@
               "line": 3,
               "column": 12
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "loc": {
@@ -425,7 +425,7 @@
             "line": 3,
             "column": 12
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
         }
       },
       "_meta": {
@@ -438,7 +438,7 @@
             "line": 3,
             "column": 13
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
         }
       },
       "loc": {
@@ -450,7 +450,7 @@
           "line": 3,
           "column": 13
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
       }
     },
     {
@@ -470,7 +470,7 @@
                 "line": 4,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "loc": {
@@ -482,7 +482,7 @@
               "line": 4,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "right": {
@@ -504,7 +504,7 @@
                       "line": 4,
                       "column": 11
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                   }
                 },
                 "loc": {
@@ -516,7 +516,7 @@
                     "line": 4,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                 }
               },
               "init": null,
@@ -537,7 +537,7 @@
                     "line": 4,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                 }
               },
               "loc": {
@@ -549,7 +549,7 @@
                   "line": 4,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
               }
             }
           ],
@@ -579,7 +579,7 @@
                           "line": 4,
                           "column": 18
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                       }
                     },
                     "loc": {
@@ -591,7 +591,7 @@
                         "line": 4,
                         "column": 18
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                     }
                   },
                   "right": {
@@ -608,7 +608,7 @@
                           "line": 4,
                           "column": 22
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                       }
                     },
                     "loc": {
@@ -620,7 +620,7 @@
                         "line": 4,
                         "column": 22
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                     }
                   },
                   "_meta": {
@@ -633,7 +633,7 @@
                         "line": 4,
                         "column": 22
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                     }
                   },
                   "loc": {
@@ -645,7 +645,7 @@
                       "line": 4,
                       "column": 22
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                   }
                 },
                 "isYield": false,
@@ -659,7 +659,7 @@
                       "line": 4,
                       "column": 22
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                   }
                 },
                 "loc": {
@@ -671,7 +671,7 @@
                     "line": 4,
                     "column": 22
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                 }
               }
             ],
@@ -686,7 +686,7 @@
                   "line": 4,
                   "column": 22
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "loc": {
@@ -698,7 +698,7 @@
                 "line": 4,
                 "column": 22
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "modifiers": [],
@@ -712,7 +712,7 @@
                 "line": 4,
                 "column": 22
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "loc": {
@@ -724,7 +724,7 @@
               "line": 4,
               "column": 22
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "operator": "=",
@@ -739,7 +739,7 @@
               "line": 4,
               "column": 22
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "loc": {
@@ -751,7 +751,7 @@
             "line": 4,
             "column": 22
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
         }
       },
       "_meta": {
@@ -764,7 +764,7 @@
             "line": 4,
             "column": 23
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
         }
       },
       "loc": {
@@ -776,13 +776,13 @@
           "line": 4,
           "column": 23
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -794,7 +794,7 @@
         "line": 5,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
     }
   },
   "loc": {
@@ -806,6 +806,6 @@
       "line": 5,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/exprs.php.json
+++ b/parser-PHP/tests/benchmark/base/exprs.php.json
@@ -18,7 +18,7 @@
                 "line": 2,
                 "column": 3
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
             },
             "origin": {
               "kind": "variable",
@@ -48,7 +48,7 @@
               "line": 2,
               "column": 3
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "right": {
@@ -70,7 +70,7 @@
                     "line": 2,
                     "column": 8
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                 },
                 "origin": {
                   "kind": "variable",
@@ -100,7 +100,7 @@
                   "line": 2,
                   "column": 8
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "right": {
@@ -117,7 +117,7 @@
                     "line": 2,
                     "column": 14
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                 },
                 "origin": {
                   "kind": "string",
@@ -149,7 +149,7 @@
                   "line": 2,
                   "column": 14
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "_meta": {
@@ -162,7 +162,7 @@
                   "line": 2,
                   "column": 14
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
               },
               "origin": {
                 "kind": "bin",
@@ -229,7 +229,7 @@
                 "line": 2,
                 "column": 14
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "right": {
@@ -247,7 +247,7 @@
                     "line": 2,
                     "column": 20
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                 },
                 "origin": {
                   "kind": "variable",
@@ -277,7 +277,7 @@
                   "line": 2,
                   "column": 20
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "consequent": {
@@ -294,7 +294,7 @@
                     "line": 2,
                     "column": 24
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                 },
                 "origin": {
                   "kind": "number",
@@ -323,7 +323,7 @@
                   "line": 2,
                   "column": 24
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "alternative": {
@@ -340,7 +340,7 @@
                     "line": 2,
                     "column": 28
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                 },
                 "origin": {
                   "kind": "number",
@@ -369,7 +369,7 @@
                   "line": 2,
                   "column": 28
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "_meta": {
@@ -382,7 +382,7 @@
                   "line": 2,
                   "column": 28
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
               },
               "origin": {
                 "kind": "retif",
@@ -463,7 +463,7 @@
                 "line": 2,
                 "column": 28
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "_meta": {
@@ -476,7 +476,7 @@
                 "line": 2,
                 "column": 28
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
             },
             "origin": {
               "kind": "bin",
@@ -629,7 +629,7 @@
               "line": 2,
               "column": 28
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "operator": "=",
@@ -644,7 +644,7 @@
               "line": 2,
               "column": 30
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
           },
           "origin": {
             "kind": "assign",
@@ -832,7 +832,7 @@
             "line": 2,
             "column": 30
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
         }
       },
       "_meta": {
@@ -845,7 +845,7 @@
             "line": 2,
             "column": 30
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
         },
         "origin": {
           "kind": "expressionstatement",
@@ -1049,7 +1049,7 @@
           "line": 2,
           "column": 30
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
       }
     },
     {
@@ -1069,7 +1069,7 @@
                 "line": 3,
                 "column": 3
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
             },
             "origin": {
               "kind": "variable",
@@ -1099,7 +1099,7 @@
               "line": 3,
               "column": 3
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "right": {
@@ -1118,7 +1118,7 @@
                   "line": 3,
                   "column": 12
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
               },
               "origin": {
                 "kind": "variable",
@@ -1148,7 +1148,7 @@
                 "line": 3,
                 "column": 12
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "isSuffix": false,
@@ -1162,7 +1162,7 @@
                 "line": 3,
                 "column": 12
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
             },
             "origin": {
               "kind": "unary",
@@ -1209,7 +1209,7 @@
               "line": 3,
               "column": 12
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "operator": "=",
@@ -1224,7 +1224,7 @@
               "line": 3,
               "column": 13
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
           },
           "origin": {
             "kind": "assign",
@@ -1306,7 +1306,7 @@
             "line": 3,
             "column": 13
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
         }
       },
       "_meta": {
@@ -1319,7 +1319,7 @@
             "line": 3,
             "column": 13
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
         },
         "origin": {
           "kind": "expressionstatement",
@@ -1417,7 +1417,7 @@
           "line": 3,
           "column": 13
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
       }
     },
     {
@@ -1437,7 +1437,7 @@
                 "line": 4,
                 "column": 3
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
             },
             "origin": {
               "kind": "variable",
@@ -1467,7 +1467,7 @@
               "line": 4,
               "column": 3
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "right": {
@@ -1489,7 +1489,7 @@
                       "line": 4,
                       "column": 11
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                   },
                   "origin": {
                     "kind": "identifier",
@@ -1518,7 +1518,7 @@
                     "line": 4,
                     "column": 11
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                 }
               },
               "init": null,
@@ -1541,7 +1541,7 @@
                     "line": 4,
                     "column": 11
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                 },
                 "origin": {
                   "kind": "parameter",
@@ -1594,7 +1594,7 @@
                   "line": 4,
                   "column": 11
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
               }
             }
           ],
@@ -1624,7 +1624,7 @@
                           "line": 4,
                           "column": 18
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                       },
                       "origin": {
                         "kind": "variable",
@@ -1654,7 +1654,7 @@
                         "line": 4,
                         "column": 18
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                     }
                   },
                   "right": {
@@ -1671,7 +1671,7 @@
                           "line": 4,
                           "column": 22
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                       },
                       "origin": {
                         "kind": "number",
@@ -1700,7 +1700,7 @@
                         "line": 4,
                         "column": 22
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                     }
                   },
                   "_meta": {
@@ -1713,7 +1713,7 @@
                         "line": 4,
                         "column": 22
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                     },
                     "origin": {
                       "kind": "bin",
@@ -1777,7 +1777,7 @@
                       "line": 4,
                       "column": 22
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                   }
                 },
                 "isYield": false,
@@ -1791,7 +1791,7 @@
                       "line": 4,
                       "column": 22
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                   },
                   "origin": {
                     "kind": "bin",
@@ -1855,7 +1855,7 @@
                     "line": 4,
                     "column": 22
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
                 }
               }
             ],
@@ -1870,7 +1870,7 @@
                   "line": 4,
                   "column": 22
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
               },
               "origin": {
                 "kind": "bin",
@@ -1934,7 +1934,7 @@
                 "line": 4,
                 "column": 22
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "modifiers": [],
@@ -1948,7 +1948,7 @@
                 "line": 4,
                 "column": 22
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
             },
             "origin": {
               "kind": "arrowfunc",
@@ -2076,7 +2076,7 @@
               "line": 4,
               "column": 22
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "operator": "=",
@@ -2091,7 +2091,7 @@
               "line": 4,
               "column": 23
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
           },
           "origin": {
             "kind": "assign",
@@ -2254,7 +2254,7 @@
             "line": 4,
             "column": 23
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
         }
       },
       "_meta": {
@@ -2267,7 +2267,7 @@
             "line": 4,
             "column": 23
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
         },
         "origin": {
           "kind": "expressionstatement",
@@ -2446,13 +2446,13 @@
           "line": 4,
           "column": 23
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -2464,7 +2464,7 @@
         "line": 5,
         "column": 1
       },
-      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
     },
     "origin": {
       "kind": "program",
@@ -2941,6 +2941,6 @@
       "line": 5,
       "column": 1
     },
-    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/exprs.php.json
+++ b/parser-PHP/tests/benchmark/base/exprs.php.json
@@ -18,25 +18,7 @@
                 "line": 2,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-            },
-            "origin": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 0,
-                  "offset": 6
-                },
-                "end": {
-                  "line": 2,
-                  "column": 2,
-                  "offset": 8
-                }
-              },
-              "name": "x",
-              "curly": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "loc": {
@@ -48,7 +30,7 @@
               "line": 2,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "right": {
@@ -70,25 +52,7 @@
                     "line": 2,
                     "column": 8
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-                },
-                "origin": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 5,
-                      "offset": 11
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 7,
-                      "offset": 13
-                    }
-                  },
-                  "name": "a",
-                  "curly": false
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
                 }
               },
               "loc": {
@@ -100,7 +64,7 @@
                   "line": 2,
                   "column": 8
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "right": {
@@ -117,28 +81,9 @@
                     "line": 2,
                     "column": 14
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
                 },
-                "origin": {
-                  "kind": "string",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 10,
-                      "offset": 16
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 13,
-                      "offset": 19
-                    }
-                  },
-                  "value": "-",
-                  "raw": "\"-\"",
-                  "unicode": false,
-                  "isDoubleQuote": true
-                }
+                "encapsed": true
               },
               "loc": {
                 "start": {
@@ -149,7 +94,7 @@
                   "line": 2,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "_meta": {
@@ -162,62 +107,7 @@
                   "line": 2,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-              },
-              "origin": {
-                "kind": "bin",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 5,
-                    "offset": 11
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 13,
-                    "offset": 19
-                  }
-                },
-                "type": ".",
-                "left": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 5,
-                      "offset": 11
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 7,
-                      "offset": 13
-                    }
-                  },
-                  "name": "a",
-                  "curly": false
-                },
-                "right": {
-                  "kind": "string",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 10,
-                      "offset": 16
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 13,
-                      "offset": 19
-                    }
-                  },
-                  "value": "-",
-                  "raw": "\"-\"",
-                  "unicode": false,
-                  "isDoubleQuote": true
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "loc": {
@@ -229,7 +119,7 @@
                 "line": 2,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "right": {
@@ -247,25 +137,7 @@
                     "line": 2,
                     "column": 20
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-                },
-                "origin": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 17,
-                      "offset": 23
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 19,
-                      "offset": 25
-                    }
-                  },
-                  "name": "b",
-                  "curly": false
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
                 }
               },
               "loc": {
@@ -277,7 +149,7 @@
                   "line": 2,
                   "column": 20
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "consequent": {
@@ -294,24 +166,7 @@
                     "line": 2,
                     "column": 24
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-                },
-                "origin": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 22,
-                      "offset": 28
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 23,
-                      "offset": 29
-                    }
-                  },
-                  "value": "1"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
                 }
               },
               "loc": {
@@ -323,7 +178,7 @@
                   "line": 2,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "alternative": {
@@ -340,24 +195,7 @@
                     "line": 2,
                     "column": 28
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-                },
-                "origin": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 26,
-                      "offset": 32
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 27,
-                      "offset": 33
-                    }
-                  },
-                  "value": "2"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
                 }
               },
               "loc": {
@@ -369,7 +207,7 @@
                   "line": 2,
                   "column": 28
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "_meta": {
@@ -382,76 +220,7 @@
                   "line": 2,
                   "column": 28
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-              },
-              "origin": {
-                "kind": "retif",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 17,
-                    "offset": 23
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 27,
-                    "offset": 33
-                  }
-                },
-                "test": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 17,
-                      "offset": 23
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 19,
-                      "offset": 25
-                    }
-                  },
-                  "name": "b",
-                  "curly": false
-                },
-                "trueExpr": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 22,
-                      "offset": 28
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 23,
-                      "offset": 29
-                    }
-                  },
-                  "value": "1"
-                },
-                "falseExpr": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 26,
-                      "offset": 32
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 27,
-                      "offset": 33
-                    }
-                  },
-                  "value": "2"
-                },
-                "parenthesizedExpression": true
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "loc": {
@@ -463,7 +232,7 @@
                 "line": 2,
                 "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "_meta": {
@@ -474,150 +243,9 @@
               },
               "end": {
                 "line": 2,
-                "column": 28
+                "column": 29
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-            },
-            "origin": {
-              "kind": "bin",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 5,
-                  "offset": 11
-                },
-                "end": {
-                  "line": 2,
-                  "column": 27,
-                  "offset": 33
-                }
-              },
-              "type": ".",
-              "left": {
-                "kind": "bin",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 5,
-                    "offset": 11
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 13,
-                    "offset": 19
-                  }
-                },
-                "type": ".",
-                "left": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 5,
-                      "offset": 11
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 7,
-                      "offset": 13
-                    }
-                  },
-                  "name": "a",
-                  "curly": false
-                },
-                "right": {
-                  "kind": "string",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 10,
-                      "offset": 16
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 13,
-                      "offset": 19
-                    }
-                  },
-                  "value": "-",
-                  "raw": "\"-\"",
-                  "unicode": false,
-                  "isDoubleQuote": true
-                }
-              },
-              "right": {
-                "kind": "retif",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 17,
-                    "offset": 23
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 27,
-                    "offset": 33
-                  }
-                },
-                "test": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 17,
-                      "offset": 23
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 19,
-                      "offset": 25
-                    }
-                  },
-                  "name": "b",
-                  "curly": false
-                },
-                "trueExpr": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 22,
-                      "offset": 28
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 23,
-                      "offset": 29
-                    }
-                  },
-                  "value": "1"
-                },
-                "falseExpr": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 26,
-                      "offset": 32
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 27,
-                      "offset": 33
-                    }
-                  },
-                  "value": "2"
-                },
-                "parenthesizedExpression": true
-              }
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "loc": {
@@ -627,9 +255,9 @@
             },
             "end": {
               "line": 2,
-              "column": 28
+              "column": 29
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "operator": "=",
@@ -642,185 +270,9 @@
             },
             "end": {
               "line": 2,
-              "column": 30
+              "column": 29
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-          },
-          "origin": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 2,
-                "column": 0,
-                "offset": 6
-              },
-              "end": {
-                "line": 2,
-                "column": 29,
-                "offset": 35
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 0,
-                  "offset": 6
-                },
-                "end": {
-                  "line": 2,
-                  "column": 2,
-                  "offset": 8
-                }
-              },
-              "name": "x",
-              "curly": false
-            },
-            "right": {
-              "kind": "bin",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 5,
-                  "offset": 11
-                },
-                "end": {
-                  "line": 2,
-                  "column": 27,
-                  "offset": 33
-                }
-              },
-              "type": ".",
-              "left": {
-                "kind": "bin",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 5,
-                    "offset": 11
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 13,
-                    "offset": 19
-                  }
-                },
-                "type": ".",
-                "left": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 5,
-                      "offset": 11
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 7,
-                      "offset": 13
-                    }
-                  },
-                  "name": "a",
-                  "curly": false
-                },
-                "right": {
-                  "kind": "string",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 10,
-                      "offset": 16
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 13,
-                      "offset": 19
-                    }
-                  },
-                  "value": "-",
-                  "raw": "\"-\"",
-                  "unicode": false,
-                  "isDoubleQuote": true
-                }
-              },
-              "right": {
-                "kind": "retif",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 17,
-                    "offset": 23
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 27,
-                    "offset": 33
-                  }
-                },
-                "test": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 17,
-                      "offset": 23
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 19,
-                      "offset": 25
-                    }
-                  },
-                  "name": "b",
-                  "curly": false
-                },
-                "trueExpr": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 22,
-                      "offset": 28
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 23,
-                      "offset": 29
-                    }
-                  },
-                  "value": "1"
-                },
-                "falseExpr": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 26,
-                      "offset": 32
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 27,
-                      "offset": 33
-                    }
-                  },
-                  "value": "2"
-                },
-                "parenthesizedExpression": true
-              }
-            },
-            "operator": "="
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "loc": {
@@ -830,9 +282,9 @@
           },
           "end": {
             "line": 2,
-            "column": 30
+            "column": 29
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
         }
       },
       "_meta": {
@@ -845,199 +297,7 @@
             "line": 2,
             "column": 30
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-        },
-        "origin": {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 2,
-              "column": 0,
-              "offset": 6
-            },
-            "end": {
-              "line": 2,
-              "column": 29,
-              "offset": 35
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 2,
-                "column": 0,
-                "offset": 6
-              },
-              "end": {
-                "line": 2,
-                "column": 29,
-                "offset": 35
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 0,
-                  "offset": 6
-                },
-                "end": {
-                  "line": 2,
-                  "column": 2,
-                  "offset": 8
-                }
-              },
-              "name": "x",
-              "curly": false
-            },
-            "right": {
-              "kind": "bin",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 5,
-                  "offset": 11
-                },
-                "end": {
-                  "line": 2,
-                  "column": 27,
-                  "offset": 33
-                }
-              },
-              "type": ".",
-              "left": {
-                "kind": "bin",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 5,
-                    "offset": 11
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 13,
-                    "offset": 19
-                  }
-                },
-                "type": ".",
-                "left": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 5,
-                      "offset": 11
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 7,
-                      "offset": 13
-                    }
-                  },
-                  "name": "a",
-                  "curly": false
-                },
-                "right": {
-                  "kind": "string",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 10,
-                      "offset": 16
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 13,
-                      "offset": 19
-                    }
-                  },
-                  "value": "-",
-                  "raw": "\"-\"",
-                  "unicode": false,
-                  "isDoubleQuote": true
-                }
-              },
-              "right": {
-                "kind": "retif",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 17,
-                    "offset": 23
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 27,
-                    "offset": 33
-                  }
-                },
-                "test": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 17,
-                      "offset": 23
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 19,
-                      "offset": 25
-                    }
-                  },
-                  "name": "b",
-                  "curly": false
-                },
-                "trueExpr": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 22,
-                      "offset": 28
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 23,
-                      "offset": 29
-                    }
-                  },
-                  "value": "1"
-                },
-                "falseExpr": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 26,
-                      "offset": 32
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 27,
-                      "offset": 33
-                    }
-                  },
-                  "value": "2"
-                },
-                "parenthesizedExpression": true
-              }
-            },
-            "operator": "="
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
         }
       },
       "loc": {
@@ -1049,7 +309,7 @@
           "line": 2,
           "column": 30
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
       }
     },
     {
@@ -1069,25 +329,7 @@
                 "line": 3,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-            },
-            "origin": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 0,
-                  "offset": 36
-                },
-                "end": {
-                  "line": 3,
-                  "column": 2,
-                  "offset": 38
-                }
-              },
-              "name": "y",
-              "curly": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "loc": {
@@ -1099,7 +341,7 @@
               "line": 3,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "right": {
@@ -1118,25 +360,7 @@
                   "line": 3,
                   "column": 12
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-              },
-              "origin": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 6,
-                    "offset": 42
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 11,
-                    "offset": 47
-                  }
-                },
-                "name": "flag",
-                "curly": false
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "loc": {
@@ -1148,7 +372,7 @@
                 "line": 3,
                 "column": 12
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "isSuffix": false,
@@ -1162,42 +386,7 @@
                 "line": 3,
                 "column": 12
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-            },
-            "origin": {
-              "kind": "unary",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 5,
-                  "offset": 41
-                },
-                "end": {
-                  "line": 3,
-                  "column": 11,
-                  "offset": 47
-                }
-              },
-              "type": "!",
-              "what": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 6,
-                    "offset": 42
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 11,
-                    "offset": 47
-                  }
-                },
-                "name": "flag",
-                "curly": false
-              }
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "loc": {
@@ -1209,7 +398,7 @@
               "line": 3,
               "column": 12
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "operator": "=",
@@ -1222,79 +411,9 @@
             },
             "end": {
               "line": 3,
-              "column": 13
+              "column": 12
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-          },
-          "origin": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 0,
-                "offset": 36
-              },
-              "end": {
-                "line": 3,
-                "column": 12,
-                "offset": 48
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 0,
-                  "offset": 36
-                },
-                "end": {
-                  "line": 3,
-                  "column": 2,
-                  "offset": 38
-                }
-              },
-              "name": "y",
-              "curly": false
-            },
-            "right": {
-              "kind": "unary",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 5,
-                  "offset": 41
-                },
-                "end": {
-                  "line": 3,
-                  "column": 11,
-                  "offset": 47
-                }
-              },
-              "type": "!",
-              "what": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 6,
-                    "offset": 42
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 11,
-                    "offset": 47
-                  }
-                },
-                "name": "flag",
-                "curly": false
-              }
-            },
-            "operator": "="
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "loc": {
@@ -1304,9 +423,9 @@
           },
           "end": {
             "line": 3,
-            "column": 13
+            "column": 12
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
         }
       },
       "_meta": {
@@ -1319,93 +438,7 @@
             "line": 3,
             "column": 13
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-        },
-        "origin": {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 36
-            },
-            "end": {
-              "line": 3,
-              "column": 12,
-              "offset": 48
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 0,
-                "offset": 36
-              },
-              "end": {
-                "line": 3,
-                "column": 12,
-                "offset": 48
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 0,
-                  "offset": 36
-                },
-                "end": {
-                  "line": 3,
-                  "column": 2,
-                  "offset": 38
-                }
-              },
-              "name": "y",
-              "curly": false
-            },
-            "right": {
-              "kind": "unary",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 5,
-                  "offset": 41
-                },
-                "end": {
-                  "line": 3,
-                  "column": 11,
-                  "offset": 47
-                }
-              },
-              "type": "!",
-              "what": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 6,
-                    "offset": 42
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 11,
-                    "offset": 47
-                  }
-                },
-                "name": "flag",
-                "curly": false
-              }
-            },
-            "operator": "="
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
         }
       },
       "loc": {
@@ -1417,7 +450,7 @@
           "line": 3,
           "column": 13
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
       }
     },
     {
@@ -1437,25 +470,7 @@
                 "line": 4,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-            },
-            "origin": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 4,
-                  "column": 0,
-                  "offset": 49
-                },
-                "end": {
-                  "line": 4,
-                  "column": 2,
-                  "offset": 51
-                }
-              },
-              "name": "f",
-              "curly": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "loc": {
@@ -1467,7 +482,7 @@
               "line": 4,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "right": {
@@ -1489,24 +504,7 @@
                       "line": 4,
                       "column": 11
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-                  },
-                  "origin": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 4,
-                        "column": 8,
-                        "offset": 57
-                      },
-                      "end": {
-                        "line": 4,
-                        "column": 10,
-                        "offset": 59
-                      }
-                    },
-                    "name": "z"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
                   }
                 },
                 "loc": {
@@ -1518,7 +516,7 @@
                     "line": 4,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
                 }
               },
               "init": null,
@@ -1529,9 +527,7 @@
                 "_meta": {}
               },
               "_meta": {
-                "byref": false,
                 "variadic": false,
-                "attributes": [],
                 "loc": {
                   "start": {
                     "line": 4,
@@ -1541,48 +537,7 @@
                     "line": 4,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-                },
-                "origin": {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 4,
-                      "column": 8,
-                      "offset": 57
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 10,
-                      "offset": 59
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 4,
-                        "column": 8,
-                        "offset": 57
-                      },
-                      "end": {
-                        "line": 4,
-                        "column": 10,
-                        "offset": 59
-                      }
-                    },
-                    "name": "z"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": []
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
                 }
               },
               "loc": {
@@ -1594,7 +549,7 @@
                   "line": 4,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
               }
             }
           ],
@@ -1624,25 +579,7 @@
                           "line": 4,
                           "column": 18
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-                      },
-                      "origin": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 4,
-                            "column": 15,
-                            "offset": 64
-                          },
-                          "end": {
-                            "line": 4,
-                            "column": 17,
-                            "offset": 66
-                          }
-                        },
-                        "name": "z",
-                        "curly": false
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
                       }
                     },
                     "loc": {
@@ -1654,7 +591,7 @@
                         "line": 4,
                         "column": 18
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
                     }
                   },
                   "right": {
@@ -1671,24 +608,7 @@
                           "line": 4,
                           "column": 22
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-                      },
-                      "origin": {
-                        "kind": "number",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 4,
-                            "column": 20,
-                            "offset": 69
-                          },
-                          "end": {
-                            "line": 4,
-                            "column": 21,
-                            "offset": 70
-                          }
-                        },
-                        "value": "1"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
                       }
                     },
                     "loc": {
@@ -1700,7 +620,7 @@
                         "line": 4,
                         "column": 22
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
                     }
                   },
                   "_meta": {
@@ -1713,59 +633,7 @@
                         "line": 4,
                         "column": 22
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-                    },
-                    "origin": {
-                      "kind": "bin",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 4,
-                          "column": 15,
-                          "offset": 64
-                        },
-                        "end": {
-                          "line": 4,
-                          "column": 21,
-                          "offset": 70
-                        }
-                      },
-                      "type": "+",
-                      "left": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 4,
-                            "column": 15,
-                            "offset": 64
-                          },
-                          "end": {
-                            "line": 4,
-                            "column": 17,
-                            "offset": 66
-                          }
-                        },
-                        "name": "z",
-                        "curly": false
-                      },
-                      "right": {
-                        "kind": "number",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 4,
-                            "column": 20,
-                            "offset": 69
-                          },
-                          "end": {
-                            "line": 4,
-                            "column": 21,
-                            "offset": 70
-                          }
-                        },
-                        "value": "1"
-                      }
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
                     }
                   },
                   "loc": {
@@ -1777,7 +645,7 @@
                       "line": 4,
                       "column": 22
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
                   }
                 },
                 "isYield": false,
@@ -1791,59 +659,7 @@
                       "line": 4,
                       "column": 22
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-                  },
-                  "origin": {
-                    "kind": "bin",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 4,
-                        "column": 15,
-                        "offset": 64
-                      },
-                      "end": {
-                        "line": 4,
-                        "column": 21,
-                        "offset": 70
-                      }
-                    },
-                    "type": "+",
-                    "left": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 4,
-                          "column": 15,
-                          "offset": 64
-                        },
-                        "end": {
-                          "line": 4,
-                          "column": 17,
-                          "offset": 66
-                        }
-                      },
-                      "name": "z",
-                      "curly": false
-                    },
-                    "right": {
-                      "kind": "number",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 4,
-                          "column": 20,
-                          "offset": 69
-                        },
-                        "end": {
-                          "line": 4,
-                          "column": 21,
-                          "offset": 70
-                        }
-                      },
-                      "value": "1"
-                    }
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
                   }
                 },
                 "loc": {
@@ -1855,7 +671,7 @@
                     "line": 4,
                     "column": 22
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
                 }
               }
             ],
@@ -1870,59 +686,7 @@
                   "line": 4,
                   "column": 22
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-              },
-              "origin": {
-                "kind": "bin",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 4,
-                    "column": 15,
-                    "offset": 64
-                  },
-                  "end": {
-                    "line": 4,
-                    "column": 21,
-                    "offset": 70
-                  }
-                },
-                "type": "+",
-                "left": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 4,
-                      "column": 15,
-                      "offset": 64
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 17,
-                      "offset": 66
-                    }
-                  },
-                  "name": "z",
-                  "curly": false
-                },
-                "right": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 4,
-                      "column": 20,
-                      "offset": 69
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 21,
-                      "offset": 70
-                    }
-                  },
-                  "value": "1"
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
               }
             },
             "loc": {
@@ -1934,7 +698,7 @@
                 "line": 4,
                 "column": 22
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "modifiers": [],
@@ -1948,123 +712,7 @@
                 "line": 4,
                 "column": 22
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-            },
-            "origin": {
-              "kind": "arrowfunc",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 4,
-                  "column": 5,
-                  "offset": 54
-                },
-                "end": {
-                  "line": 4,
-                  "column": 21,
-                  "offset": 70
-                }
-              },
-              "arguments": [
-                {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 4,
-                      "column": 8,
-                      "offset": 57
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 10,
-                      "offset": 59
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 4,
-                        "column": 8,
-                        "offset": 57
-                      },
-                      "end": {
-                        "line": 4,
-                        "column": 10,
-                        "offset": 59
-                      }
-                    },
-                    "name": "z"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": []
-                }
-              ],
-              "byref": false,
-              "body": {
-                "kind": "bin",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 4,
-                    "column": 15,
-                    "offset": 64
-                  },
-                  "end": {
-                    "line": 4,
-                    "column": 21,
-                    "offset": 70
-                  }
-                },
-                "type": "+",
-                "left": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 4,
-                      "column": 15,
-                      "offset": 64
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 17,
-                      "offset": 66
-                    }
-                  },
-                  "name": "z",
-                  "curly": false
-                },
-                "right": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 4,
-                      "column": 20,
-                      "offset": 69
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 21,
-                      "offset": 70
-                    }
-                  },
-                  "value": "1"
-                }
-              },
-              "type": null,
-              "nullable": false,
-              "isStatic": false,
-              "attrGroups": []
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
             }
           },
           "loc": {
@@ -2076,7 +724,7 @@
               "line": 4,
               "column": 22
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "operator": "=",
@@ -2089,160 +737,9 @@
             },
             "end": {
               "line": 4,
-              "column": 23
+              "column": 22
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-          },
-          "origin": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 4,
-                "column": 0,
-                "offset": 49
-              },
-              "end": {
-                "line": 4,
-                "column": 22,
-                "offset": 71
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 4,
-                  "column": 0,
-                  "offset": 49
-                },
-                "end": {
-                  "line": 4,
-                  "column": 2,
-                  "offset": 51
-                }
-              },
-              "name": "f",
-              "curly": false
-            },
-            "right": {
-              "kind": "arrowfunc",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 4,
-                  "column": 5,
-                  "offset": 54
-                },
-                "end": {
-                  "line": 4,
-                  "column": 21,
-                  "offset": 70
-                }
-              },
-              "arguments": [
-                {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 4,
-                      "column": 8,
-                      "offset": 57
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 10,
-                      "offset": 59
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 4,
-                        "column": 8,
-                        "offset": 57
-                      },
-                      "end": {
-                        "line": 4,
-                        "column": 10,
-                        "offset": 59
-                      }
-                    },
-                    "name": "z"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": []
-                }
-              ],
-              "byref": false,
-              "body": {
-                "kind": "bin",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 4,
-                    "column": 15,
-                    "offset": 64
-                  },
-                  "end": {
-                    "line": 4,
-                    "column": 21,
-                    "offset": 70
-                  }
-                },
-                "type": "+",
-                "left": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 4,
-                      "column": 15,
-                      "offset": 64
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 17,
-                      "offset": 66
-                    }
-                  },
-                  "name": "z",
-                  "curly": false
-                },
-                "right": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 4,
-                      "column": 20,
-                      "offset": 69
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 21,
-                      "offset": 70
-                    }
-                  },
-                  "value": "1"
-                }
-              },
-              "type": null,
-              "nullable": false,
-              "isStatic": false,
-              "attrGroups": []
-            },
-            "operator": "="
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
           }
         },
         "loc": {
@@ -2252,9 +749,9 @@
           },
           "end": {
             "line": 4,
-            "column": 23
+            "column": 22
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
         }
       },
       "_meta": {
@@ -2267,174 +764,7 @@
             "line": 4,
             "column": 23
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-        },
-        "origin": {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 4,
-              "column": 0,
-              "offset": 49
-            },
-            "end": {
-              "line": 4,
-              "column": 22,
-              "offset": 71
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 4,
-                "column": 0,
-                "offset": 49
-              },
-              "end": {
-                "line": 4,
-                "column": 22,
-                "offset": 71
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 4,
-                  "column": 0,
-                  "offset": 49
-                },
-                "end": {
-                  "line": 4,
-                  "column": 2,
-                  "offset": 51
-                }
-              },
-              "name": "f",
-              "curly": false
-            },
-            "right": {
-              "kind": "arrowfunc",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 4,
-                  "column": 5,
-                  "offset": 54
-                },
-                "end": {
-                  "line": 4,
-                  "column": 21,
-                  "offset": 70
-                }
-              },
-              "arguments": [
-                {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 4,
-                      "column": 8,
-                      "offset": 57
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 10,
-                      "offset": 59
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 4,
-                        "column": 8,
-                        "offset": 57
-                      },
-                      "end": {
-                        "line": 4,
-                        "column": 10,
-                        "offset": 59
-                      }
-                    },
-                    "name": "z"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": []
-                }
-              ],
-              "byref": false,
-              "body": {
-                "kind": "bin",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 4,
-                    "column": 15,
-                    "offset": 64
-                  },
-                  "end": {
-                    "line": 4,
-                    "column": 21,
-                    "offset": 70
-                  }
-                },
-                "type": "+",
-                "left": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 4,
-                      "column": 15,
-                      "offset": 64
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 17,
-                      "offset": 66
-                    }
-                  },
-                  "name": "z",
-                  "curly": false
-                },
-                "right": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 4,
-                      "column": 20,
-                      "offset": 69
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 21,
-                      "offset": 70
-                    }
-                  },
-                  "value": "1"
-                }
-              },
-              "type": null,
-              "nullable": false,
-              "isStatic": false,
-              "attrGroups": []
-            },
-            "operator": "="
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
         }
       },
       "loc": {
@@ -2446,13 +776,13 @@
           "line": 4,
           "column": 23
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -2464,472 +794,7 @@
         "line": 5,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
-    },
-    "origin": {
-      "kind": "program",
-      "loc": {
-        "source": null,
-        "start": {
-          "line": 1,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "line": 5,
-          "column": 0,
-          "offset": 72
-        }
-      },
-      "children": [
-        {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 2,
-              "column": 0,
-              "offset": 6
-            },
-            "end": {
-              "line": 2,
-              "column": 29,
-              "offset": 35
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 2,
-                "column": 0,
-                "offset": 6
-              },
-              "end": {
-                "line": 2,
-                "column": 29,
-                "offset": 35
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 0,
-                  "offset": 6
-                },
-                "end": {
-                  "line": 2,
-                  "column": 2,
-                  "offset": 8
-                }
-              },
-              "name": "x",
-              "curly": false
-            },
-            "right": {
-              "kind": "bin",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 5,
-                  "offset": 11
-                },
-                "end": {
-                  "line": 2,
-                  "column": 27,
-                  "offset": 33
-                }
-              },
-              "type": ".",
-              "left": {
-                "kind": "bin",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 5,
-                    "offset": 11
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 13,
-                    "offset": 19
-                  }
-                },
-                "type": ".",
-                "left": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 5,
-                      "offset": 11
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 7,
-                      "offset": 13
-                    }
-                  },
-                  "name": "a",
-                  "curly": false
-                },
-                "right": {
-                  "kind": "string",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 10,
-                      "offset": 16
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 13,
-                      "offset": 19
-                    }
-                  },
-                  "value": "-",
-                  "raw": "\"-\"",
-                  "unicode": false,
-                  "isDoubleQuote": true
-                }
-              },
-              "right": {
-                "kind": "retif",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 17,
-                    "offset": 23
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 27,
-                    "offset": 33
-                  }
-                },
-                "test": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 17,
-                      "offset": 23
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 19,
-                      "offset": 25
-                    }
-                  },
-                  "name": "b",
-                  "curly": false
-                },
-                "trueExpr": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 22,
-                      "offset": 28
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 23,
-                      "offset": 29
-                    }
-                  },
-                  "value": "1"
-                },
-                "falseExpr": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 26,
-                      "offset": 32
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 27,
-                      "offset": 33
-                    }
-                  },
-                  "value": "2"
-                },
-                "parenthesizedExpression": true
-              }
-            },
-            "operator": "="
-          }
-        },
-        {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 36
-            },
-            "end": {
-              "line": 3,
-              "column": 12,
-              "offset": 48
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 0,
-                "offset": 36
-              },
-              "end": {
-                "line": 3,
-                "column": 12,
-                "offset": 48
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 0,
-                  "offset": 36
-                },
-                "end": {
-                  "line": 3,
-                  "column": 2,
-                  "offset": 38
-                }
-              },
-              "name": "y",
-              "curly": false
-            },
-            "right": {
-              "kind": "unary",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 5,
-                  "offset": 41
-                },
-                "end": {
-                  "line": 3,
-                  "column": 11,
-                  "offset": 47
-                }
-              },
-              "type": "!",
-              "what": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 6,
-                    "offset": 42
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 11,
-                    "offset": 47
-                  }
-                },
-                "name": "flag",
-                "curly": false
-              }
-            },
-            "operator": "="
-          }
-        },
-        {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 4,
-              "column": 0,
-              "offset": 49
-            },
-            "end": {
-              "line": 4,
-              "column": 22,
-              "offset": 71
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 4,
-                "column": 0,
-                "offset": 49
-              },
-              "end": {
-                "line": 4,
-                "column": 22,
-                "offset": 71
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 4,
-                  "column": 0,
-                  "offset": 49
-                },
-                "end": {
-                  "line": 4,
-                  "column": 2,
-                  "offset": 51
-                }
-              },
-              "name": "f",
-              "curly": false
-            },
-            "right": {
-              "kind": "arrowfunc",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 4,
-                  "column": 5,
-                  "offset": 54
-                },
-                "end": {
-                  "line": 4,
-                  "column": 21,
-                  "offset": 70
-                }
-              },
-              "arguments": [
-                {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 4,
-                      "column": 8,
-                      "offset": 57
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 10,
-                      "offset": 59
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 4,
-                        "column": 8,
-                        "offset": 57
-                      },
-                      "end": {
-                        "line": 4,
-                        "column": 10,
-                        "offset": 59
-                      }
-                    },
-                    "name": "z"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": []
-                }
-              ],
-              "byref": false,
-              "body": {
-                "kind": "bin",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 4,
-                    "column": 15,
-                    "offset": 64
-                  },
-                  "end": {
-                    "line": 4,
-                    "column": 21,
-                    "offset": 70
-                  }
-                },
-                "type": "+",
-                "left": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 4,
-                      "column": 15,
-                      "offset": 64
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 17,
-                      "offset": 66
-                    }
-                  },
-                  "name": "z",
-                  "curly": false
-                },
-                "right": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 4,
-                      "column": 20,
-                      "offset": 69
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 21,
-                      "offset": 70
-                    }
-                  },
-                  "value": "1"
-                }
-              },
-              "type": null,
-              "nullable": false,
-              "isStatic": false,
-              "attrGroups": []
-            },
-            "operator": "="
-          }
-        }
-      ],
-      "errors": [],
-      "comments": []
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
     }
   },
   "loc": {
@@ -2941,6 +806,6 @@
       "line": 5,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/exprs.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/exprs.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/flow-extras.php.json
+++ b/parser-PHP/tests/benchmark/base/flow-extras.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 15
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+            "sourcefile": "flow-extras.php"
           }
         },
         "loc": {
@@ -28,7 +28,7 @@
             "line": 3,
             "column": 15
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+          "sourcefile": "flow-extras.php"
         }
       },
       "parameters": [
@@ -47,7 +47,7 @@
                   "line": 3,
                   "column": 20
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "flow-extras.php"
               }
             },
             "loc": {
@@ -59,7 +59,7 @@
                 "line": 3,
                 "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "flow-extras.php"
             }
           },
           "init": null,
@@ -80,7 +80,7 @@
                 "line": 3,
                 "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "flow-extras.php"
             }
           },
           "loc": {
@@ -92,7 +92,7 @@
               "line": 3,
               "column": 20
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+            "sourcefile": "flow-extras.php"
           }
         },
         {
@@ -110,7 +110,7 @@
                   "line": 3,
                   "column": 28
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "flow-extras.php"
               }
             },
             "loc": {
@@ -122,7 +122,7 @@
                 "line": 3,
                 "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "flow-extras.php"
             }
           },
           "init": null,
@@ -143,7 +143,7 @@
                 "line": 3,
                 "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "flow-extras.php"
             }
           },
           "loc": {
@@ -155,7 +155,7 @@
               "line": 3,
               "column": 28
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+            "sourcefile": "flow-extras.php"
           }
         }
       ],
@@ -184,7 +184,7 @@
                       "line": 5,
                       "column": 10
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "flow-extras.php"
                   }
                 },
                 "loc": {
@@ -196,7 +196,7 @@
                     "line": 5,
                     "column": 10
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "flow-extras.php"
                 }
               },
               "right": {
@@ -213,7 +213,7 @@
                         "line": 5,
                         "column": 26
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "flow-extras.php"
                     }
                   },
                   "loc": {
@@ -225,7 +225,7 @@
                       "line": 5,
                       "column": 26
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "flow-extras.php"
                   }
                 },
                 "consequent": {
@@ -242,7 +242,7 @@
                           "line": 5,
                           "column": 26
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                        "sourcefile": "flow-extras.php"
                       }
                     },
                     "loc": {
@@ -254,7 +254,7 @@
                         "line": 5,
                         "column": 26
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "flow-extras.php"
                     }
                   },
                   "property": {
@@ -270,7 +270,7 @@
                           "line": 5,
                           "column": 33
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                        "sourcefile": "flow-extras.php"
                       }
                     },
                     "loc": {
@@ -282,7 +282,7 @@
                         "line": 5,
                         "column": 33
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "flow-extras.php"
                     }
                   },
                   "computed": false,
@@ -296,7 +296,7 @@
                         "line": 5,
                         "column": 33
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "flow-extras.php"
                     },
                     "nullsafe": true
                   },
@@ -309,7 +309,7 @@
                       "line": 5,
                       "column": 33
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "flow-extras.php"
                   }
                 },
                 "alternative": {
@@ -328,7 +328,7 @@
                       "line": 5,
                       "column": 33
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "flow-extras.php"
                   }
                 },
                 "loc": {
@@ -340,7 +340,7 @@
                     "line": 5,
                     "column": 33
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "flow-extras.php"
                 }
               },
               "operator": "=",
@@ -355,7 +355,7 @@
                     "line": 5,
                     "column": 33
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "flow-extras.php"
                 }
               },
               "loc": {
@@ -367,7 +367,7 @@
                   "line": 5,
                   "column": 33
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "flow-extras.php"
               }
             },
             "_meta": {
@@ -380,7 +380,7 @@
                   "line": 5,
                   "column": 34
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "flow-extras.php"
               }
             },
             "loc": {
@@ -392,7 +392,7 @@
                 "line": 5,
                 "column": 34
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "flow-extras.php"
             }
           },
           {
@@ -412,7 +412,7 @@
                       "line": 6,
                       "column": 11
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "flow-extras.php"
                   }
                 },
                 "loc": {
@@ -424,7 +424,7 @@
                     "line": 6,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "flow-extras.php"
                 }
               },
               "right": {
@@ -443,7 +443,7 @@
                         "line": 6,
                         "column": 20
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "flow-extras.php"
                     }
                   },
                   "loc": {
@@ -455,7 +455,7 @@
                       "line": 6,
                       "column": 20
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "flow-extras.php"
                   }
                 },
                 "right": {
@@ -473,7 +473,7 @@
                         "line": 6,
                         "column": 26
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "flow-extras.php"
                     }
                   },
                   "loc": {
@@ -485,7 +485,7 @@
                       "line": 6,
                       "column": 26
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "flow-extras.php"
                   }
                 },
                 "_meta": {
@@ -498,7 +498,7 @@
                       "line": 6,
                       "column": 26
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "flow-extras.php"
                   }
                 },
                 "loc": {
@@ -510,7 +510,7 @@
                     "line": 6,
                     "column": 26
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "flow-extras.php"
                 }
               },
               "operator": "=",
@@ -525,7 +525,7 @@
                     "line": 6,
                     "column": 26
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "flow-extras.php"
                 }
               },
               "loc": {
@@ -537,7 +537,7 @@
                   "line": 6,
                   "column": 26
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "flow-extras.php"
               }
             },
             "_meta": {
@@ -550,7 +550,7 @@
                   "line": 6,
                   "column": 27
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "flow-extras.php"
               }
             },
             "loc": {
@@ -562,7 +562,7 @@
                 "line": 6,
                 "column": 27
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "flow-extras.php"
             }
           },
           {
@@ -581,7 +581,7 @@
                       "line": 8,
                       "column": 17
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "flow-extras.php"
                   }
                 },
                 "loc": {
@@ -593,7 +593,7 @@
                     "line": 8,
                     "column": 17
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "flow-extras.php"
                 }
               },
               "_meta": {
@@ -606,7 +606,7 @@
                     "line": 8,
                     "column": 17
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "flow-extras.php"
                 }
               },
               "loc": {
@@ -618,7 +618,7 @@
                   "line": 8,
                   "column": 17
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "flow-extras.php"
               }
             },
             "_meta": {
@@ -631,7 +631,7 @@
                   "line": 8,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "flow-extras.php"
               }
             },
             "loc": {
@@ -643,7 +643,7 @@
                 "line": 8,
                 "column": 18
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "flow-extras.php"
             }
           },
           {
@@ -665,7 +665,7 @@
                         "line": 9,
                         "column": 22
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "flow-extras.php"
                     }
                   },
                   "loc": {
@@ -677,7 +677,7 @@
                       "line": 9,
                       "column": 22
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "flow-extras.php"
                   }
                 },
                 "arguments": [],
@@ -691,7 +691,7 @@
                       "line": 9,
                       "column": 24
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "flow-extras.php"
                   }
                 },
                 "loc": {
@@ -703,7 +703,7 @@
                     "line": 9,
                     "column": 24
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "flow-extras.php"
                 }
               },
               "_meta": {
@@ -716,7 +716,7 @@
                     "line": 9,
                     "column": 24
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "flow-extras.php"
                 }
               },
               "loc": {
@@ -728,7 +728,7 @@
                   "line": 9,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "flow-extras.php"
               }
             },
             "_meta": {
@@ -741,7 +741,7 @@
                   "line": 9,
                   "column": 25
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "flow-extras.php"
               }
             },
             "loc": {
@@ -753,7 +753,7 @@
                 "line": 9,
                 "column": 25
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "flow-extras.php"
             }
           },
           {
@@ -771,7 +771,7 @@
                     "line": 11,
                     "column": 17
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "flow-extras.php"
                 }
               },
               "loc": {
@@ -783,7 +783,7 @@
                   "line": 11,
                   "column": 17
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "flow-extras.php"
               }
             },
             "isYield": false,
@@ -797,7 +797,7 @@
                   "line": 11,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "flow-extras.php"
               }
             },
             "loc": {
@@ -809,7 +809,7 @@
                 "line": 11,
                 "column": 18
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "flow-extras.php"
             }
           }
         ],
@@ -824,7 +824,7 @@
               "line": 12,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+            "sourcefile": "flow-extras.php"
           }
         },
         "loc": {
@@ -836,7 +836,7 @@
             "line": 12,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+          "sourcefile": "flow-extras.php"
         }
       },
       "modifiers": [],
@@ -850,7 +850,7 @@
             "line": 12,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+          "sourcefile": "flow-extras.php"
         }
       },
       "loc": {
@@ -862,13 +862,13 @@
           "line": 12,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+        "sourcefile": "flow-extras.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php",
+  "uri": "flow-extras.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -880,7 +880,7 @@
         "line": 13,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+      "sourcefile": "flow-extras.php"
     }
   },
   "loc": {
@@ -892,6 +892,6 @@
       "line": 13,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+    "sourcefile": "flow-extras.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/flow-extras.php.json
+++ b/parser-PHP/tests/benchmark/base/flow-extras.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 15
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
           }
         },
         "loc": {
@@ -28,7 +28,7 @@
             "line": 3,
             "column": 15
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
         }
       },
       "parameters": [
@@ -47,7 +47,7 @@
                   "line": 3,
                   "column": 20
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "loc": {
@@ -59,7 +59,7 @@
                 "line": 3,
                 "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           "init": null,
@@ -80,7 +80,7 @@
                 "line": 3,
                 "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           "loc": {
@@ -92,7 +92,7 @@
               "line": 3,
               "column": 20
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
           }
         },
         {
@@ -110,7 +110,7 @@
                   "line": 3,
                   "column": 28
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "loc": {
@@ -122,7 +122,7 @@
                 "line": 3,
                 "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           "init": null,
@@ -143,7 +143,7 @@
                 "line": 3,
                 "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           "loc": {
@@ -155,7 +155,7 @@
               "line": 3,
               "column": 28
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
           }
         }
       ],
@@ -184,7 +184,7 @@
                       "line": 5,
                       "column": 10
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "loc": {
@@ -196,7 +196,7 @@
                     "line": 5,
                     "column": 10
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "right": {
@@ -213,7 +213,7 @@
                         "line": 5,
                         "column": 26
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                     }
                   },
                   "loc": {
@@ -225,7 +225,7 @@
                       "line": 5,
                       "column": 26
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "consequent": {
@@ -242,7 +242,7 @@
                           "line": 5,
                           "column": 26
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                       }
                     },
                     "loc": {
@@ -254,7 +254,7 @@
                         "line": 5,
                         "column": 26
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                     }
                   },
                   "property": {
@@ -270,7 +270,7 @@
                           "line": 5,
                           "column": 33
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                       }
                     },
                     "loc": {
@@ -282,7 +282,7 @@
                         "line": 5,
                         "column": 33
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                     }
                   },
                   "computed": false,
@@ -296,7 +296,7 @@
                         "line": 5,
                         "column": 33
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                     },
                     "nullsafe": true
                   },
@@ -309,7 +309,7 @@
                       "line": 5,
                       "column": 33
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "alternative": {
@@ -328,7 +328,7 @@
                       "line": 5,
                       "column": 33
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "loc": {
@@ -340,7 +340,7 @@
                     "line": 5,
                     "column": 33
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "operator": "=",
@@ -355,7 +355,7 @@
                     "line": 5,
                     "column": 33
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "loc": {
@@ -367,7 +367,7 @@
                   "line": 5,
                   "column": 33
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "_meta": {
@@ -380,7 +380,7 @@
                   "line": 5,
                   "column": 34
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "loc": {
@@ -392,7 +392,7 @@
                 "line": 5,
                 "column": 34
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           {
@@ -412,7 +412,7 @@
                       "line": 6,
                       "column": 11
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "loc": {
@@ -424,7 +424,7 @@
                     "line": 6,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "right": {
@@ -443,7 +443,7 @@
                         "line": 6,
                         "column": 20
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                     }
                   },
                   "loc": {
@@ -455,7 +455,7 @@
                       "line": 6,
                       "column": 20
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "right": {
@@ -473,7 +473,7 @@
                         "line": 6,
                         "column": 26
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                     }
                   },
                   "loc": {
@@ -485,7 +485,7 @@
                       "line": 6,
                       "column": 26
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "_meta": {
@@ -498,7 +498,7 @@
                       "line": 6,
                       "column": 26
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "loc": {
@@ -510,7 +510,7 @@
                     "line": 6,
                     "column": 26
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "operator": "=",
@@ -525,7 +525,7 @@
                     "line": 6,
                     "column": 26
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "loc": {
@@ -537,7 +537,7 @@
                   "line": 6,
                   "column": 26
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "_meta": {
@@ -550,7 +550,7 @@
                   "line": 6,
                   "column": 27
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "loc": {
@@ -562,7 +562,7 @@
                 "line": 6,
                 "column": 27
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           {
@@ -581,7 +581,7 @@
                       "line": 8,
                       "column": 17
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "loc": {
@@ -593,7 +593,7 @@
                     "line": 8,
                     "column": 17
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "_meta": {
@@ -606,7 +606,7 @@
                     "line": 8,
                     "column": 17
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "loc": {
@@ -618,7 +618,7 @@
                   "line": 8,
                   "column": 17
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "_meta": {
@@ -631,7 +631,7 @@
                   "line": 8,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "loc": {
@@ -643,7 +643,7 @@
                 "line": 8,
                 "column": 18
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           {
@@ -665,7 +665,7 @@
                         "line": 9,
                         "column": 22
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                     }
                   },
                   "loc": {
@@ -677,7 +677,7 @@
                       "line": 9,
                       "column": 22
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "arguments": [],
@@ -691,7 +691,7 @@
                       "line": 9,
                       "column": 24
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "loc": {
@@ -703,7 +703,7 @@
                     "line": 9,
                     "column": 24
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "_meta": {
@@ -716,7 +716,7 @@
                     "line": 9,
                     "column": 24
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "loc": {
@@ -728,7 +728,7 @@
                   "line": 9,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "_meta": {
@@ -741,7 +741,7 @@
                   "line": 9,
                   "column": 25
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "loc": {
@@ -753,7 +753,7 @@
                 "line": 9,
                 "column": 25
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           {
@@ -771,7 +771,7 @@
                     "line": 11,
                     "column": 17
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "loc": {
@@ -783,7 +783,7 @@
                   "line": 11,
                   "column": 17
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "isYield": false,
@@ -797,7 +797,7 @@
                   "line": 11,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "loc": {
@@ -809,7 +809,7 @@
                 "line": 11,
                 "column": 18
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           }
         ],
@@ -824,7 +824,7 @@
               "line": 12,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
           }
         },
         "loc": {
@@ -836,7 +836,7 @@
             "line": 12,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
         }
       },
       "modifiers": [],
@@ -850,7 +850,7 @@
             "line": 12,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
         }
       },
       "loc": {
@@ -862,13 +862,13 @@
           "line": 12,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -880,7 +880,7 @@
         "line": 13,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
     }
   },
   "loc": {
@@ -892,6 +892,6 @@
       "line": 13,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/flow-extras.php.json
+++ b/parser-PHP/tests/benchmark/base/flow-extras.php.json
@@ -16,24 +16,7 @@
               "line": 3,
               "column": 15
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-          },
-          "origin": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 9,
-                "offset": 16
-              },
-              "end": {
-                "line": 3,
-                "column": 14,
-                "offset": 21
-              }
-            },
-            "name": "fetch"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
           }
         },
         "loc": {
@@ -45,7 +28,7 @@
             "line": 3,
             "column": 15
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
         }
       },
       "parameters": [
@@ -64,24 +47,7 @@
                   "line": 3,
                   "column": 20
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 15,
-                    "offset": 22
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 19,
-                    "offset": 26
-                  }
-                },
-                "name": "req"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "loc": {
@@ -93,7 +59,7 @@
                 "line": 3,
                 "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           "init": null,
@@ -104,9 +70,7 @@
             "_meta": {}
           },
           "_meta": {
-            "byref": false,
             "variadic": false,
-            "attributes": [],
             "loc": {
               "start": {
                 "line": 3,
@@ -116,48 +80,7 @@
                 "line": 3,
                 "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-            },
-            "origin": {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 15,
-                  "offset": 22
-                },
-                "end": {
-                  "line": 3,
-                  "column": 19,
-                  "offset": 26
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 15,
-                    "offset": 22
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 19,
-                    "offset": 26
-                  }
-                },
-                "name": "req"
-              },
-              "value": null,
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           "loc": {
@@ -169,7 +92,7 @@
               "line": 3,
               "column": 20
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
           }
         },
         {
@@ -187,24 +110,7 @@
                   "line": 3,
                   "column": 28
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 21,
-                    "offset": 28
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 27,
-                    "offset": 34
-                  }
-                },
-                "name": "items"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "loc": {
@@ -216,7 +122,7 @@
                 "line": 3,
                 "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           "init": null,
@@ -227,9 +133,7 @@
             "_meta": {}
           },
           "_meta": {
-            "byref": false,
             "variadic": false,
-            "attributes": [],
             "loc": {
               "start": {
                 "line": 3,
@@ -239,48 +143,7 @@
                 "line": 3,
                 "column": 28
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-            },
-            "origin": {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 21,
-                  "offset": 28
-                },
-                "end": {
-                  "line": 3,
-                  "column": 27,
-                  "offset": 34
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 21,
-                    "offset": 28
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 27,
-                    "offset": 34
-                  }
-                },
-                "name": "items"
-              },
-              "value": null,
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           "loc": {
@@ -292,7 +155,7 @@
               "line": 3,
               "column": 28
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
           }
         }
       ],
@@ -321,25 +184,7 @@
                       "line": 5,
                       "column": 10
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                  },
-                  "origin": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 4,
-                        "offset": 42
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 9,
-                        "offset": 47
-                      }
-                    },
-                    "name": "name",
-                    "curly": false
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "loc": {
@@ -351,49 +196,43 @@
                     "line": 5,
                     "column": 10
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "right": {
                 "type": "ConditionalExpression",
                 "test": {
-                  "type": "CallExpression",
-                  "callee": {
-                    "type": "ConditionalExpression",
-                    "test": {
-                      "type": "Identifier",
-                      "name": "req",
-                      "_meta": {
-                        "loc": {
-                          "start": {
-                            "line": 5,
-                            "column": 13
-                          },
-                          "end": {
-                            "line": 5,
-                            "column": 17
-                          },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                        },
-                        "origin": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 12,
-                              "offset": 50
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 16,
-                              "offset": 54
-                            }
-                          },
-                          "name": "req",
-                          "curly": false
-                        }
+                  "type": "Noop",
+                  "_meta": {
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 13
                       },
+                      "end": {
+                        "line": 5,
+                        "column": 26
+                      },
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    }
+                  },
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 13
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 26
+                    },
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  }
+                },
+                "consequent": {
+                  "type": "MemberAccess",
+                  "object": {
+                    "type": "Noop",
+                    "_meta": {
                       "loc": {
                         "start": {
                           "line": 5,
@@ -401,755 +240,21 @@
                         },
                         "end": {
                           "line": 5,
-                          "column": 17
-                        },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                      }
-                    },
-                    "consequent": {
-                      "type": "MemberAccess",
-                      "object": {
-                        "type": "Identifier",
-                        "name": "req",
-                        "_meta": {
-                          "loc": {
-                            "start": {
-                              "line": 5,
-                              "column": 13
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 17
-                            },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                          },
-                          "origin": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 5,
-                                "column": 12,
-                                "offset": 50
-                              },
-                              "end": {
-                                "line": 5,
-                                "column": 16,
-                                "offset": 54
-                              }
-                            },
-                            "name": "req",
-                            "curly": false
-                          }
-                        },
-                        "loc": {
-                          "start": {
-                            "line": 5,
-                            "column": 13
-                          },
-                          "end": {
-                            "line": 5,
-                            "column": 17
-                          },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                        }
-                      },
-                      "property": {
-                        "type": "Identifier",
-                        "name": "user",
-                        "_meta": {
-                          "loc": {
-                            "start": {
-                              "line": 5,
-                              "column": 20
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 24
-                            },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                          },
-                          "origin": {
-                            "kind": "identifier",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 5,
-                                "column": 19,
-                                "offset": 57
-                              },
-                              "end": {
-                                "line": 5,
-                                "column": 23,
-                                "offset": 61
-                              }
-                            },
-                            "name": "user"
-                          }
-                        },
-                        "loc": {
-                          "start": {
-                            "line": 5,
-                            "column": 20
-                          },
-                          "end": {
-                            "line": 5,
-                            "column": 24
-                          },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                        }
-                      },
-                      "computed": false,
-                      "_meta": {
-                        "loc": {
-                          "start": {
-                            "line": 5,
-                            "column": 17
-                          },
-                          "end": {
-                            "line": 5,
-                            "column": 24
-                          },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                        },
-                        "origin": {
-                          "kind": "nullsafepropertylookup",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 16,
-                              "offset": 54
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 23,
-                              "offset": 61
-                            }
-                          },
-                          "what": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 5,
-                                "column": 12,
-                                "offset": 50
-                              },
-                              "end": {
-                                "line": 5,
-                                "column": 16,
-                                "offset": 54
-                              }
-                            },
-                            "name": "req",
-                            "curly": false
-                          },
-                          "offset": {
-                            "kind": "identifier",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 5,
-                                "column": 19,
-                                "offset": 57
-                              },
-                              "end": {
-                                "line": 5,
-                                "column": 23,
-                                "offset": 61
-                              }
-                            },
-                            "name": "user"
-                          }
-                        },
-                        "nullsafe": true
-                      },
-                      "loc": {
-                        "start": {
-                          "line": 5,
-                          "column": 17
-                        },
-                        "end": {
-                          "line": 5,
-                          "column": 24
-                        },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                      }
-                    },
-                    "alternative": {
-                      "type": "Literal",
-                      "value": null,
-                      "literalType": "null",
-                      "_meta": {}
-                    },
-                    "_meta": {
-                      "loc": {
-                        "start": {
-                          "line": 5,
-                          "column": 17
-                        },
-                        "end": {
-                          "line": 5,
-                          "column": 24
-                        },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                      },
-                      "origin": {
-                        "kind": "nullsafepropertylookup",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 5,
-                            "column": 16,
-                            "offset": 54
-                          },
-                          "end": {
-                            "line": 5,
-                            "column": 23,
-                            "offset": 61
-                          }
-                        },
-                        "what": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 12,
-                              "offset": 50
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 16,
-                              "offset": 54
-                            }
-                          },
-                          "name": "req",
-                          "curly": false
-                        },
-                        "offset": {
-                          "kind": "identifier",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 19,
-                              "offset": 57
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 23,
-                              "offset": 61
-                            }
-                          },
-                          "name": "user"
-                        }
-                      }
-                    },
-                    "loc": {
-                      "start": {
-                        "line": 5,
-                        "column": 17
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 24
-                      },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                    }
-                  },
-                  "arguments": [],
-                  "_meta": {
-                    "loc": {
-                      "start": {
-                        "line": 5,
-                        "column": 17
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 26
-                      },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                    },
-                    "origin": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 5,
-                          "column": 16,
-                          "offset": 54
-                        },
-                        "end": {
-                          "line": 5,
-                          "column": 25,
-                          "offset": 63
-                        }
-                      },
-                      "what": {
-                        "kind": "nullsafepropertylookup",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 5,
-                            "column": 16,
-                            "offset": 54
-                          },
-                          "end": {
-                            "line": 5,
-                            "column": 23,
-                            "offset": 61
-                          }
-                        },
-                        "what": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 12,
-                              "offset": 50
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 16,
-                              "offset": 54
-                            }
-                          },
-                          "name": "req",
-                          "curly": false
-                        },
-                        "offset": {
-                          "kind": "identifier",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 19,
-                              "offset": 57
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 23,
-                              "offset": 61
-                            }
-                          },
-                          "name": "user"
-                        }
-                      },
-                      "arguments": []
-                    }
-                  },
-                  "loc": {
-                    "start": {
-                      "line": 5,
-                      "column": 17
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 26
-                    },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                  }
-                },
-                "consequent": {
-                  "type": "MemberAccess",
-                  "object": {
-                    "type": "CallExpression",
-                    "callee": {
-                      "type": "ConditionalExpression",
-                      "test": {
-                        "type": "Identifier",
-                        "name": "req",
-                        "_meta": {
-                          "loc": {
-                            "start": {
-                              "line": 5,
-                              "column": 13
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 17
-                            },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                          },
-                          "origin": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 5,
-                                "column": 12,
-                                "offset": 50
-                              },
-                              "end": {
-                                "line": 5,
-                                "column": 16,
-                                "offset": 54
-                              }
-                            },
-                            "name": "req",
-                            "curly": false
-                          }
-                        },
-                        "loc": {
-                          "start": {
-                            "line": 5,
-                            "column": 13
-                          },
-                          "end": {
-                            "line": 5,
-                            "column": 17
-                          },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                        }
-                      },
-                      "consequent": {
-                        "type": "MemberAccess",
-                        "object": {
-                          "type": "Identifier",
-                          "name": "req",
-                          "_meta": {
-                            "loc": {
-                              "start": {
-                                "line": 5,
-                                "column": 13
-                              },
-                              "end": {
-                                "line": 5,
-                                "column": 17
-                              },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                            },
-                            "origin": {
-                              "kind": "variable",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 5,
-                                  "column": 12,
-                                  "offset": 50
-                                },
-                                "end": {
-                                  "line": 5,
-                                  "column": 16,
-                                  "offset": 54
-                                }
-                              },
-                              "name": "req",
-                              "curly": false
-                            }
-                          },
-                          "loc": {
-                            "start": {
-                              "line": 5,
-                              "column": 13
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 17
-                            },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                          }
-                        },
-                        "property": {
-                          "type": "Identifier",
-                          "name": "user",
-                          "_meta": {
-                            "loc": {
-                              "start": {
-                                "line": 5,
-                                "column": 20
-                              },
-                              "end": {
-                                "line": 5,
-                                "column": 24
-                              },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                            },
-                            "origin": {
-                              "kind": "identifier",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 5,
-                                  "column": 19,
-                                  "offset": 57
-                                },
-                                "end": {
-                                  "line": 5,
-                                  "column": 23,
-                                  "offset": 61
-                                }
-                              },
-                              "name": "user"
-                            }
-                          },
-                          "loc": {
-                            "start": {
-                              "line": 5,
-                              "column": 20
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 24
-                            },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                          }
-                        },
-                        "computed": false,
-                        "_meta": {
-                          "loc": {
-                            "start": {
-                              "line": 5,
-                              "column": 17
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 24
-                            },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                          },
-                          "origin": {
-                            "kind": "nullsafepropertylookup",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 5,
-                                "column": 16,
-                                "offset": 54
-                              },
-                              "end": {
-                                "line": 5,
-                                "column": 23,
-                                "offset": 61
-                              }
-                            },
-                            "what": {
-                              "kind": "variable",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 5,
-                                  "column": 12,
-                                  "offset": 50
-                                },
-                                "end": {
-                                  "line": 5,
-                                  "column": 16,
-                                  "offset": 54
-                                }
-                              },
-                              "name": "req",
-                              "curly": false
-                            },
-                            "offset": {
-                              "kind": "identifier",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 5,
-                                  "column": 19,
-                                  "offset": 57
-                                },
-                                "end": {
-                                  "line": 5,
-                                  "column": 23,
-                                  "offset": 61
-                                }
-                              },
-                              "name": "user"
-                            }
-                          },
-                          "nullsafe": true
-                        },
-                        "loc": {
-                          "start": {
-                            "line": 5,
-                            "column": 17
-                          },
-                          "end": {
-                            "line": 5,
-                            "column": 24
-                          },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                        }
-                      },
-                      "alternative": {
-                        "type": "Literal",
-                        "value": null,
-                        "literalType": "null",
-                        "_meta": {}
-                      },
-                      "_meta": {
-                        "loc": {
-                          "start": {
-                            "line": 5,
-                            "column": 17
-                          },
-                          "end": {
-                            "line": 5,
-                            "column": 24
-                          },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                        },
-                        "origin": {
-                          "kind": "nullsafepropertylookup",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 16,
-                              "offset": 54
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 23,
-                              "offset": 61
-                            }
-                          },
-                          "what": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 5,
-                                "column": 12,
-                                "offset": 50
-                              },
-                              "end": {
-                                "line": 5,
-                                "column": 16,
-                                "offset": 54
-                              }
-                            },
-                            "name": "req",
-                            "curly": false
-                          },
-                          "offset": {
-                            "kind": "identifier",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 5,
-                                "column": 19,
-                                "offset": 57
-                              },
-                              "end": {
-                                "line": 5,
-                                "column": 23,
-                                "offset": 61
-                              }
-                            },
-                            "name": "user"
-                          }
-                        }
-                      },
-                      "loc": {
-                        "start": {
-                          "line": 5,
-                          "column": 17
-                        },
-                        "end": {
-                          "line": 5,
-                          "column": 24
-                        },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                      }
-                    },
-                    "arguments": [],
-                    "_meta": {
-                      "loc": {
-                        "start": {
-                          "line": 5,
-                          "column": 17
-                        },
-                        "end": {
-                          "line": 5,
                           "column": 26
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                      },
-                      "origin": {
-                        "kind": "call",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 5,
-                            "column": 16,
-                            "offset": 54
-                          },
-                          "end": {
-                            "line": 5,
-                            "column": 25,
-                            "offset": 63
-                          }
-                        },
-                        "what": {
-                          "kind": "nullsafepropertylookup",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 16,
-                              "offset": 54
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 23,
-                              "offset": 61
-                            }
-                          },
-                          "what": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 5,
-                                "column": 12,
-                                "offset": 50
-                              },
-                              "end": {
-                                "line": 5,
-                                "column": 16,
-                                "offset": 54
-                              }
-                            },
-                            "name": "req",
-                            "curly": false
-                          },
-                          "offset": {
-                            "kind": "identifier",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 5,
-                                "column": 19,
-                                "offset": 57
-                              },
-                              "end": {
-                                "line": 5,
-                                "column": 23,
-                                "offset": 61
-                              }
-                            },
-                            "name": "user"
-                          }
-                        },
-                        "arguments": []
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                       }
                     },
                     "loc": {
                       "start": {
                         "line": 5,
-                        "column": 17
+                        "column": 13
                       },
                       "end": {
                         "line": 5,
                         "column": 26
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                     }
                   },
                   "property": {
@@ -1165,24 +270,7 @@
                           "line": 5,
                           "column": 33
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                      },
-                      "origin": {
-                        "kind": "identifier",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 5,
-                            "column": 28,
-                            "offset": 66
-                          },
-                          "end": {
-                            "line": 5,
-                            "column": 32,
-                            "offset": 70
-                          }
-                        },
-                        "name": "name"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                       }
                     },
                     "loc": {
@@ -1194,7 +282,7 @@
                         "line": 5,
                         "column": 33
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                     }
                   },
                   "computed": false,
@@ -1202,127 +290,26 @@
                     "loc": {
                       "start": {
                         "line": 5,
-                        "column": 26
+                        "column": 13
                       },
                       "end": {
                         "line": 5,
                         "column": 33
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                    },
-                    "origin": {
-                      "kind": "nullsafepropertylookup",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 5,
-                          "column": 25,
-                          "offset": 63
-                        },
-                        "end": {
-                          "line": 5,
-                          "column": 32,
-                          "offset": 70
-                        }
-                      },
-                      "what": {
-                        "kind": "call",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 5,
-                            "column": 16,
-                            "offset": 54
-                          },
-                          "end": {
-                            "line": 5,
-                            "column": 25,
-                            "offset": 63
-                          }
-                        },
-                        "what": {
-                          "kind": "nullsafepropertylookup",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 16,
-                              "offset": 54
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 23,
-                              "offset": 61
-                            }
-                          },
-                          "what": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 5,
-                                "column": 12,
-                                "offset": 50
-                              },
-                              "end": {
-                                "line": 5,
-                                "column": 16,
-                                "offset": 54
-                              }
-                            },
-                            "name": "req",
-                            "curly": false
-                          },
-                          "offset": {
-                            "kind": "identifier",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 5,
-                                "column": 19,
-                                "offset": 57
-                              },
-                              "end": {
-                                "line": 5,
-                                "column": 23,
-                                "offset": 61
-                              }
-                            },
-                            "name": "user"
-                          }
-                        },
-                        "arguments": []
-                      },
-                      "offset": {
-                        "kind": "identifier",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 5,
-                            "column": 28,
-                            "offset": 66
-                          },
-                          "end": {
-                            "line": 5,
-                            "column": 32,
-                            "offset": 70
-                          }
-                        },
-                        "name": "name"
-                      }
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                     },
                     "nullsafe": true
                   },
                   "loc": {
                     "start": {
                       "line": 5,
-                      "column": 26
+                      "column": 13
                     },
                     "end": {
                       "line": 5,
                       "column": 33
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "alternative": {
@@ -1335,126 +322,25 @@
                   "loc": {
                     "start": {
                       "line": 5,
-                      "column": 26
+                      "column": 13
                     },
                     "end": {
                       "line": 5,
                       "column": 33
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                  },
-                  "origin": {
-                    "kind": "nullsafepropertylookup",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 25,
-                        "offset": 63
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 32,
-                        "offset": 70
-                      }
-                    },
-                    "what": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 5,
-                          "column": 16,
-                          "offset": 54
-                        },
-                        "end": {
-                          "line": 5,
-                          "column": 25,
-                          "offset": 63
-                        }
-                      },
-                      "what": {
-                        "kind": "nullsafepropertylookup",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 5,
-                            "column": 16,
-                            "offset": 54
-                          },
-                          "end": {
-                            "line": 5,
-                            "column": 23,
-                            "offset": 61
-                          }
-                        },
-                        "what": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 12,
-                              "offset": 50
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 16,
-                              "offset": 54
-                            }
-                          },
-                          "name": "req",
-                          "curly": false
-                        },
-                        "offset": {
-                          "kind": "identifier",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 19,
-                              "offset": 57
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 23,
-                              "offset": 61
-                            }
-                          },
-                          "name": "user"
-                        }
-                      },
-                      "arguments": []
-                    },
-                    "offset": {
-                      "kind": "identifier",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 5,
-                          "column": 28,
-                          "offset": 66
-                        },
-                        "end": {
-                          "line": 5,
-                          "column": 32,
-                          "offset": 70
-                        }
-                      },
-                      "name": "name"
-                    }
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "loc": {
                   "start": {
                     "line": 5,
-                    "column": 26
+                    "column": 13
                   },
                   "end": {
                     "line": 5,
                     "column": 33
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "operator": "=",
@@ -1467,145 +353,9 @@
                   },
                   "end": {
                     "line": 5,
-                    "column": 34
+                    "column": 33
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                },
-                "origin": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 4,
-                      "offset": 42
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 33,
-                      "offset": 71
-                    }
-                  },
-                  "left": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 4,
-                        "offset": 42
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 9,
-                        "offset": 47
-                      }
-                    },
-                    "name": "name",
-                    "curly": false
-                  },
-                  "right": {
-                    "kind": "nullsafepropertylookup",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 25,
-                        "offset": 63
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 32,
-                        "offset": 70
-                      }
-                    },
-                    "what": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 5,
-                          "column": 16,
-                          "offset": 54
-                        },
-                        "end": {
-                          "line": 5,
-                          "column": 25,
-                          "offset": 63
-                        }
-                      },
-                      "what": {
-                        "kind": "nullsafepropertylookup",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 5,
-                            "column": 16,
-                            "offset": 54
-                          },
-                          "end": {
-                            "line": 5,
-                            "column": 23,
-                            "offset": 61
-                          }
-                        },
-                        "what": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 12,
-                              "offset": 50
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 16,
-                              "offset": 54
-                            }
-                          },
-                          "name": "req",
-                          "curly": false
-                        },
-                        "offset": {
-                          "kind": "identifier",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 19,
-                              "offset": 57
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 23,
-                              "offset": 61
-                            }
-                          },
-                          "name": "user"
-                        }
-                      },
-                      "arguments": []
-                    },
-                    "offset": {
-                      "kind": "identifier",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 5,
-                          "column": 28,
-                          "offset": 66
-                        },
-                        "end": {
-                          "line": 5,
-                          "column": 32,
-                          "offset": 70
-                        }
-                      },
-                      "name": "name"
-                    }
-                  },
-                  "operator": "="
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "loc": {
@@ -1615,9 +365,9 @@
                 },
                 "end": {
                   "line": 5,
-                  "column": 34
+                  "column": 33
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "_meta": {
@@ -1630,159 +380,7 @@
                   "line": 5,
                   "column": 34
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-              },
-              "origin": {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 4,
-                    "offset": 42
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 33,
-                    "offset": 71
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 4,
-                      "offset": 42
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 33,
-                      "offset": 71
-                    }
-                  },
-                  "left": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 4,
-                        "offset": 42
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 9,
-                        "offset": 47
-                      }
-                    },
-                    "name": "name",
-                    "curly": false
-                  },
-                  "right": {
-                    "kind": "nullsafepropertylookup",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 25,
-                        "offset": 63
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 32,
-                        "offset": 70
-                      }
-                    },
-                    "what": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 5,
-                          "column": 16,
-                          "offset": 54
-                        },
-                        "end": {
-                          "line": 5,
-                          "column": 25,
-                          "offset": 63
-                        }
-                      },
-                      "what": {
-                        "kind": "nullsafepropertylookup",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 5,
-                            "column": 16,
-                            "offset": 54
-                          },
-                          "end": {
-                            "line": 5,
-                            "column": 23,
-                            "offset": 61
-                          }
-                        },
-                        "what": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 12,
-                              "offset": 50
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 16,
-                              "offset": 54
-                            }
-                          },
-                          "name": "req",
-                          "curly": false
-                        },
-                        "offset": {
-                          "kind": "identifier",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 19,
-                              "offset": 57
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 23,
-                              "offset": 61
-                            }
-                          },
-                          "name": "user"
-                        }
-                      },
-                      "arguments": []
-                    },
-                    "offset": {
-                      "kind": "identifier",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 5,
-                          "column": 28,
-                          "offset": 66
-                        },
-                        "end": {
-                          "line": 5,
-                          "column": 32,
-                          "offset": 70
-                        }
-                      },
-                      "name": "name"
-                    }
-                  },
-                  "operator": "="
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "loc": {
@@ -1794,7 +392,7 @@
                 "line": 5,
                 "column": 34
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           {
@@ -1814,25 +412,7 @@
                       "line": 6,
                       "column": 11
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                  },
-                  "origin": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 4,
-                        "offset": 76
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 10,
-                        "offset": 82
-                      }
-                    },
-                    "name": "value",
-                    "curly": false
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "loc": {
@@ -1844,7 +424,7 @@
                     "line": 6,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "right": {
@@ -1863,25 +443,7 @@
                         "line": 6,
                         "column": 20
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                    },
-                    "origin": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 6,
-                          "column": 13,
-                          "offset": 85
-                        },
-                        "end": {
-                          "line": 6,
-                          "column": 19,
-                          "offset": 91
-                        }
-                      },
-                      "name": "items",
-                      "curly": false
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                     }
                   },
                   "loc": {
@@ -1893,7 +455,7 @@
                       "line": 6,
                       "column": 20
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "right": {
@@ -1911,25 +473,7 @@
                         "line": 6,
                         "column": 26
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                    },
-                    "origin": {
-                      "kind": "array",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 6,
-                          "column": 23,
-                          "offset": 95
-                        },
-                        "end": {
-                          "line": 6,
-                          "column": 25,
-                          "offset": 97
-                        }
-                      },
-                      "items": [],
-                      "shortForm": true
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                     }
                   },
                   "loc": {
@@ -1941,7 +485,7 @@
                       "line": 6,
                       "column": 26
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "_meta": {
@@ -1954,60 +498,7 @@
                       "line": 6,
                       "column": 26
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                  },
-                  "origin": {
-                    "kind": "bin",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 13,
-                        "offset": 85
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 25,
-                        "offset": 97
-                      }
-                    },
-                    "type": "??",
-                    "left": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 6,
-                          "column": 13,
-                          "offset": 85
-                        },
-                        "end": {
-                          "line": 6,
-                          "column": 19,
-                          "offset": 91
-                        }
-                      },
-                      "name": "items",
-                      "curly": false
-                    },
-                    "right": {
-                      "kind": "array",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 6,
-                          "column": 23,
-                          "offset": 95
-                        },
-                        "end": {
-                          "line": 6,
-                          "column": 25,
-                          "offset": 97
-                        }
-                      },
-                      "items": [],
-                      "shortForm": true
-                    }
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "loc": {
@@ -2019,7 +510,7 @@
                     "line": 6,
                     "column": 26
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "operator": "=",
@@ -2032,97 +523,9 @@
                   },
                   "end": {
                     "line": 6,
-                    "column": 27
+                    "column": 26
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                },
-                "origin": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 4,
-                      "offset": 76
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 26,
-                      "offset": 98
-                    }
-                  },
-                  "left": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 4,
-                        "offset": 76
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 10,
-                        "offset": 82
-                      }
-                    },
-                    "name": "value",
-                    "curly": false
-                  },
-                  "right": {
-                    "kind": "bin",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 13,
-                        "offset": 85
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 25,
-                        "offset": 97
-                      }
-                    },
-                    "type": "??",
-                    "left": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 6,
-                          "column": 13,
-                          "offset": 85
-                        },
-                        "end": {
-                          "line": 6,
-                          "column": 19,
-                          "offset": 91
-                        }
-                      },
-                      "name": "items",
-                      "curly": false
-                    },
-                    "right": {
-                      "kind": "array",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 6,
-                          "column": 23,
-                          "offset": 95
-                        },
-                        "end": {
-                          "line": 6,
-                          "column": 25,
-                          "offset": 97
-                        }
-                      },
-                      "items": [],
-                      "shortForm": true
-                    }
-                  },
-                  "operator": "="
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "loc": {
@@ -2132,9 +535,9 @@
                 },
                 "end": {
                   "line": 6,
-                  "column": 27
+                  "column": 26
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "_meta": {
@@ -2147,111 +550,7 @@
                   "line": 6,
                   "column": 27
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-              },
-              "origin": {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 4,
-                    "offset": 76
-                  },
-                  "end": {
-                    "line": 6,
-                    "column": 26,
-                    "offset": 98
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 4,
-                      "offset": 76
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 26,
-                      "offset": 98
-                    }
-                  },
-                  "left": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 4,
-                        "offset": 76
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 10,
-                        "offset": 82
-                      }
-                    },
-                    "name": "value",
-                    "curly": false
-                  },
-                  "right": {
-                    "kind": "bin",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 13,
-                        "offset": 85
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 25,
-                        "offset": 97
-                      }
-                    },
-                    "type": "??",
-                    "left": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 6,
-                          "column": 13,
-                          "offset": 85
-                        },
-                        "end": {
-                          "line": 6,
-                          "column": 19,
-                          "offset": 91
-                        }
-                      },
-                      "name": "items",
-                      "curly": false
-                    },
-                    "right": {
-                      "kind": "array",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 6,
-                          "column": 23,
-                          "offset": 95
-                        },
-                        "end": {
-                          "line": 6,
-                          "column": 25,
-                          "offset": 97
-                        }
-                      },
-                      "items": [],
-                      "shortForm": true
-                    }
-                  },
-                  "operator": "="
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "loc": {
@@ -2263,7 +562,7 @@
                 "line": 6,
                 "column": 27
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           {
@@ -2271,8 +570,7 @@
             "expression": {
               "type": "YieldExpression",
               "argument": {
-                "type": "Identifier",
-                "name": "value",
+                "type": "Noop",
                 "_meta": {
                   "loc": {
                     "start": {
@@ -2283,25 +581,7 @@
                       "line": 8,
                       "column": 17
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                  },
-                  "origin": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 8,
-                        "column": 10,
-                        "offset": 110
-                      },
-                      "end": {
-                        "line": 8,
-                        "column": 16,
-                        "offset": 116
-                      }
-                    },
-                    "name": "value",
-                    "curly": false
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "loc": {
@@ -2313,11 +593,10 @@
                     "line": 8,
                     "column": 17
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "_meta": {
-                "key": null,
                 "loc": {
                   "start": {
                     "line": 8,
@@ -2325,44 +604,9 @@
                   },
                   "end": {
                     "line": 8,
-                    "column": 18
+                    "column": 17
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                },
-                "origin": {
-                  "kind": "yield",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 4,
-                      "offset": 104
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 17,
-                      "offset": 117
-                    }
-                  },
-                  "value": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 8,
-                        "column": 10,
-                        "offset": 110
-                      },
-                      "end": {
-                        "line": 8,
-                        "column": 16,
-                        "offset": 116
-                      }
-                    },
-                    "name": "value",
-                    "curly": false
-                  },
-                  "key": null
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "loc": {
@@ -2372,9 +616,9 @@
                 },
                 "end": {
                   "line": 8,
-                  "column": 18
+                  "column": 17
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "_meta": {
@@ -2387,58 +631,7 @@
                   "line": 8,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-              },
-              "origin": {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 8,
-                    "column": 4,
-                    "offset": 104
-                  },
-                  "end": {
-                    "line": 8,
-                    "column": 17,
-                    "offset": 117
-                  }
-                },
-                "expression": {
-                  "kind": "yield",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 4,
-                      "offset": 104
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 17,
-                      "offset": 117
-                    }
-                  },
-                  "value": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 8,
-                        "column": 10,
-                        "offset": 110
-                      },
-                      "end": {
-                        "line": 8,
-                        "column": 16,
-                        "offset": 116
-                      }
-                    },
-                    "name": "value",
-                    "curly": false
-                  },
-                  "key": null
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "loc": {
@@ -2450,7 +643,7 @@
                 "line": 8,
                 "column": 18
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           {
@@ -2472,25 +665,7 @@
                         "line": 9,
                         "column": 22
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                    },
-                    "origin": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 15,
-                          "offset": 133
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 21,
-                          "offset": 139
-                        }
-                      },
-                      "name": "source",
-                      "resolution": "uqn"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                     }
                   },
                   "loc": {
@@ -2502,7 +677,7 @@
                       "line": 9,
                       "column": 22
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "arguments": [],
@@ -2516,42 +691,7 @@
                       "line": 9,
                       "column": 24
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                  },
-                  "origin": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 15,
-                        "offset": 133
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 23,
-                        "offset": 141
-                      }
-                    },
-                    "what": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 15,
-                          "offset": 133
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 21,
-                          "offset": 139
-                        }
-                      },
-                      "name": "source",
-                      "resolution": "uqn"
-                    },
-                    "arguments": []
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "loc": {
@@ -2563,11 +703,10 @@
                     "line": 9,
                     "column": 24
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "_meta": {
-                "isYieldFrom": true,
                 "loc": {
                   "start": {
                     "line": 9,
@@ -2575,60 +714,9 @@
                   },
                   "end": {
                     "line": 9,
-                    "column": 25
+                    "column": 24
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                },
-                "origin": {
-                  "kind": "yieldfrom",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 9,
-                      "column": 4,
-                      "offset": 122
-                    },
-                    "end": {
-                      "line": 9,
-                      "column": 24,
-                      "offset": 142
-                    }
-                  },
-                  "value": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 15,
-                        "offset": 133
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 23,
-                        "offset": 141
-                      }
-                    },
-                    "what": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 15,
-                          "offset": 133
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 21,
-                          "offset": 139
-                        }
-                      },
-                      "name": "source",
-                      "resolution": "uqn"
-                    },
-                    "arguments": []
-                  }
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "loc": {
@@ -2638,9 +726,9 @@
                 },
                 "end": {
                   "line": 9,
-                  "column": 25
+                  "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "_meta": {
@@ -2653,74 +741,7 @@
                   "line": 9,
                   "column": 25
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-              },
-              "origin": {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 9,
-                    "column": 4,
-                    "offset": 122
-                  },
-                  "end": {
-                    "line": 9,
-                    "column": 24,
-                    "offset": 142
-                  }
-                },
-                "expression": {
-                  "kind": "yieldfrom",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 9,
-                      "column": 4,
-                      "offset": 122
-                    },
-                    "end": {
-                      "line": 9,
-                      "column": 24,
-                      "offset": 142
-                    }
-                  },
-                  "value": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 15,
-                        "offset": 133
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 23,
-                        "offset": 141
-                      }
-                    },
-                    "what": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 15,
-                          "offset": 133
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 21,
-                          "offset": 139
-                        }
-                      },
-                      "name": "source",
-                      "resolution": "uqn"
-                    },
-                    "arguments": []
-                  }
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "loc": {
@@ -2732,7 +753,7 @@
                 "line": 9,
                 "column": 25
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           {
@@ -2750,25 +771,7 @@
                     "line": 11,
                     "column": 17
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-                },
-                "origin": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 11,
-                      "column": 11,
-                      "offset": 155
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 16,
-                      "offset": 160
-                    }
-                  },
-                  "name": "name",
-                  "curly": false
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "loc": {
@@ -2780,7 +783,7 @@
                   "line": 11,
                   "column": 17
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "isYield": false,
@@ -2794,41 +797,7 @@
                   "line": 11,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-              },
-              "origin": {
-                "kind": "return",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 11,
-                    "column": 4,
-                    "offset": 148
-                  },
-                  "end": {
-                    "line": 11,
-                    "column": 17,
-                    "offset": 161
-                  }
-                },
-                "expr": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 11,
-                      "column": 11,
-                      "offset": 155
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 16,
-                      "offset": 160
-                    }
-                  },
-                  "name": "name",
-                  "curly": false
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "loc": {
@@ -2840,7 +809,7 @@
                 "line": 11,
                 "column": 18
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           }
         ],
@@ -2855,433 +824,7 @@
               "line": 12,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-          },
-          "origin": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 4,
-                "column": 0,
-                "offset": 36
-              },
-              "end": {
-                "line": 12,
-                "column": 1,
-                "offset": 163
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 4,
-                    "offset": 42
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 33,
-                    "offset": 71
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 4,
-                      "offset": 42
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 33,
-                      "offset": 71
-                    }
-                  },
-                  "left": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 4,
-                        "offset": 42
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 9,
-                        "offset": 47
-                      }
-                    },
-                    "name": "name",
-                    "curly": false
-                  },
-                  "right": {
-                    "kind": "nullsafepropertylookup",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 25,
-                        "offset": 63
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 32,
-                        "offset": 70
-                      }
-                    },
-                    "what": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 5,
-                          "column": 16,
-                          "offset": 54
-                        },
-                        "end": {
-                          "line": 5,
-                          "column": 25,
-                          "offset": 63
-                        }
-                      },
-                      "what": {
-                        "kind": "nullsafepropertylookup",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 5,
-                            "column": 16,
-                            "offset": 54
-                          },
-                          "end": {
-                            "line": 5,
-                            "column": 23,
-                            "offset": 61
-                          }
-                        },
-                        "what": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 12,
-                              "offset": 50
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 16,
-                              "offset": 54
-                            }
-                          },
-                          "name": "req",
-                          "curly": false
-                        },
-                        "offset": {
-                          "kind": "identifier",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 19,
-                              "offset": 57
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 23,
-                              "offset": 61
-                            }
-                          },
-                          "name": "user"
-                        }
-                      },
-                      "arguments": []
-                    },
-                    "offset": {
-                      "kind": "identifier",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 5,
-                          "column": 28,
-                          "offset": 66
-                        },
-                        "end": {
-                          "line": 5,
-                          "column": 32,
-                          "offset": 70
-                        }
-                      },
-                      "name": "name"
-                    }
-                  },
-                  "operator": "="
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 4,
-                    "offset": 76
-                  },
-                  "end": {
-                    "line": 6,
-                    "column": 26,
-                    "offset": 98
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 4,
-                      "offset": 76
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 26,
-                      "offset": 98
-                    }
-                  },
-                  "left": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 4,
-                        "offset": 76
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 10,
-                        "offset": 82
-                      }
-                    },
-                    "name": "value",
-                    "curly": false
-                  },
-                  "right": {
-                    "kind": "bin",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 13,
-                        "offset": 85
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 25,
-                        "offset": 97
-                      }
-                    },
-                    "type": "??",
-                    "left": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 6,
-                          "column": 13,
-                          "offset": 85
-                        },
-                        "end": {
-                          "line": 6,
-                          "column": 19,
-                          "offset": 91
-                        }
-                      },
-                      "name": "items",
-                      "curly": false
-                    },
-                    "right": {
-                      "kind": "array",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 6,
-                          "column": 23,
-                          "offset": 95
-                        },
-                        "end": {
-                          "line": 6,
-                          "column": 25,
-                          "offset": 97
-                        }
-                      },
-                      "items": [],
-                      "shortForm": true
-                    }
-                  },
-                  "operator": "="
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 8,
-                    "column": 4,
-                    "offset": 104
-                  },
-                  "end": {
-                    "line": 8,
-                    "column": 17,
-                    "offset": 117
-                  }
-                },
-                "expression": {
-                  "kind": "yield",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 4,
-                      "offset": 104
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 17,
-                      "offset": 117
-                    }
-                  },
-                  "value": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 8,
-                        "column": 10,
-                        "offset": 110
-                      },
-                      "end": {
-                        "line": 8,
-                        "column": 16,
-                        "offset": 116
-                      }
-                    },
-                    "name": "value",
-                    "curly": false
-                  },
-                  "key": null
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 9,
-                    "column": 4,
-                    "offset": 122
-                  },
-                  "end": {
-                    "line": 9,
-                    "column": 24,
-                    "offset": 142
-                  }
-                },
-                "expression": {
-                  "kind": "yieldfrom",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 9,
-                      "column": 4,
-                      "offset": 122
-                    },
-                    "end": {
-                      "line": 9,
-                      "column": 24,
-                      "offset": 142
-                    }
-                  },
-                  "value": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 15,
-                        "offset": 133
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 23,
-                        "offset": 141
-                      }
-                    },
-                    "what": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 15,
-                          "offset": 133
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 21,
-                          "offset": 139
-                        }
-                      },
-                      "name": "source",
-                      "resolution": "uqn"
-                    },
-                    "arguments": []
-                  }
-                }
-              },
-              {
-                "kind": "return",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 11,
-                    "column": 4,
-                    "offset": 148
-                  },
-                  "end": {
-                    "line": 11,
-                    "column": 17,
-                    "offset": 161
-                  }
-                },
-                "expr": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 11,
-                      "column": 11,
-                      "offset": 155
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 16,
-                      "offset": 160
-                    }
-                  },
-                  "name": "name",
-                  "curly": false
-                }
-              }
-            ]
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
           }
         },
         "loc": {
@@ -3293,12 +836,11 @@
             "line": 12,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
         }
       },
       "modifiers": [],
       "_meta": {
-        "attributes": [],
         "loc": {
           "start": {
             "line": 3,
@@ -3308,554 +850,7 @@
             "line": 12,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-        },
-        "origin": {
-          "kind": "function",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 7
-            },
-            "end": {
-              "line": 12,
-              "column": 1,
-              "offset": 163
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 9,
-                "offset": 16
-              },
-              "end": {
-                "line": 3,
-                "column": 14,
-                "offset": 21
-              }
-            },
-            "name": "fetch"
-          },
-          "arguments": [
-            {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 15,
-                  "offset": 22
-                },
-                "end": {
-                  "line": 3,
-                  "column": 19,
-                  "offset": 26
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 15,
-                    "offset": 22
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 19,
-                    "offset": 26
-                  }
-                },
-                "name": "req"
-              },
-              "value": null,
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
-            },
-            {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 21,
-                  "offset": 28
-                },
-                "end": {
-                  "line": 3,
-                  "column": 27,
-                  "offset": 34
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 21,
-                    "offset": 28
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 27,
-                    "offset": 34
-                  }
-                },
-                "name": "items"
-              },
-              "value": null,
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
-            }
-          ],
-          "byref": false,
-          "type": null,
-          "nullable": false,
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 4,
-                "column": 0,
-                "offset": 36
-              },
-              "end": {
-                "line": 12,
-                "column": 1,
-                "offset": 163
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 4,
-                    "offset": 42
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 33,
-                    "offset": 71
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 4,
-                      "offset": 42
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 33,
-                      "offset": 71
-                    }
-                  },
-                  "left": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 4,
-                        "offset": 42
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 9,
-                        "offset": 47
-                      }
-                    },
-                    "name": "name",
-                    "curly": false
-                  },
-                  "right": {
-                    "kind": "nullsafepropertylookup",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 25,
-                        "offset": 63
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 32,
-                        "offset": 70
-                      }
-                    },
-                    "what": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 5,
-                          "column": 16,
-                          "offset": 54
-                        },
-                        "end": {
-                          "line": 5,
-                          "column": 25,
-                          "offset": 63
-                        }
-                      },
-                      "what": {
-                        "kind": "nullsafepropertylookup",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 5,
-                            "column": 16,
-                            "offset": 54
-                          },
-                          "end": {
-                            "line": 5,
-                            "column": 23,
-                            "offset": 61
-                          }
-                        },
-                        "what": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 12,
-                              "offset": 50
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 16,
-                              "offset": 54
-                            }
-                          },
-                          "name": "req",
-                          "curly": false
-                        },
-                        "offset": {
-                          "kind": "identifier",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 19,
-                              "offset": 57
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 23,
-                              "offset": 61
-                            }
-                          },
-                          "name": "user"
-                        }
-                      },
-                      "arguments": []
-                    },
-                    "offset": {
-                      "kind": "identifier",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 5,
-                          "column": 28,
-                          "offset": 66
-                        },
-                        "end": {
-                          "line": 5,
-                          "column": 32,
-                          "offset": 70
-                        }
-                      },
-                      "name": "name"
-                    }
-                  },
-                  "operator": "="
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 4,
-                    "offset": 76
-                  },
-                  "end": {
-                    "line": 6,
-                    "column": 26,
-                    "offset": 98
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 4,
-                      "offset": 76
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 26,
-                      "offset": 98
-                    }
-                  },
-                  "left": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 4,
-                        "offset": 76
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 10,
-                        "offset": 82
-                      }
-                    },
-                    "name": "value",
-                    "curly": false
-                  },
-                  "right": {
-                    "kind": "bin",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 13,
-                        "offset": 85
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 25,
-                        "offset": 97
-                      }
-                    },
-                    "type": "??",
-                    "left": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 6,
-                          "column": 13,
-                          "offset": 85
-                        },
-                        "end": {
-                          "line": 6,
-                          "column": 19,
-                          "offset": 91
-                        }
-                      },
-                      "name": "items",
-                      "curly": false
-                    },
-                    "right": {
-                      "kind": "array",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 6,
-                          "column": 23,
-                          "offset": 95
-                        },
-                        "end": {
-                          "line": 6,
-                          "column": 25,
-                          "offset": 97
-                        }
-                      },
-                      "items": [],
-                      "shortForm": true
-                    }
-                  },
-                  "operator": "="
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 8,
-                    "column": 4,
-                    "offset": 104
-                  },
-                  "end": {
-                    "line": 8,
-                    "column": 17,
-                    "offset": 117
-                  }
-                },
-                "expression": {
-                  "kind": "yield",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 4,
-                      "offset": 104
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 17,
-                      "offset": 117
-                    }
-                  },
-                  "value": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 8,
-                        "column": 10,
-                        "offset": 110
-                      },
-                      "end": {
-                        "line": 8,
-                        "column": 16,
-                        "offset": 116
-                      }
-                    },
-                    "name": "value",
-                    "curly": false
-                  },
-                  "key": null
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 9,
-                    "column": 4,
-                    "offset": 122
-                  },
-                  "end": {
-                    "line": 9,
-                    "column": 24,
-                    "offset": 142
-                  }
-                },
-                "expression": {
-                  "kind": "yieldfrom",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 9,
-                      "column": 4,
-                      "offset": 122
-                    },
-                    "end": {
-                      "line": 9,
-                      "column": 24,
-                      "offset": 142
-                    }
-                  },
-                  "value": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 15,
-                        "offset": 133
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 23,
-                        "offset": 141
-                      }
-                    },
-                    "what": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 15,
-                          "offset": 133
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 21,
-                          "offset": 139
-                        }
-                      },
-                      "name": "source",
-                      "resolution": "uqn"
-                    },
-                    "arguments": []
-                  }
-                }
-              },
-              {
-                "kind": "return",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 11,
-                    "column": 4,
-                    "offset": 148
-                  },
-                  "end": {
-                    "line": 11,
-                    "column": 17,
-                    "offset": 161
-                  }
-                },
-                "expr": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 11,
-                      "column": 11,
-                      "offset": 155
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 16,
-                      "offset": 160
-                    }
-                  },
-                  "name": "name",
-                  "curly": false
-                }
-              }
-            ]
-          },
-          "attrGroups": []
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
         }
       },
       "loc": {
@@ -3867,13 +862,13 @@
           "line": 12,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -3885,574 +880,7 @@
         "line": 13,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
-    },
-    "origin": {
-      "kind": "program",
-      "loc": {
-        "source": null,
-        "start": {
-          "line": 1,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "line": 13,
-          "column": 0,
-          "offset": 164
-        }
-      },
-      "children": [
-        {
-          "kind": "function",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 7
-            },
-            "end": {
-              "line": 12,
-              "column": 1,
-              "offset": 163
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 9,
-                "offset": 16
-              },
-              "end": {
-                "line": 3,
-                "column": 14,
-                "offset": 21
-              }
-            },
-            "name": "fetch"
-          },
-          "arguments": [
-            {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 15,
-                  "offset": 22
-                },
-                "end": {
-                  "line": 3,
-                  "column": 19,
-                  "offset": 26
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 15,
-                    "offset": 22
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 19,
-                    "offset": 26
-                  }
-                },
-                "name": "req"
-              },
-              "value": null,
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
-            },
-            {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 21,
-                  "offset": 28
-                },
-                "end": {
-                  "line": 3,
-                  "column": 27,
-                  "offset": 34
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 21,
-                    "offset": 28
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 27,
-                    "offset": 34
-                  }
-                },
-                "name": "items"
-              },
-              "value": null,
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
-            }
-          ],
-          "byref": false,
-          "type": null,
-          "nullable": false,
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 4,
-                "column": 0,
-                "offset": 36
-              },
-              "end": {
-                "line": 12,
-                "column": 1,
-                "offset": 163
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 4,
-                    "offset": 42
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 33,
-                    "offset": 71
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 4,
-                      "offset": 42
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 33,
-                      "offset": 71
-                    }
-                  },
-                  "left": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 4,
-                        "offset": 42
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 9,
-                        "offset": 47
-                      }
-                    },
-                    "name": "name",
-                    "curly": false
-                  },
-                  "right": {
-                    "kind": "nullsafepropertylookup",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 25,
-                        "offset": 63
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 32,
-                        "offset": 70
-                      }
-                    },
-                    "what": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 5,
-                          "column": 16,
-                          "offset": 54
-                        },
-                        "end": {
-                          "line": 5,
-                          "column": 25,
-                          "offset": 63
-                        }
-                      },
-                      "what": {
-                        "kind": "nullsafepropertylookup",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 5,
-                            "column": 16,
-                            "offset": 54
-                          },
-                          "end": {
-                            "line": 5,
-                            "column": 23,
-                            "offset": 61
-                          }
-                        },
-                        "what": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 12,
-                              "offset": 50
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 16,
-                              "offset": 54
-                            }
-                          },
-                          "name": "req",
-                          "curly": false
-                        },
-                        "offset": {
-                          "kind": "identifier",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 5,
-                              "column": 19,
-                              "offset": 57
-                            },
-                            "end": {
-                              "line": 5,
-                              "column": 23,
-                              "offset": 61
-                            }
-                          },
-                          "name": "user"
-                        }
-                      },
-                      "arguments": []
-                    },
-                    "offset": {
-                      "kind": "identifier",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 5,
-                          "column": 28,
-                          "offset": 66
-                        },
-                        "end": {
-                          "line": 5,
-                          "column": 32,
-                          "offset": 70
-                        }
-                      },
-                      "name": "name"
-                    }
-                  },
-                  "operator": "="
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 4,
-                    "offset": 76
-                  },
-                  "end": {
-                    "line": 6,
-                    "column": 26,
-                    "offset": 98
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 4,
-                      "offset": 76
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 26,
-                      "offset": 98
-                    }
-                  },
-                  "left": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 4,
-                        "offset": 76
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 10,
-                        "offset": 82
-                      }
-                    },
-                    "name": "value",
-                    "curly": false
-                  },
-                  "right": {
-                    "kind": "bin",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 13,
-                        "offset": 85
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 25,
-                        "offset": 97
-                      }
-                    },
-                    "type": "??",
-                    "left": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 6,
-                          "column": 13,
-                          "offset": 85
-                        },
-                        "end": {
-                          "line": 6,
-                          "column": 19,
-                          "offset": 91
-                        }
-                      },
-                      "name": "items",
-                      "curly": false
-                    },
-                    "right": {
-                      "kind": "array",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 6,
-                          "column": 23,
-                          "offset": 95
-                        },
-                        "end": {
-                          "line": 6,
-                          "column": 25,
-                          "offset": 97
-                        }
-                      },
-                      "items": [],
-                      "shortForm": true
-                    }
-                  },
-                  "operator": "="
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 8,
-                    "column": 4,
-                    "offset": 104
-                  },
-                  "end": {
-                    "line": 8,
-                    "column": 17,
-                    "offset": 117
-                  }
-                },
-                "expression": {
-                  "kind": "yield",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 4,
-                      "offset": 104
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 17,
-                      "offset": 117
-                    }
-                  },
-                  "value": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 8,
-                        "column": 10,
-                        "offset": 110
-                      },
-                      "end": {
-                        "line": 8,
-                        "column": 16,
-                        "offset": 116
-                      }
-                    },
-                    "name": "value",
-                    "curly": false
-                  },
-                  "key": null
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 9,
-                    "column": 4,
-                    "offset": 122
-                  },
-                  "end": {
-                    "line": 9,
-                    "column": 24,
-                    "offset": 142
-                  }
-                },
-                "expression": {
-                  "kind": "yieldfrom",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 9,
-                      "column": 4,
-                      "offset": 122
-                    },
-                    "end": {
-                      "line": 9,
-                      "column": 24,
-                      "offset": 142
-                    }
-                  },
-                  "value": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 15,
-                        "offset": 133
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 23,
-                        "offset": 141
-                      }
-                    },
-                    "what": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 15,
-                          "offset": 133
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 21,
-                          "offset": 139
-                        }
-                      },
-                      "name": "source",
-                      "resolution": "uqn"
-                    },
-                    "arguments": []
-                  }
-                }
-              },
-              {
-                "kind": "return",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 11,
-                    "column": 4,
-                    "offset": 148
-                  },
-                  "end": {
-                    "line": 11,
-                    "column": 17,
-                    "offset": 161
-                  }
-                },
-                "expr": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 11,
-                      "column": 11,
-                      "offset": 155
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 16,
-                      "offset": 160
-                    }
-                  },
-                  "name": "name",
-                  "curly": false
-                }
-              }
-            ]
-          },
-          "attrGroups": []
-        }
-      ],
-      "errors": [],
-      "comments": []
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
     }
   },
   "loc": {
@@ -4464,6 +892,6 @@
       "line": 13,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/flow-extras.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/flow-extras.php.json
+++ b/parser-PHP/tests/benchmark/base/flow-extras.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 15
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
           },
           "origin": {
             "kind": "identifier",
@@ -45,7 +45,7 @@
             "line": 3,
             "column": 15
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
         }
       },
       "parameters": [
@@ -64,7 +64,7 @@
                   "line": 3,
                   "column": 20
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -93,7 +93,7 @@
                 "line": 3,
                 "column": 20
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           "init": null,
@@ -116,7 +116,7 @@
                 "line": 3,
                 "column": 20
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
             },
             "origin": {
               "kind": "parameter",
@@ -169,7 +169,7 @@
               "line": 3,
               "column": 20
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
           }
         },
         {
@@ -187,7 +187,7 @@
                   "line": 3,
                   "column": 28
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -216,7 +216,7 @@
                 "line": 3,
                 "column": 28
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           "init": null,
@@ -239,7 +239,7 @@
                 "line": 3,
                 "column": 28
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
             },
             "origin": {
               "kind": "parameter",
@@ -292,7 +292,7 @@
               "line": 3,
               "column": 28
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
           }
         }
       ],
@@ -321,7 +321,7 @@
                       "line": 5,
                       "column": 10
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   },
                   "origin": {
                     "kind": "variable",
@@ -351,7 +351,7 @@
                     "line": 5,
                     "column": 10
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "right": {
@@ -373,7 +373,7 @@
                             "line": 5,
                             "column": 17
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                         },
                         "origin": {
                           "kind": "variable",
@@ -403,7 +403,7 @@
                           "line": 5,
                           "column": 17
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                       }
                     },
                     "consequent": {
@@ -421,7 +421,7 @@
                               "line": 5,
                               "column": 17
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                           },
                           "origin": {
                             "kind": "variable",
@@ -451,7 +451,7 @@
                             "line": 5,
                             "column": 17
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                         }
                       },
                       "property": {
@@ -467,7 +467,7 @@
                               "line": 5,
                               "column": 24
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                           },
                           "origin": {
                             "kind": "identifier",
@@ -496,7 +496,7 @@
                             "line": 5,
                             "column": 24
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                         }
                       },
                       "computed": false,
@@ -510,7 +510,7 @@
                             "line": 5,
                             "column": 24
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                         },
                         "origin": {
                           "kind": "nullsafepropertylookup",
@@ -574,7 +574,7 @@
                           "line": 5,
                           "column": 24
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                       }
                     },
                     "alternative": {
@@ -593,7 +593,7 @@
                           "line": 5,
                           "column": 24
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                       },
                       "origin": {
                         "kind": "nullsafepropertylookup",
@@ -656,7 +656,7 @@
                         "line": 5,
                         "column": 24
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                     }
                   },
                   "arguments": [],
@@ -670,7 +670,7 @@
                         "line": 5,
                         "column": 26
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                     },
                     "origin": {
                       "kind": "call",
@@ -750,7 +750,7 @@
                       "line": 5,
                       "column": 26
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "consequent": {
@@ -772,7 +772,7 @@
                               "line": 5,
                               "column": 17
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                           },
                           "origin": {
                             "kind": "variable",
@@ -802,7 +802,7 @@
                             "line": 5,
                             "column": 17
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                         }
                       },
                       "consequent": {
@@ -820,7 +820,7 @@
                                 "line": 5,
                                 "column": 17
                               },
-                              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                             },
                             "origin": {
                               "kind": "variable",
@@ -850,7 +850,7 @@
                               "line": 5,
                               "column": 17
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                           }
                         },
                         "property": {
@@ -866,7 +866,7 @@
                                 "line": 5,
                                 "column": 24
                               },
-                              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                             },
                             "origin": {
                               "kind": "identifier",
@@ -895,7 +895,7 @@
                               "line": 5,
                               "column": 24
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                           }
                         },
                         "computed": false,
@@ -909,7 +909,7 @@
                               "line": 5,
                               "column": 24
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                           },
                           "origin": {
                             "kind": "nullsafepropertylookup",
@@ -973,7 +973,7 @@
                             "line": 5,
                             "column": 24
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                         }
                       },
                       "alternative": {
@@ -992,7 +992,7 @@
                             "line": 5,
                             "column": 24
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                         },
                         "origin": {
                           "kind": "nullsafepropertylookup",
@@ -1055,7 +1055,7 @@
                           "line": 5,
                           "column": 24
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                       }
                     },
                     "arguments": [],
@@ -1069,7 +1069,7 @@
                           "line": 5,
                           "column": 26
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                       },
                       "origin": {
                         "kind": "call",
@@ -1149,7 +1149,7 @@
                         "line": 5,
                         "column": 26
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                     }
                   },
                   "property": {
@@ -1165,7 +1165,7 @@
                           "line": 5,
                           "column": 33
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                       },
                       "origin": {
                         "kind": "identifier",
@@ -1194,7 +1194,7 @@
                         "line": 5,
                         "column": 33
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                     }
                   },
                   "computed": false,
@@ -1208,7 +1208,7 @@
                         "line": 5,
                         "column": 33
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                     },
                     "origin": {
                       "kind": "nullsafepropertylookup",
@@ -1322,7 +1322,7 @@
                       "line": 5,
                       "column": 33
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "alternative": {
@@ -1341,7 +1341,7 @@
                       "line": 5,
                       "column": 33
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   },
                   "origin": {
                     "kind": "nullsafepropertylookup",
@@ -1454,7 +1454,7 @@
                     "line": 5,
                     "column": 33
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "operator": "=",
@@ -1469,7 +1469,7 @@
                     "line": 5,
                     "column": 34
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 },
                 "origin": {
                   "kind": "assign",
@@ -1617,7 +1617,7 @@
                   "line": 5,
                   "column": 34
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "_meta": {
@@ -1630,7 +1630,7 @@
                   "line": 5,
                   "column": 34
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               },
               "origin": {
                 "kind": "expressionstatement",
@@ -1794,7 +1794,7 @@
                 "line": 5,
                 "column": 34
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           {
@@ -1814,7 +1814,7 @@
                       "line": 6,
                       "column": 11
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   },
                   "origin": {
                     "kind": "variable",
@@ -1844,12 +1844,12 @@
                     "line": 6,
                     "column": 11
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "right": {
                 "type": "BinaryExpression",
-                "operator": "??",
+                "operator": "||",
                 "left": {
                   "type": "Identifier",
                   "name": "items",
@@ -1863,7 +1863,7 @@
                         "line": 6,
                         "column": 20
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                     },
                     "origin": {
                       "kind": "variable",
@@ -1893,7 +1893,7 @@
                       "line": 6,
                       "column": 20
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "right": {
@@ -1911,7 +1911,7 @@
                         "line": 6,
                         "column": 26
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                     },
                     "origin": {
                       "kind": "array",
@@ -1941,7 +1941,7 @@
                       "line": 6,
                       "column": 26
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "_meta": {
@@ -1954,7 +1954,7 @@
                       "line": 6,
                       "column": 26
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   },
                   "origin": {
                     "kind": "bin",
@@ -2019,7 +2019,7 @@
                     "line": 6,
                     "column": 26
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "operator": "=",
@@ -2034,7 +2034,7 @@
                     "line": 6,
                     "column": 27
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 },
                 "origin": {
                   "kind": "assign",
@@ -2134,7 +2134,7 @@
                   "line": 6,
                   "column": 27
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "_meta": {
@@ -2147,7 +2147,7 @@
                   "line": 6,
                   "column": 27
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               },
               "origin": {
                 "kind": "expressionstatement",
@@ -2263,7 +2263,7 @@
                 "line": 6,
                 "column": 27
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           {
@@ -2283,7 +2283,7 @@
                       "line": 8,
                       "column": 17
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   },
                   "origin": {
                     "kind": "variable",
@@ -2313,7 +2313,7 @@
                     "line": 8,
                     "column": 17
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "_meta": {
@@ -2327,7 +2327,7 @@
                     "line": 8,
                     "column": 18
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 },
                 "origin": {
                   "kind": "yield",
@@ -2374,7 +2374,7 @@
                   "line": 8,
                   "column": 18
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "_meta": {
@@ -2387,7 +2387,7 @@
                   "line": 8,
                   "column": 18
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               },
               "origin": {
                 "kind": "expressionstatement",
@@ -2450,7 +2450,7 @@
                 "line": 8,
                 "column": 18
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           {
@@ -2472,7 +2472,7 @@
                         "line": 9,
                         "column": 22
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                     },
                     "origin": {
                       "kind": "name",
@@ -2502,7 +2502,7 @@
                       "line": 9,
                       "column": 22
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   }
                 },
                 "arguments": [],
@@ -2516,7 +2516,7 @@
                       "line": 9,
                       "column": 24
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                   },
                   "origin": {
                     "kind": "call",
@@ -2563,7 +2563,7 @@
                     "line": 9,
                     "column": 24
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 }
               },
               "_meta": {
@@ -2577,7 +2577,7 @@
                     "line": 9,
                     "column": 25
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 },
                 "origin": {
                   "kind": "yieldfrom",
@@ -2640,7 +2640,7 @@
                   "line": 9,
                   "column": 25
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "_meta": {
@@ -2653,7 +2653,7 @@
                   "line": 9,
                   "column": 25
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               },
               "origin": {
                 "kind": "expressionstatement",
@@ -2732,7 +2732,7 @@
                 "line": 9,
                 "column": 25
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           },
           {
@@ -2750,7 +2750,7 @@
                     "line": 11,
                     "column": 17
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
                 },
                 "origin": {
                   "kind": "variable",
@@ -2780,7 +2780,7 @@
                   "line": 11,
                   "column": 17
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               }
             },
             "isYield": false,
@@ -2794,7 +2794,7 @@
                   "line": 11,
                   "column": 18
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
               },
               "origin": {
                 "kind": "return",
@@ -2840,7 +2840,7 @@
                 "line": 11,
                 "column": 18
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
             }
           }
         ],
@@ -2855,7 +2855,7 @@
               "line": 12,
               "column": 2
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
           },
           "origin": {
             "kind": "block",
@@ -3293,7 +3293,7 @@
             "line": 12,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
         }
       },
       "modifiers": [],
@@ -3308,7 +3308,7 @@
             "line": 12,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
         },
         "origin": {
           "kind": "function",
@@ -3867,13 +3867,13 @@
           "line": 12,
           "column": 2
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -3885,7 +3885,7 @@
         "line": 13,
         "column": 1
       },
-      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
     },
     "origin": {
       "kind": "program",
@@ -4464,6 +4464,6 @@
       "line": 13,
       "column": 1
     },
-    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/flow-extras.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/function.php.json
+++ b/parser-PHP/tests/benchmark/base/function.php.json
@@ -16,7 +16,7 @@
               "line": 2,
               "column": 13
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
           }
         },
         "loc": {
@@ -28,7 +28,7 @@
             "line": 2,
             "column": 13
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
         }
       },
       "parameters": [
@@ -47,7 +47,7 @@
                   "line": 2,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
               }
             },
             "loc": {
@@ -59,7 +59,7 @@
                 "line": 2,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
             }
           },
           "init": null,
@@ -80,7 +80,7 @@
                 "line": 2,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
             }
           },
           "loc": {
@@ -92,7 +92,7 @@
               "line": 2,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
           }
         },
         {
@@ -110,7 +110,7 @@
                   "line": 2,
                   "column": 20
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
               }
             },
             "loc": {
@@ -122,7 +122,7 @@
                 "line": 2,
                 "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
             }
           },
           "init": {
@@ -139,7 +139,7 @@
                   "line": 2,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
               }
             },
             "loc": {
@@ -151,7 +151,7 @@
                 "line": 2,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
             }
           },
           "cloned": false,
@@ -171,7 +171,7 @@
                 "line": 2,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
             }
           },
           "loc": {
@@ -183,7 +183,7 @@
               "line": 2,
               "column": 24
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
           }
         }
       ],
@@ -210,7 +210,7 @@
                     "line": 3,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                 }
               },
               "loc": {
@@ -222,7 +222,7 @@
                   "line": 3,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
               }
             },
             "consequent": {
@@ -245,7 +245,7 @@
                             "line": 4,
                             "column": 19
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                         }
                       },
                       "loc": {
@@ -257,7 +257,7 @@
                           "line": 4,
                           "column": 19
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                       }
                     },
                     "arguments": [
@@ -274,7 +274,7 @@
                               "line": 4,
                               "column": 22
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                           }
                         },
                         "loc": {
@@ -286,7 +286,7 @@
                             "line": 4,
                             "column": 22
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                         }
                       }
                     ],
@@ -300,7 +300,7 @@
                           "line": 4,
                           "column": 23
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                       }
                     },
                     "loc": {
@@ -312,7 +312,7 @@
                         "line": 4,
                         "column": 23
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                     }
                   },
                   "isYield": false,
@@ -326,7 +326,7 @@
                         "line": 4,
                         "column": 24
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                     }
                   },
                   "loc": {
@@ -338,7 +338,7 @@
                       "line": 4,
                       "column": 24
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                   }
                 }
               ],
@@ -353,7 +353,7 @@
                     "line": 5,
                     "column": 6
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                 }
               },
               "loc": {
@@ -365,7 +365,7 @@
                   "line": 5,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
               }
             },
             "alternative": null,
@@ -379,7 +379,7 @@
                   "line": 5,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
               }
             },
             "loc": {
@@ -391,7 +391,7 @@
                 "line": 5,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
             }
           },
           {
@@ -410,7 +410,7 @@
                     "line": 6,
                     "column": 13
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                 }
               },
               "loc": {
@@ -422,7 +422,7 @@
                   "line": 6,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
               }
             },
             "isYield": false,
@@ -436,7 +436,7 @@
                   "line": 6,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
               }
             },
             "loc": {
@@ -448,7 +448,7 @@
                 "line": 6,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
             }
           }
         ],
@@ -463,7 +463,7 @@
               "line": 7,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
           }
         },
         "loc": {
@@ -475,7 +475,7 @@
             "line": 7,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
         }
       },
       "modifiers": [],
@@ -489,7 +489,7 @@
             "line": 7,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
         }
       },
       "loc": {
@@ -501,13 +501,13 @@
           "line": 7,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -519,7 +519,7 @@
         "line": 8,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
     }
   },
   "loc": {
@@ -531,6 +531,6 @@
       "line": 8,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/function.php.json
+++ b/parser-PHP/tests/benchmark/base/function.php.json
@@ -16,7 +16,7 @@
               "line": 2,
               "column": 13
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+            "sourcefile": "function.php"
           }
         },
         "loc": {
@@ -28,7 +28,7 @@
             "line": 2,
             "column": 13
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+          "sourcefile": "function.php"
         }
       },
       "parameters": [
@@ -47,7 +47,7 @@
                   "line": 2,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "function.php"
               }
             },
             "loc": {
@@ -59,7 +59,7 @@
                 "line": 2,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "function.php"
             }
           },
           "init": null,
@@ -80,7 +80,7 @@
                 "line": 2,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "function.php"
             }
           },
           "loc": {
@@ -92,7 +92,7 @@
               "line": 2,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+            "sourcefile": "function.php"
           }
         },
         {
@@ -110,7 +110,7 @@
                   "line": 2,
                   "column": 20
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "function.php"
               }
             },
             "loc": {
@@ -122,7 +122,7 @@
                 "line": 2,
                 "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "function.php"
             }
           },
           "init": {
@@ -139,7 +139,7 @@
                   "line": 2,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "function.php"
               }
             },
             "loc": {
@@ -151,7 +151,7 @@
                 "line": 2,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "function.php"
             }
           },
           "cloned": false,
@@ -171,7 +171,7 @@
                 "line": 2,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "function.php"
             }
           },
           "loc": {
@@ -183,7 +183,7 @@
               "line": 2,
               "column": 24
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+            "sourcefile": "function.php"
           }
         }
       ],
@@ -210,7 +210,7 @@
                     "line": 3,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                  "sourcefile": "function.php"
                 }
               },
               "loc": {
@@ -222,7 +222,7 @@
                   "line": 3,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "function.php"
               }
             },
             "consequent": {
@@ -245,7 +245,7 @@
                             "line": 4,
                             "column": 19
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                          "sourcefile": "function.php"
                         }
                       },
                       "loc": {
@@ -257,7 +257,7 @@
                           "line": 4,
                           "column": 19
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                        "sourcefile": "function.php"
                       }
                     },
                     "arguments": [
@@ -274,7 +274,7 @@
                               "line": 4,
                               "column": 22
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                            "sourcefile": "function.php"
                           }
                         },
                         "loc": {
@@ -286,7 +286,7 @@
                             "line": 4,
                             "column": 22
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                          "sourcefile": "function.php"
                         }
                       }
                     ],
@@ -300,7 +300,7 @@
                           "line": 4,
                           "column": 23
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                        "sourcefile": "function.php"
                       }
                     },
                     "loc": {
@@ -312,7 +312,7 @@
                         "line": 4,
                         "column": 23
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                      "sourcefile": "function.php"
                     }
                   },
                   "isYield": false,
@@ -326,7 +326,7 @@
                         "line": 4,
                         "column": 24
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                      "sourcefile": "function.php"
                     }
                   },
                   "loc": {
@@ -338,7 +338,7 @@
                       "line": 4,
                       "column": 24
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                    "sourcefile": "function.php"
                   }
                 }
               ],
@@ -353,7 +353,7 @@
                     "line": 5,
                     "column": 6
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                  "sourcefile": "function.php"
                 }
               },
               "loc": {
@@ -365,7 +365,7 @@
                   "line": 5,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "function.php"
               }
             },
             "alternative": null,
@@ -379,7 +379,7 @@
                   "line": 5,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "function.php"
               }
             },
             "loc": {
@@ -391,7 +391,7 @@
                 "line": 5,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "function.php"
             }
           },
           {
@@ -410,7 +410,7 @@
                     "line": 6,
                     "column": 13
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                  "sourcefile": "function.php"
                 }
               },
               "loc": {
@@ -422,7 +422,7 @@
                   "line": 6,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "function.php"
               }
             },
             "isYield": false,
@@ -436,7 +436,7 @@
                   "line": 6,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "function.php"
               }
             },
             "loc": {
@@ -448,7 +448,7 @@
                 "line": 6,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "function.php"
             }
           }
         ],
@@ -463,7 +463,7 @@
               "line": 7,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+            "sourcefile": "function.php"
           }
         },
         "loc": {
@@ -475,7 +475,7 @@
             "line": 7,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+          "sourcefile": "function.php"
         }
       },
       "modifiers": [],
@@ -489,7 +489,7 @@
             "line": 7,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+          "sourcefile": "function.php"
         }
       },
       "loc": {
@@ -501,13 +501,13 @@
           "line": 7,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+        "sourcefile": "function.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php",
+  "uri": "function.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -519,7 +519,7 @@
         "line": 8,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+      "sourcefile": "function.php"
     }
   },
   "loc": {
@@ -531,6 +531,6 @@
       "line": 8,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+    "sourcefile": "function.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/function.php.json
+++ b/parser-PHP/tests/benchmark/base/function.php.json
@@ -16,24 +16,7 @@
               "line": 2,
               "column": 13
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
-          },
-          "origin": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 2,
-                "column": 9,
-                "offset": 15
-              },
-              "end": {
-                "line": 2,
-                "column": 12,
-                "offset": 18
-              }
-            },
-            "name": "foo"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
           }
         },
         "loc": {
@@ -45,7 +28,7 @@
             "line": 2,
             "column": 13
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
         }
       },
       "parameters": [
@@ -64,24 +47,7 @@
                   "line": 2,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 13,
-                    "offset": 19
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 15,
-                    "offset": 21
-                  }
-                },
-                "name": "x"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
               }
             },
             "loc": {
@@ -93,7 +59,7 @@
                 "line": 2,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
             }
           },
           "init": null,
@@ -104,9 +70,7 @@
             "_meta": {}
           },
           "_meta": {
-            "byref": false,
             "variadic": false,
-            "attributes": [],
             "loc": {
               "start": {
                 "line": 2,
@@ -116,48 +80,7 @@
                 "line": 2,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
-            },
-            "origin": {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 13,
-                  "offset": 19
-                },
-                "end": {
-                  "line": 2,
-                  "column": 15,
-                  "offset": 21
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 13,
-                    "offset": 19
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 15,
-                    "offset": 21
-                  }
-                },
-                "name": "x"
-              },
-              "value": null,
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
             }
           },
           "loc": {
@@ -169,7 +92,7 @@
               "line": 2,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
           }
         },
         {
@@ -187,24 +110,7 @@
                   "line": 2,
                   "column": 20
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 17,
-                    "offset": 23
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 19,
-                    "offset": 25
-                  }
-                },
-                "name": "y"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
               }
             },
             "loc": {
@@ -216,7 +122,7 @@
                 "line": 2,
                 "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
             }
           },
           "init": {
@@ -233,24 +139,7 @@
                   "line": 2,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
-              },
-              "origin": {
-                "kind": "number",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 22,
-                    "offset": 28
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 23,
-                    "offset": 29
-                  }
-                },
-                "value": "1"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
               }
             },
             "loc": {
@@ -262,7 +151,7 @@
                 "line": 2,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
             }
           },
           "cloned": false,
@@ -272,9 +161,7 @@
             "_meta": {}
           },
           "_meta": {
-            "byref": false,
             "variadic": false,
-            "attributes": [],
             "loc": {
               "start": {
                 "line": 2,
@@ -284,64 +171,7 @@
                 "line": 2,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
-            },
-            "origin": {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 17,
-                  "offset": 23
-                },
-                "end": {
-                  "line": 2,
-                  "column": 23,
-                  "offset": 29
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 17,
-                    "offset": 23
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 19,
-                    "offset": 25
-                  }
-                },
-                "name": "y"
-              },
-              "value": {
-                "kind": "number",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 22,
-                    "offset": 28
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 23,
-                    "offset": 29
-                  }
-                },
-                "value": "1"
-              },
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
             }
           },
           "loc": {
@@ -353,7 +183,7 @@
               "line": 2,
               "column": 24
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
           }
         }
       ],
@@ -380,25 +210,7 @@
                     "line": 3,
                     "column": 11
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
-                },
-                "origin": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 8,
-                      "offset": 41
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 10,
-                      "offset": 43
-                    }
-                  },
-                  "name": "x",
-                  "curly": false
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
                 }
               },
               "loc": {
@@ -410,7 +222,7 @@
                   "line": 3,
                   "column": 11
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
               }
             },
             "consequent": {
@@ -433,25 +245,7 @@
                             "line": 4,
                             "column": 19
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
-                        },
-                        "origin": {
-                          "kind": "name",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 4,
-                              "column": 15,
-                              "offset": 62
-                            },
-                            "end": {
-                              "line": 4,
-                              "column": 18,
-                              "offset": 65
-                            }
-                          },
-                          "name": "bar",
-                          "resolution": "uqn"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
                         }
                       },
                       "loc": {
@@ -463,7 +257,7 @@
                           "line": 4,
                           "column": 19
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
                       }
                     },
                     "arguments": [
@@ -480,25 +274,7 @@
                               "line": 4,
                               "column": 22
                             },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
-                          },
-                          "origin": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 4,
-                                "column": 19,
-                                "offset": 66
-                              },
-                              "end": {
-                                "line": 4,
-                                "column": 21,
-                                "offset": 68
-                              }
-                            },
-                            "name": "y",
-                            "curly": false
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
                           }
                         },
                         "loc": {
@@ -510,7 +286,7 @@
                             "line": 4,
                             "column": 22
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
                         }
                       }
                     ],
@@ -524,61 +300,7 @@
                           "line": 4,
                           "column": 23
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
-                      },
-                      "origin": {
-                        "kind": "call",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 4,
-                            "column": 15,
-                            "offset": 62
-                          },
-                          "end": {
-                            "line": 4,
-                            "column": 22,
-                            "offset": 69
-                          }
-                        },
-                        "what": {
-                          "kind": "name",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 4,
-                              "column": 15,
-                              "offset": 62
-                            },
-                            "end": {
-                              "line": 4,
-                              "column": 18,
-                              "offset": 65
-                            }
-                          },
-                          "name": "bar",
-                          "resolution": "uqn"
-                        },
-                        "arguments": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 4,
-                                "column": 19,
-                                "offset": 66
-                              },
-                              "end": {
-                                "line": 4,
-                                "column": 21,
-                                "offset": 68
-                              }
-                            },
-                            "name": "y",
-                            "curly": false
-                          }
-                        ]
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
                       }
                     },
                     "loc": {
@@ -590,7 +312,7 @@
                         "line": 4,
                         "column": 23
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
                     }
                   },
                   "isYield": false,
@@ -604,77 +326,7 @@
                         "line": 4,
                         "column": 24
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
-                    },
-                    "origin": {
-                      "kind": "return",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 4,
-                          "column": 8,
-                          "offset": 55
-                        },
-                        "end": {
-                          "line": 4,
-                          "column": 23,
-                          "offset": 70
-                        }
-                      },
-                      "expr": {
-                        "kind": "call",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 4,
-                            "column": 15,
-                            "offset": 62
-                          },
-                          "end": {
-                            "line": 4,
-                            "column": 22,
-                            "offset": 69
-                          }
-                        },
-                        "what": {
-                          "kind": "name",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 4,
-                              "column": 15,
-                              "offset": 62
-                            },
-                            "end": {
-                              "line": 4,
-                              "column": 18,
-                              "offset": 65
-                            }
-                          },
-                          "name": "bar",
-                          "resolution": "uqn"
-                        },
-                        "arguments": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 4,
-                                "column": 19,
-                                "offset": 66
-                              },
-                              "end": {
-                                "line": 4,
-                                "column": 21,
-                                "offset": 68
-                              }
-                            },
-                            "name": "y",
-                            "curly": false
-                          }
-                        ]
-                      }
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
                     }
                   },
                   "loc": {
@@ -686,7 +338,7 @@
                       "line": 4,
                       "column": 24
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
                   }
                 }
               ],
@@ -701,95 +353,7 @@
                     "line": 5,
                     "column": 6
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
-                },
-                "origin": {
-                  "kind": "block",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 12,
-                      "offset": 45
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 5,
-                      "offset": 76
-                    }
-                  },
-                  "children": [
-                    {
-                      "kind": "return",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 4,
-                          "column": 8,
-                          "offset": 55
-                        },
-                        "end": {
-                          "line": 4,
-                          "column": 23,
-                          "offset": 70
-                        }
-                      },
-                      "expr": {
-                        "kind": "call",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 4,
-                            "column": 15,
-                            "offset": 62
-                          },
-                          "end": {
-                            "line": 4,
-                            "column": 22,
-                            "offset": 69
-                          }
-                        },
-                        "what": {
-                          "kind": "name",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 4,
-                              "column": 15,
-                              "offset": 62
-                            },
-                            "end": {
-                              "line": 4,
-                              "column": 18,
-                              "offset": 65
-                            }
-                          },
-                          "name": "bar",
-                          "resolution": "uqn"
-                        },
-                        "arguments": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 4,
-                                "column": 19,
-                                "offset": 66
-                              },
-                              "end": {
-                                "line": 4,
-                                "column": 21,
-                                "offset": 68
-                              }
-                            },
-                            "name": "y",
-                            "curly": false
-                          }
-                        ]
-                      }
-                    }
-                  ]
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
                 }
               },
               "loc": {
@@ -801,7 +365,7 @@
                   "line": 5,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
               }
             },
             "alternative": null,
@@ -815,131 +379,7 @@
                   "line": 5,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
-              },
-              "origin": {
-                "kind": "if",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 4,
-                    "offset": 37
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 5,
-                    "offset": 76
-                  }
-                },
-                "test": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 8,
-                      "offset": 41
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 10,
-                      "offset": 43
-                    }
-                  },
-                  "name": "x",
-                  "curly": false
-                },
-                "body": {
-                  "kind": "block",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 12,
-                      "offset": 45
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 5,
-                      "offset": 76
-                    }
-                  },
-                  "children": [
-                    {
-                      "kind": "return",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 4,
-                          "column": 8,
-                          "offset": 55
-                        },
-                        "end": {
-                          "line": 4,
-                          "column": 23,
-                          "offset": 70
-                        }
-                      },
-                      "expr": {
-                        "kind": "call",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 4,
-                            "column": 15,
-                            "offset": 62
-                          },
-                          "end": {
-                            "line": 4,
-                            "column": 22,
-                            "offset": 69
-                          }
-                        },
-                        "what": {
-                          "kind": "name",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 4,
-                              "column": 15,
-                              "offset": 62
-                            },
-                            "end": {
-                              "line": 4,
-                              "column": 18,
-                              "offset": 65
-                            }
-                          },
-                          "name": "bar",
-                          "resolution": "uqn"
-                        },
-                        "arguments": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 4,
-                                "column": 19,
-                                "offset": 66
-                              },
-                              "end": {
-                                "line": 4,
-                                "column": 21,
-                                "offset": 68
-                              }
-                            },
-                            "name": "y",
-                            "curly": false
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                },
-                "alternate": null,
-                "shortForm": false
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
               }
             },
             "loc": {
@@ -951,7 +391,7 @@
                 "line": 5,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
             }
           },
           {
@@ -970,24 +410,7 @@
                     "line": 6,
                     "column": 13
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
-                },
-                "origin": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 11,
-                      "offset": 88
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 12,
-                      "offset": 89
-                    }
-                  },
-                  "value": "0"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
                 }
               },
               "loc": {
@@ -999,7 +422,7 @@
                   "line": 6,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
               }
             },
             "isYield": false,
@@ -1013,40 +436,7 @@
                   "line": 6,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
-              },
-              "origin": {
-                "kind": "return",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 4,
-                    "offset": 81
-                  },
-                  "end": {
-                    "line": 6,
-                    "column": 13,
-                    "offset": 90
-                  }
-                },
-                "expr": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 11,
-                      "offset": 88
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 12,
-                      "offset": 89
-                    }
-                  },
-                  "value": "0"
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
               }
             },
             "loc": {
@@ -1058,7 +448,7 @@
                 "line": 6,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
             }
           }
         ],
@@ -1073,182 +463,7 @@
               "line": 7,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
-          },
-          "origin": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 2,
-                "column": 25,
-                "offset": 31
-              },
-              "end": {
-                "line": 7,
-                "column": 1,
-                "offset": 92
-              }
-            },
-            "children": [
-              {
-                "kind": "if",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 4,
-                    "offset": 37
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 5,
-                    "offset": 76
-                  }
-                },
-                "test": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 8,
-                      "offset": 41
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 10,
-                      "offset": 43
-                    }
-                  },
-                  "name": "x",
-                  "curly": false
-                },
-                "body": {
-                  "kind": "block",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 12,
-                      "offset": 45
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 5,
-                      "offset": 76
-                    }
-                  },
-                  "children": [
-                    {
-                      "kind": "return",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 4,
-                          "column": 8,
-                          "offset": 55
-                        },
-                        "end": {
-                          "line": 4,
-                          "column": 23,
-                          "offset": 70
-                        }
-                      },
-                      "expr": {
-                        "kind": "call",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 4,
-                            "column": 15,
-                            "offset": 62
-                          },
-                          "end": {
-                            "line": 4,
-                            "column": 22,
-                            "offset": 69
-                          }
-                        },
-                        "what": {
-                          "kind": "name",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 4,
-                              "column": 15,
-                              "offset": 62
-                            },
-                            "end": {
-                              "line": 4,
-                              "column": 18,
-                              "offset": 65
-                            }
-                          },
-                          "name": "bar",
-                          "resolution": "uqn"
-                        },
-                        "arguments": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 4,
-                                "column": 19,
-                                "offset": 66
-                              },
-                              "end": {
-                                "line": 4,
-                                "column": 21,
-                                "offset": 68
-                              }
-                            },
-                            "name": "y",
-                            "curly": false
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                },
-                "alternate": null,
-                "shortForm": false
-              },
-              {
-                "kind": "return",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 4,
-                    "offset": 81
-                  },
-                  "end": {
-                    "line": 6,
-                    "column": 13,
-                    "offset": 90
-                  }
-                },
-                "expr": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 11,
-                      "offset": 88
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 12,
-                      "offset": 89
-                    }
-                  },
-                  "value": "0"
-                }
-              }
-            ]
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
           }
         },
         "loc": {
@@ -1260,12 +475,11 @@
             "line": 7,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
         }
       },
       "modifiers": [],
       "_meta": {
-        "attributes": [],
         "loc": {
           "start": {
             "line": 2,
@@ -1275,319 +489,7 @@
             "line": 7,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
-        },
-        "origin": {
-          "kind": "function",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 2,
-              "column": 0,
-              "offset": 6
-            },
-            "end": {
-              "line": 7,
-              "column": 1,
-              "offset": 92
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 2,
-                "column": 9,
-                "offset": 15
-              },
-              "end": {
-                "line": 2,
-                "column": 12,
-                "offset": 18
-              }
-            },
-            "name": "foo"
-          },
-          "arguments": [
-            {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 13,
-                  "offset": 19
-                },
-                "end": {
-                  "line": 2,
-                  "column": 15,
-                  "offset": 21
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 13,
-                    "offset": 19
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 15,
-                    "offset": 21
-                  }
-                },
-                "name": "x"
-              },
-              "value": null,
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
-            },
-            {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 17,
-                  "offset": 23
-                },
-                "end": {
-                  "line": 2,
-                  "column": 23,
-                  "offset": 29
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 17,
-                    "offset": 23
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 19,
-                    "offset": 25
-                  }
-                },
-                "name": "y"
-              },
-              "value": {
-                "kind": "number",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 22,
-                    "offset": 28
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 23,
-                    "offset": 29
-                  }
-                },
-                "value": "1"
-              },
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
-            }
-          ],
-          "byref": false,
-          "type": null,
-          "nullable": false,
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 2,
-                "column": 25,
-                "offset": 31
-              },
-              "end": {
-                "line": 7,
-                "column": 1,
-                "offset": 92
-              }
-            },
-            "children": [
-              {
-                "kind": "if",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 4,
-                    "offset": 37
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 5,
-                    "offset": 76
-                  }
-                },
-                "test": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 8,
-                      "offset": 41
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 10,
-                      "offset": 43
-                    }
-                  },
-                  "name": "x",
-                  "curly": false
-                },
-                "body": {
-                  "kind": "block",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 12,
-                      "offset": 45
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 5,
-                      "offset": 76
-                    }
-                  },
-                  "children": [
-                    {
-                      "kind": "return",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 4,
-                          "column": 8,
-                          "offset": 55
-                        },
-                        "end": {
-                          "line": 4,
-                          "column": 23,
-                          "offset": 70
-                        }
-                      },
-                      "expr": {
-                        "kind": "call",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 4,
-                            "column": 15,
-                            "offset": 62
-                          },
-                          "end": {
-                            "line": 4,
-                            "column": 22,
-                            "offset": 69
-                          }
-                        },
-                        "what": {
-                          "kind": "name",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 4,
-                              "column": 15,
-                              "offset": 62
-                            },
-                            "end": {
-                              "line": 4,
-                              "column": 18,
-                              "offset": 65
-                            }
-                          },
-                          "name": "bar",
-                          "resolution": "uqn"
-                        },
-                        "arguments": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 4,
-                                "column": 19,
-                                "offset": 66
-                              },
-                              "end": {
-                                "line": 4,
-                                "column": 21,
-                                "offset": 68
-                              }
-                            },
-                            "name": "y",
-                            "curly": false
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                },
-                "alternate": null,
-                "shortForm": false
-              },
-              {
-                "kind": "return",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 4,
-                    "offset": 81
-                  },
-                  "end": {
-                    "line": 6,
-                    "column": 13,
-                    "offset": 90
-                  }
-                },
-                "expr": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 11,
-                      "offset": 88
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 12,
-                      "offset": 89
-                    }
-                  },
-                  "value": "0"
-                }
-              }
-            ]
-          },
-          "attrGroups": []
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
         }
       },
       "loc": {
@@ -1599,13 +501,13 @@
           "line": 7,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -1617,339 +519,7 @@
         "line": 8,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
-    },
-    "origin": {
-      "kind": "program",
-      "loc": {
-        "source": null,
-        "start": {
-          "line": 1,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "line": 8,
-          "column": 0,
-          "offset": 93
-        }
-      },
-      "children": [
-        {
-          "kind": "function",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 2,
-              "column": 0,
-              "offset": 6
-            },
-            "end": {
-              "line": 7,
-              "column": 1,
-              "offset": 92
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 2,
-                "column": 9,
-                "offset": 15
-              },
-              "end": {
-                "line": 2,
-                "column": 12,
-                "offset": 18
-              }
-            },
-            "name": "foo"
-          },
-          "arguments": [
-            {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 13,
-                  "offset": 19
-                },
-                "end": {
-                  "line": 2,
-                  "column": 15,
-                  "offset": 21
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 13,
-                    "offset": 19
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 15,
-                    "offset": 21
-                  }
-                },
-                "name": "x"
-              },
-              "value": null,
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
-            },
-            {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 17,
-                  "offset": 23
-                },
-                "end": {
-                  "line": 2,
-                  "column": 23,
-                  "offset": 29
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 17,
-                    "offset": 23
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 19,
-                    "offset": 25
-                  }
-                },
-                "name": "y"
-              },
-              "value": {
-                "kind": "number",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 22,
-                    "offset": 28
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 23,
-                    "offset": 29
-                  }
-                },
-                "value": "1"
-              },
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
-            }
-          ],
-          "byref": false,
-          "type": null,
-          "nullable": false,
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 2,
-                "column": 25,
-                "offset": 31
-              },
-              "end": {
-                "line": 7,
-                "column": 1,
-                "offset": 92
-              }
-            },
-            "children": [
-              {
-                "kind": "if",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 4,
-                    "offset": 37
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 5,
-                    "offset": 76
-                  }
-                },
-                "test": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 8,
-                      "offset": 41
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 10,
-                      "offset": 43
-                    }
-                  },
-                  "name": "x",
-                  "curly": false
-                },
-                "body": {
-                  "kind": "block",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 12,
-                      "offset": 45
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 5,
-                      "offset": 76
-                    }
-                  },
-                  "children": [
-                    {
-                      "kind": "return",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 4,
-                          "column": 8,
-                          "offset": 55
-                        },
-                        "end": {
-                          "line": 4,
-                          "column": 23,
-                          "offset": 70
-                        }
-                      },
-                      "expr": {
-                        "kind": "call",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 4,
-                            "column": 15,
-                            "offset": 62
-                          },
-                          "end": {
-                            "line": 4,
-                            "column": 22,
-                            "offset": 69
-                          }
-                        },
-                        "what": {
-                          "kind": "name",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 4,
-                              "column": 15,
-                              "offset": 62
-                            },
-                            "end": {
-                              "line": 4,
-                              "column": 18,
-                              "offset": 65
-                            }
-                          },
-                          "name": "bar",
-                          "resolution": "uqn"
-                        },
-                        "arguments": [
-                          {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 4,
-                                "column": 19,
-                                "offset": 66
-                              },
-                              "end": {
-                                "line": 4,
-                                "column": 21,
-                                "offset": 68
-                              }
-                            },
-                            "name": "y",
-                            "curly": false
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                },
-                "alternate": null,
-                "shortForm": false
-              },
-              {
-                "kind": "return",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 4,
-                    "offset": 81
-                  },
-                  "end": {
-                    "line": 6,
-                    "column": 13,
-                    "offset": 90
-                  }
-                },
-                "expr": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 11,
-                      "offset": 88
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 12,
-                      "offset": 89
-                    }
-                  },
-                  "value": "0"
-                }
-              }
-            ]
-          },
-          "attrGroups": []
-        }
-      ],
-      "errors": [],
-      "comments": []
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
     }
   },
   "loc": {
@@ -1961,6 +531,6 @@
       "line": 8,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/function.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/function.php.json
+++ b/parser-PHP/tests/benchmark/base/function.php.json
@@ -16,7 +16,7 @@
               "line": 2,
               "column": 13
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
           },
           "origin": {
             "kind": "identifier",
@@ -45,7 +45,7 @@
             "line": 2,
             "column": 13
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
         }
       },
       "parameters": [
@@ -64,7 +64,7 @@
                   "line": 2,
                   "column": 16
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -93,7 +93,7 @@
                 "line": 2,
                 "column": 16
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
             }
           },
           "init": null,
@@ -116,7 +116,7 @@
                 "line": 2,
                 "column": 16
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
             },
             "origin": {
               "kind": "parameter",
@@ -169,7 +169,7 @@
               "line": 2,
               "column": 16
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
           }
         },
         {
@@ -187,7 +187,7 @@
                   "line": 2,
                   "column": 20
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -216,7 +216,7 @@
                 "line": 2,
                 "column": 20
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
             }
           },
           "init": {
@@ -233,7 +233,7 @@
                   "line": 2,
                   "column": 24
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
               },
               "origin": {
                 "kind": "number",
@@ -262,7 +262,7 @@
                 "line": 2,
                 "column": 24
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
             }
           },
           "cloned": false,
@@ -284,7 +284,7 @@
                 "line": 2,
                 "column": 24
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
             },
             "origin": {
               "kind": "parameter",
@@ -353,7 +353,7 @@
               "line": 2,
               "column": 24
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
           }
         }
       ],
@@ -380,7 +380,7 @@
                     "line": 3,
                     "column": 11
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                 },
                 "origin": {
                   "kind": "variable",
@@ -410,7 +410,7 @@
                   "line": 3,
                   "column": 11
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
               }
             },
             "consequent": {
@@ -433,7 +433,7 @@
                             "line": 4,
                             "column": 19
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                         },
                         "origin": {
                           "kind": "name",
@@ -463,7 +463,7 @@
                           "line": 4,
                           "column": 19
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                       }
                     },
                     "arguments": [
@@ -480,7 +480,7 @@
                               "line": 4,
                               "column": 22
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                           },
                           "origin": {
                             "kind": "variable",
@@ -510,7 +510,7 @@
                             "line": 4,
                             "column": 22
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                         }
                       }
                     ],
@@ -524,7 +524,7 @@
                           "line": 4,
                           "column": 23
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                       },
                       "origin": {
                         "kind": "call",
@@ -590,7 +590,7 @@
                         "line": 4,
                         "column": 23
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                     }
                   },
                   "isYield": false,
@@ -604,7 +604,7 @@
                         "line": 4,
                         "column": 24
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                     },
                     "origin": {
                       "kind": "return",
@@ -686,7 +686,7 @@
                       "line": 4,
                       "column": 24
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                   }
                 }
               ],
@@ -701,7 +701,7 @@
                     "line": 5,
                     "column": 6
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                 },
                 "origin": {
                   "kind": "block",
@@ -801,7 +801,7 @@
                   "line": 5,
                   "column": 6
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
               }
             },
             "alternative": null,
@@ -815,7 +815,7 @@
                   "line": 5,
                   "column": 6
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
               },
               "origin": {
                 "kind": "if",
@@ -951,7 +951,7 @@
                 "line": 5,
                 "column": 6
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
             }
           },
           {
@@ -970,7 +970,7 @@
                     "line": 6,
                     "column": 13
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
                 },
                 "origin": {
                   "kind": "number",
@@ -999,7 +999,7 @@
                   "line": 6,
                   "column": 13
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
               }
             },
             "isYield": false,
@@ -1013,7 +1013,7 @@
                   "line": 6,
                   "column": 14
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
               },
               "origin": {
                 "kind": "return",
@@ -1058,7 +1058,7 @@
                 "line": 6,
                 "column": 14
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
             }
           }
         ],
@@ -1073,7 +1073,7 @@
               "line": 7,
               "column": 2
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
           },
           "origin": {
             "kind": "block",
@@ -1260,7 +1260,7 @@
             "line": 7,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
         }
       },
       "modifiers": [],
@@ -1275,7 +1275,7 @@
             "line": 7,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
         },
         "origin": {
           "kind": "function",
@@ -1599,13 +1599,13 @@
           "line": 7,
           "column": 2
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -1617,7 +1617,7 @@
         "line": 8,
         "column": 1
       },
-      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
     },
     "origin": {
       "kind": "program",
@@ -1961,6 +1961,6 @@
       "line": 8,
       "column": 1
     },
-    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/function.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/modern-php.php.json
+++ b/parser-PHP/tests/benchmark/base/modern-php.php.json
@@ -16,7 +16,7 @@
               "line": 4,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
           }
         },
         "loc": {
@@ -28,7 +28,7 @@
             "line": 4,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
         }
       },
       "body": [
@@ -55,7 +55,7 @@
                       "line": 6,
                       "column": 20
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                   }
                 },
                 "loc": {
@@ -67,7 +67,7 @@
                     "line": 6,
                     "column": 20
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                 }
               },
               {
@@ -83,7 +83,7 @@
                       "line": 6,
                       "column": 32
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                   }
                 },
                 "loc": {
@@ -95,7 +95,7 @@
                     "line": 6,
                     "column": 32
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                 }
               }
             ],
@@ -110,7 +110,7 @@
                   "line": 6,
                   "column": 33
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
               }
             },
             "loc": {
@@ -122,7 +122,7 @@
                 "line": 6,
                 "column": 33
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
             }
           },
           "_meta": {
@@ -135,7 +135,7 @@
                 "line": 6,
                 "column": 33
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
             }
           },
           "loc": {
@@ -147,7 +147,7 @@
               "line": 6,
               "column": 33
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
           }
         },
         {
@@ -165,7 +165,7 @@
                   "line": 9,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
               }
             },
             "loc": {
@@ -177,7 +177,7 @@
                 "line": 9,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
             }
           },
           "parameters": [
@@ -196,7 +196,7 @@
                       "line": 9,
                       "column": 39
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                   }
                 },
                 "loc": {
@@ -208,7 +208,7 @@
                     "line": 9,
                     "column": 39
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                 }
               },
               "init": null,
@@ -229,7 +229,7 @@
                     "line": 9,
                     "column": 39
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                 }
               },
               "loc": {
@@ -241,7 +241,7 @@
                   "line": 9,
                   "column": 39
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
               }
             }
           ],
@@ -270,7 +270,7 @@
                           "line": 11,
                           "column": 19
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                       }
                     },
                     "loc": {
@@ -282,7 +282,7 @@
                         "line": 11,
                         "column": 19
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                     }
                   },
                   "arguments": [
@@ -299,7 +299,7 @@
                             "line": 11,
                             "column": 24
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                         }
                       },
                       "loc": {
@@ -311,7 +311,7 @@
                           "line": 11,
                           "column": 24
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                       }
                     },
                     {
@@ -327,7 +327,7 @@
                             "line": 11,
                             "column": 35
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                         }
                       },
                       "loc": {
@@ -339,7 +339,7 @@
                           "line": 11,
                           "column": 35
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                       }
                     }
                   ],
@@ -353,7 +353,7 @@
                         "line": 11,
                         "column": 39
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                     }
                   },
                   "loc": {
@@ -365,7 +365,7 @@
                       "line": 11,
                       "column": 39
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                   }
                 },
                 "isYield": false,
@@ -379,7 +379,7 @@
                       "line": 11,
                       "column": 40
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                   }
                 },
                 "loc": {
@@ -391,7 +391,7 @@
                     "line": 11,
                     "column": 40
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                 }
               }
             ],
@@ -406,7 +406,7 @@
                   "line": 12,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
               }
             },
             "loc": {
@@ -418,7 +418,7 @@
                 "line": 12,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
             }
           },
           "modifiers": [
@@ -434,7 +434,7 @@
                 "line": 12,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
             }
           },
           "loc": {
@@ -446,7 +446,7 @@
               "line": 12,
               "column": 6
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
           }
         }
       ],
@@ -461,7 +461,7 @@
             "line": 13,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
         }
       },
       "loc": {
@@ -473,13 +473,13 @@
           "line": 13,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -491,7 +491,7 @@
         "line": 14,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
     }
   },
   "loc": {
@@ -503,6 +503,6 @@
       "line": 14,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/modern-php.php.json
+++ b/parser-PHP/tests/benchmark/base/modern-php.php.json
@@ -16,7 +16,7 @@
               "line": 4,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+            "sourcefile": "modern-php.php"
           }
         },
         "loc": {
@@ -28,7 +28,7 @@
             "line": 4,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+          "sourcefile": "modern-php.php"
         }
       },
       "body": [
@@ -55,7 +55,7 @@
                       "line": 6,
                       "column": 20
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                    "sourcefile": "modern-php.php"
                   }
                 },
                 "loc": {
@@ -67,7 +67,7 @@
                     "line": 6,
                     "column": 20
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                  "sourcefile": "modern-php.php"
                 }
               },
               {
@@ -83,7 +83,7 @@
                       "line": 6,
                       "column": 32
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                    "sourcefile": "modern-php.php"
                   }
                 },
                 "loc": {
@@ -95,7 +95,7 @@
                     "line": 6,
                     "column": 32
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                  "sourcefile": "modern-php.php"
                 }
               }
             ],
@@ -110,7 +110,7 @@
                   "line": 6,
                   "column": 33
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                "sourcefile": "modern-php.php"
               }
             },
             "loc": {
@@ -122,7 +122,7 @@
                 "line": 6,
                 "column": 33
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+              "sourcefile": "modern-php.php"
             }
           },
           "_meta": {
@@ -135,7 +135,7 @@
                 "line": 6,
                 "column": 33
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+              "sourcefile": "modern-php.php"
             }
           },
           "loc": {
@@ -147,7 +147,7 @@
               "line": 6,
               "column": 33
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+            "sourcefile": "modern-php.php"
           }
         },
         {
@@ -165,7 +165,7 @@
                   "line": 9,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                "sourcefile": "modern-php.php"
               }
             },
             "loc": {
@@ -177,7 +177,7 @@
                 "line": 9,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+              "sourcefile": "modern-php.php"
             }
           },
           "parameters": [
@@ -196,7 +196,7 @@
                       "line": 9,
                       "column": 39
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                    "sourcefile": "modern-php.php"
                   }
                 },
                 "loc": {
@@ -208,7 +208,7 @@
                     "line": 9,
                     "column": 39
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                  "sourcefile": "modern-php.php"
                 }
               },
               "init": null,
@@ -229,7 +229,7 @@
                     "line": 9,
                     "column": 39
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                  "sourcefile": "modern-php.php"
                 }
               },
               "loc": {
@@ -241,7 +241,7 @@
                   "line": 9,
                   "column": 39
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                "sourcefile": "modern-php.php"
               }
             }
           ],
@@ -270,7 +270,7 @@
                           "line": 11,
                           "column": 19
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                        "sourcefile": "modern-php.php"
                       }
                     },
                     "loc": {
@@ -282,7 +282,7 @@
                         "line": 11,
                         "column": 19
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                      "sourcefile": "modern-php.php"
                     }
                   },
                   "arguments": [
@@ -299,7 +299,7 @@
                             "line": 11,
                             "column": 24
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                          "sourcefile": "modern-php.php"
                         }
                       },
                       "loc": {
@@ -311,7 +311,7 @@
                           "line": 11,
                           "column": 24
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                        "sourcefile": "modern-php.php"
                       }
                     },
                     {
@@ -327,7 +327,7 @@
                             "line": 11,
                             "column": 35
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                          "sourcefile": "modern-php.php"
                         }
                       },
                       "loc": {
@@ -339,7 +339,7 @@
                           "line": 11,
                           "column": 35
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                        "sourcefile": "modern-php.php"
                       }
                     }
                   ],
@@ -353,7 +353,7 @@
                         "line": 11,
                         "column": 39
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                      "sourcefile": "modern-php.php"
                     }
                   },
                   "loc": {
@@ -365,7 +365,7 @@
                       "line": 11,
                       "column": 39
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                    "sourcefile": "modern-php.php"
                   }
                 },
                 "isYield": false,
@@ -379,7 +379,7 @@
                       "line": 11,
                       "column": 40
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                    "sourcefile": "modern-php.php"
                   }
                 },
                 "loc": {
@@ -391,7 +391,7 @@
                     "line": 11,
                     "column": 40
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                  "sourcefile": "modern-php.php"
                 }
               }
             ],
@@ -406,7 +406,7 @@
                   "line": 12,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                "sourcefile": "modern-php.php"
               }
             },
             "loc": {
@@ -418,7 +418,7 @@
                 "line": 12,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+              "sourcefile": "modern-php.php"
             }
           },
           "modifiers": [
@@ -434,7 +434,7 @@
                 "line": 12,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+              "sourcefile": "modern-php.php"
             }
           },
           "loc": {
@@ -446,7 +446,7 @@
               "line": 12,
               "column": 6
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+            "sourcefile": "modern-php.php"
           }
         }
       ],
@@ -461,7 +461,7 @@
             "line": 13,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+          "sourcefile": "modern-php.php"
         }
       },
       "loc": {
@@ -473,13 +473,13 @@
           "line": 13,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+        "sourcefile": "modern-php.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php",
+  "uri": "modern-php.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -491,7 +491,7 @@
         "line": 14,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+      "sourcefile": "modern-php.php"
     }
   },
   "loc": {
@@ -503,6 +503,6 @@
       "line": 14,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+    "sourcefile": "modern-php.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/modern-php.php.json
+++ b/parser-PHP/tests/benchmark/base/modern-php.php.json
@@ -16,7 +16,7 @@
               "line": 4,
               "column": 14
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
           },
           "origin": {
             "kind": "identifier",
@@ -45,7 +45,7 @@
             "line": 4,
             "column": 14
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
         }
       },
       "body": [
@@ -72,7 +72,7 @@
                       "line": 6,
                       "column": 20
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                   },
                   "origin": {
                     "kind": "name",
@@ -102,7 +102,7 @@
                     "line": 6,
                     "column": 20
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                 }
               },
               {
@@ -118,7 +118,7 @@
                       "line": 6,
                       "column": 32
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                   },
                   "origin": {
                     "kind": "name",
@@ -148,7 +148,7 @@
                     "line": 6,
                     "column": 32
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                 }
               }
             ],
@@ -163,7 +163,7 @@
                   "line": 6,
                   "column": 33
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
               },
               "origin": {
                 "kind": "traituse",
@@ -230,7 +230,7 @@
                 "line": 6,
                 "column": 33
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
             }
           },
           "_meta": {
@@ -243,7 +243,7 @@
                 "line": 6,
                 "column": 33
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
             },
             "origin": {
               "kind": "traituse",
@@ -311,7 +311,7 @@
               "line": 6,
               "column": 33
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
           }
         },
         {
@@ -329,7 +329,7 @@
                   "line": 9,
                   "column": 24
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -358,7 +358,7 @@
                 "line": 9,
                 "column": 24
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
             }
           },
           "parameters": [
@@ -377,7 +377,7 @@
                       "line": 9,
                       "column": 39
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                   },
                   "origin": {
                     "kind": "identifier",
@@ -406,7 +406,7 @@
                     "line": 9,
                     "column": 39
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                 }
               },
               "init": null,
@@ -440,7 +440,7 @@
                                   "line": 9,
                                   "column": 34
                                 },
-                                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                               },
                               "origin": {
                                 "kind": "string",
@@ -472,7 +472,7 @@
                                 "line": 9,
                                 "column": 34
                               },
-                              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                             }
                           }
                         ]
@@ -489,7 +489,7 @@
                     "line": 9,
                     "column": 39
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                 },
                 "origin": {
                   "kind": "parameter",
@@ -600,7 +600,7 @@
                   "line": 9,
                   "column": 39
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
               }
             }
           ],
@@ -629,7 +629,7 @@
                           "line": 11,
                           "column": 19
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                       },
                       "origin": {
                         "kind": "name",
@@ -659,7 +659,7 @@
                         "line": 11,
                         "column": 19
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                     }
                   },
                   "arguments": [
@@ -676,7 +676,7 @@
                             "line": 11,
                             "column": 28
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                         },
                         "origin": {
                           "kind": "variable",
@@ -707,7 +707,7 @@
                           "line": 11,
                           "column": 28
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                       }
                     },
                     {
@@ -724,7 +724,7 @@
                             "line": 11,
                             "column": 38
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                         },
                         "origin": {
                           "kind": "number",
@@ -754,7 +754,7 @@
                           "line": 11,
                           "column": 38
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                       }
                     }
                   ],
@@ -768,7 +768,7 @@
                         "line": 11,
                         "column": 39
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                     },
                     "origin": {
                       "kind": "call",
@@ -885,7 +885,7 @@
                       "line": 11,
                       "column": 39
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                   }
                 },
                 "isYield": false,
@@ -899,7 +899,7 @@
                       "line": 11,
                       "column": 40
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                   },
                   "origin": {
                     "kind": "return",
@@ -1032,7 +1032,7 @@
                     "line": 11,
                     "column": 40
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                 }
               }
             ],
@@ -1047,7 +1047,7 @@
                   "line": 12,
                   "column": 6
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
               },
               "origin": {
                 "kind": "block",
@@ -1198,7 +1198,7 @@
                 "line": 12,
                 "column": 6
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
             }
           },
           "modifiers": [
@@ -1226,7 +1226,7 @@
                               "line": 8,
                               "column": 24
                             },
-                            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                           },
                           "origin": {
                             "kind": "string",
@@ -1259,7 +1259,7 @@
                             "line": 8,
                             "column": 24
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                         }
                       }
                     ]
@@ -1276,7 +1276,7 @@
                 "line": 12,
                 "column": 6
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
             },
             "origin": {
               "kind": "method",
@@ -1645,7 +1645,7 @@
               "line": 12,
               "column": 6
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
           }
         }
       ],
@@ -1676,7 +1676,7 @@
                           "line": 3,
                           "column": 13
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                       },
                       "origin": {
                         "kind": "string",
@@ -1708,7 +1708,7 @@
                         "line": 3,
                         "column": 13
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
                     }
                   }
                 ]
@@ -1725,7 +1725,7 @@
             "line": 13,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
         },
         "origin": {
           "kind": "class",
@@ -2249,13 +2249,13 @@
           "line": 13,
           "column": 2
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -2267,7 +2267,7 @@
         "line": 14,
         "column": 1
       },
-      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
     },
     "origin": {
       "kind": "program",
@@ -2811,6 +2811,6 @@
       "line": 14,
       "column": 1
     },
-    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/modern-php.php.json
+++ b/parser-PHP/tests/benchmark/base/modern-php.php.json
@@ -16,24 +16,7 @@
               "line": 4,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-          },
-          "origin": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 4,
-                "column": 6,
-                "offset": 28
-              },
-              "end": {
-                "line": 4,
-                "column": 13,
-                "offset": 35
-              }
-            },
-            "name": "Service"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
           }
         },
         "loc": {
@@ -45,7 +28,7 @@
             "line": 4,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
         }
       },
       "body": [
@@ -72,25 +55,7 @@
                       "line": 6,
                       "column": 20
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-                  },
-                  "origin": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 8,
-                        "offset": 46
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 19,
-                        "offset": 57
-                      }
-                    },
-                    "name": "LoggerTrait",
-                    "resolution": "uqn"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
                   }
                 },
                 "loc": {
@@ -102,7 +67,7 @@
                     "line": 6,
                     "column": 20
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
                 }
               },
               {
@@ -118,25 +83,7 @@
                       "line": 6,
                       "column": 32
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-                  },
-                  "origin": {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 21,
-                        "offset": 59
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 31,
-                        "offset": 69
-                      }
-                    },
-                    "name": "CacheTrait",
-                    "resolution": "uqn"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
                   }
                 },
                 "loc": {
@@ -148,7 +95,7 @@
                     "line": 6,
                     "column": 32
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
                 }
               }
             ],
@@ -163,62 +110,7 @@
                   "line": 6,
                   "column": 33
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-              },
-              "origin": {
-                "kind": "traituse",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 4,
-                    "offset": 42
-                  },
-                  "end": {
-                    "line": 6,
-                    "column": 32,
-                    "offset": 70
-                  }
-                },
-                "traits": [
-                  {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 8,
-                        "offset": 46
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 19,
-                        "offset": 57
-                      }
-                    },
-                    "name": "LoggerTrait",
-                    "resolution": "uqn"
-                  },
-                  {
-                    "kind": "name",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 21,
-                        "offset": 59
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 31,
-                        "offset": 69
-                      }
-                    },
-                    "name": "CacheTrait",
-                    "resolution": "uqn"
-                  }
-                ],
-                "adaptations": null
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
               }
             },
             "loc": {
@@ -230,7 +122,7 @@
                 "line": 6,
                 "column": 33
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
             }
           },
           "_meta": {
@@ -243,64 +135,8 @@
                 "line": 6,
                 "column": 33
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-            },
-            "origin": {
-              "kind": "traituse",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 6,
-                  "column": 4,
-                  "offset": 42
-                },
-                "end": {
-                  "line": 6,
-                  "column": 32,
-                  "offset": 70
-                }
-              },
-              "traits": [
-                {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 8,
-                      "offset": 46
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 19,
-                      "offset": 57
-                    }
-                  },
-                  "name": "LoggerTrait",
-                  "resolution": "uqn"
-                },
-                {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 21,
-                      "offset": 59
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 31,
-                      "offset": 69
-                    }
-                  },
-                  "name": "CacheTrait",
-                  "resolution": "uqn"
-                }
-              ],
-              "adaptations": null
-            },
-            "adaptations": []
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+            }
           },
           "loc": {
             "start": {
@@ -311,7 +147,7 @@
               "line": 6,
               "column": 33
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
           }
         },
         {
@@ -329,24 +165,7 @@
                   "line": 9,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 9,
-                    "column": 20,
-                    "offset": 118
-                  },
-                  "end": {
-                    "line": 9,
-                    "column": 23,
-                    "offset": 121
-                  }
-                },
-                "name": "run"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
               }
             },
             "loc": {
@@ -358,7 +177,7 @@
                 "line": 9,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
             }
           },
           "parameters": [
@@ -377,24 +196,7 @@
                       "line": 9,
                       "column": 39
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-                  },
-                  "origin": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 36,
-                        "offset": 134
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 38,
-                        "offset": 136
-                      }
-                    },
-                    "name": "x"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
                   }
                 },
                 "loc": {
@@ -406,7 +208,7 @@
                     "line": 9,
                     "column": 39
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
                 }
               },
               "init": null,
@@ -417,69 +219,7 @@
                 "_meta": {}
               },
               "_meta": {
-                "byref": false,
                 "variadic": false,
-                "attributes": [
-                  {
-                    "type": "AttributeGroup",
-                    "attributes": [
-                      {
-                        "name": "Tag",
-                        "args": [
-                          {
-                            "type": "Literal",
-                            "value": "x",
-                            "literalType": "string",
-                            "_meta": {
-                              "loc": {
-                                "start": {
-                                  "line": 9,
-                                  "column": 31
-                                },
-                                "end": {
-                                  "line": 9,
-                                  "column": 34
-                                },
-                                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-                              },
-                              "origin": {
-                                "kind": "string",
-                                "loc": {
-                                  "source": null,
-                                  "start": {
-                                    "line": 9,
-                                    "column": 30,
-                                    "offset": 128
-                                  },
-                                  "end": {
-                                    "line": 9,
-                                    "column": 33,
-                                    "offset": 131
-                                  }
-                                },
-                                "value": "x",
-                                "raw": "'x'",
-                                "unicode": false,
-                                "isDoubleQuote": false
-                              }
-                            },
-                            "loc": {
-                              "start": {
-                                "line": 9,
-                                "column": 31
-                              },
-                              "end": {
-                                "line": 9,
-                                "column": 34
-                              },
-                              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ],
                 "loc": {
                   "start": {
                     "line": 9,
@@ -489,106 +229,7 @@
                     "line": 9,
                     "column": 39
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-                },
-                "origin": {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 9,
-                      "column": 24,
-                      "offset": 122
-                    },
-                    "end": {
-                      "line": 9,
-                      "column": 38,
-                      "offset": 136
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 36,
-                        "offset": 134
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 38,
-                        "offset": 136
-                      }
-                    },
-                    "name": "x"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": [
-                    {
-                      "kind": "attrgroup",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 24,
-                          "offset": 122
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 24,
-                          "offset": 122
-                        }
-                      },
-                      "attrs": [
-                        {
-                          "kind": "attribute",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 9,
-                              "column": 34,
-                              "offset": 132
-                            },
-                            "end": {
-                              "line": 9,
-                              "column": 34,
-                              "offset": 132
-                            }
-                          },
-                          "name": "Tag",
-                          "args": [
-                            {
-                              "kind": "string",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 9,
-                                  "column": 30,
-                                  "offset": 128
-                                },
-                                "end": {
-                                  "line": 9,
-                                  "column": 33,
-                                  "offset": 131
-                                }
-                              },
-                              "value": "x",
-                              "raw": "'x'",
-                              "unicode": false,
-                              "isDoubleQuote": false
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
                 }
               },
               "loc": {
@@ -600,7 +241,7 @@
                   "line": 9,
                   "column": 39
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
               }
             }
           ],
@@ -629,25 +270,7 @@
                           "line": 11,
                           "column": 19
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-                      },
-                      "origin": {
-                        "kind": "name",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 15,
-                            "offset": 159
-                          },
-                          "end": {
-                            "line": 11,
-                            "column": 18,
-                            "offset": 162
-                          }
-                        },
-                        "name": "foo",
-                        "resolution": "uqn"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
                       }
                     },
                     "loc": {
@@ -659,102 +282,64 @@
                         "line": 11,
                         "column": 19
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
                     }
                   },
                   "arguments": [
                     {
                       "type": "Identifier",
-                      "name": "x",
+                      "name": "name",
                       "_meta": {
                         "loc": {
                           "start": {
                             "line": 11,
-                            "column": 26
+                            "column": 20
                           },
                           "end": {
                             "line": 11,
-                            "column": 28
+                            "column": 24
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-                        },
-                        "origin": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 25,
-                              "offset": 169
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 27,
-                              "offset": 171
-                            }
-                          },
-                          "name": "x",
-                          "curly": false
-                        },
-                        "argName": "name"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                        }
                       },
                       "loc": {
                         "start": {
                           "line": 11,
-                          "column": 26
+                          "column": 20
                         },
                         "end": {
                           "line": 11,
-                          "column": 28
+                          "column": 24
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
                       }
                     },
                     {
-                      "type": "Literal",
-                      "value": 1,
-                      "literalType": "number",
+                      "type": "Identifier",
+                      "name": "count",
                       "_meta": {
                         "loc": {
                           "start": {
                             "line": 11,
-                            "column": 37
+                            "column": 30
                           },
                           "end": {
                             "line": 11,
-                            "column": 38
+                            "column": 35
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-                        },
-                        "origin": {
-                          "kind": "number",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 36,
-                              "offset": 180
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 37,
-                              "offset": 181
-                            }
-                          },
-                          "value": "1"
-                        },
-                        "argName": "count"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
+                        }
                       },
                       "loc": {
                         "start": {
                           "line": 11,
-                          "column": 37
+                          "column": 30
                         },
                         "end": {
                           "line": 11,
-                          "column": 38
+                          "column": 35
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
                       }
                     }
                   ],
@@ -768,112 +353,7 @@
                         "line": 11,
                         "column": 39
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-                    },
-                    "origin": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 11,
-                          "column": 15,
-                          "offset": 159
-                        },
-                        "end": {
-                          "line": 11,
-                          "column": 38,
-                          "offset": 182
-                        }
-                      },
-                      "what": {
-                        "kind": "name",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 15,
-                            "offset": 159
-                          },
-                          "end": {
-                            "line": 11,
-                            "column": 18,
-                            "offset": 162
-                          }
-                        },
-                        "name": "foo",
-                        "resolution": "uqn"
-                      },
-                      "arguments": [
-                        {
-                          "kind": "namedargument",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 19,
-                              "offset": 163
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 27,
-                              "offset": 171
-                            }
-                          },
-                          "name": "name",
-                          "value": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 25,
-                                "offset": 169
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 27,
-                                "offset": 171
-                              }
-                            },
-                            "name": "x",
-                            "curly": false
-                          }
-                        },
-                        {
-                          "kind": "namedargument",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 29,
-                              "offset": 173
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 37,
-                              "offset": 181
-                            }
-                          },
-                          "name": "count",
-                          "value": {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 36,
-                                "offset": 180
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 37,
-                                "offset": 181
-                              }
-                            },
-                            "value": "1"
-                          }
-                        }
-                      ]
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
                     }
                   },
                   "loc": {
@@ -885,7 +365,7 @@
                       "line": 11,
                       "column": 39
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
                   }
                 },
                 "isYield": false,
@@ -899,128 +379,7 @@
                       "line": 11,
                       "column": 40
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-                  },
-                  "origin": {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 11,
-                        "column": 8,
-                        "offset": 152
-                      },
-                      "end": {
-                        "line": 11,
-                        "column": 39,
-                        "offset": 183
-                      }
-                    },
-                    "expr": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 11,
-                          "column": 15,
-                          "offset": 159
-                        },
-                        "end": {
-                          "line": 11,
-                          "column": 38,
-                          "offset": 182
-                        }
-                      },
-                      "what": {
-                        "kind": "name",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 15,
-                            "offset": 159
-                          },
-                          "end": {
-                            "line": 11,
-                            "column": 18,
-                            "offset": 162
-                          }
-                        },
-                        "name": "foo",
-                        "resolution": "uqn"
-                      },
-                      "arguments": [
-                        {
-                          "kind": "namedargument",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 19,
-                              "offset": 163
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 27,
-                              "offset": 171
-                            }
-                          },
-                          "name": "name",
-                          "value": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 25,
-                                "offset": 169
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 27,
-                                "offset": 171
-                              }
-                            },
-                            "name": "x",
-                            "curly": false
-                          }
-                        },
-                        {
-                          "kind": "namedargument",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 29,
-                              "offset": 173
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 37,
-                              "offset": 181
-                            }
-                          },
-                          "name": "count",
-                          "value": {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 36,
-                                "offset": 180
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 37,
-                                "offset": 181
-                              }
-                            },
-                            "value": "1"
-                          }
-                        }
-                      ]
-                    }
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
                   }
                 },
                 "loc": {
@@ -1032,7 +391,7 @@
                     "line": 11,
                     "column": 40
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
                 }
               }
             ],
@@ -1047,146 +406,7 @@
                   "line": 12,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-              },
-              "origin": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 10,
-                    "column": 4,
-                    "offset": 142
-                  },
-                  "end": {
-                    "line": 12,
-                    "column": 5,
-                    "offset": 189
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 11,
-                        "column": 8,
-                        "offset": 152
-                      },
-                      "end": {
-                        "line": 11,
-                        "column": 39,
-                        "offset": 183
-                      }
-                    },
-                    "expr": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 11,
-                          "column": 15,
-                          "offset": 159
-                        },
-                        "end": {
-                          "line": 11,
-                          "column": 38,
-                          "offset": 182
-                        }
-                      },
-                      "what": {
-                        "kind": "name",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 15,
-                            "offset": 159
-                          },
-                          "end": {
-                            "line": 11,
-                            "column": 18,
-                            "offset": 162
-                          }
-                        },
-                        "name": "foo",
-                        "resolution": "uqn"
-                      },
-                      "arguments": [
-                        {
-                          "kind": "namedargument",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 19,
-                              "offset": 163
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 27,
-                              "offset": 171
-                            }
-                          },
-                          "name": "name",
-                          "value": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 25,
-                                "offset": 169
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 27,
-                                "offset": 171
-                              }
-                            },
-                            "name": "x",
-                            "curly": false
-                          }
-                        },
-                        {
-                          "kind": "namedargument",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 29,
-                              "offset": 173
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 37,
-                              "offset": 181
-                            }
-                          },
-                          "name": "count",
-                          "value": {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 36,
-                                "offset": 180
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 37,
-                                "offset": 181
-                              }
-                            },
-                            "value": "1"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
               }
             },
             "loc": {
@@ -1198,1064 +418,68 @@
                 "line": 12,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
             }
           },
           "modifiers": [
             "public"
           ],
           "_meta": {
-            "attributes": [
-              {
-                "type": "AttributeGroup",
-                "attributes": [
-                  {
-                    "name": "Inject",
-                    "args": [
-                      {
-                        "type": "Literal",
-                        "value": "db",
-                        "literalType": "string",
-                        "_meta": {
-                          "loc": {
-                            "start": {
-                              "line": 8,
-                              "column": 20
-                            },
-                            "end": {
-                              "line": 8,
-                              "column": 24
-                            },
-                            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-                          },
-                          "origin": {
-                            "kind": "string",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 8,
-                                "column": 19,
-                                "offset": 91
-                              },
-                              "end": {
-                                "line": 8,
-                                "column": 23,
-                                "offset": 95
-                              }
-                            },
-                            "value": "db",
-                            "raw": "'db'",
-                            "unicode": false,
-                            "isDoubleQuote": false
-                          },
-                          "argName": "name"
-                        },
-                        "loc": {
-                          "start": {
-                            "line": 8,
-                            "column": 20
-                          },
-                          "end": {
-                            "line": 8,
-                            "column": 24
-                          },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
             "loc": {
               "start": {
-                "line": 9,
+                "line": 8,
                 "column": 5
               },
               "end": {
                 "line": 12,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-            },
-            "origin": {
-              "kind": "method",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 9,
-                  "column": 4,
-                  "offset": 102
-                },
-                "end": {
-                  "line": 12,
-                  "column": 5,
-                  "offset": 189
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 9,
-                    "column": 20,
-                    "offset": 118
-                  },
-                  "end": {
-                    "line": 9,
-                    "column": 23,
-                    "offset": 121
-                  }
-                },
-                "name": "run"
-              },
-              "arguments": [
-                {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 9,
-                      "column": 24,
-                      "offset": 122
-                    },
-                    "end": {
-                      "line": 9,
-                      "column": 38,
-                      "offset": 136
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 36,
-                        "offset": 134
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 38,
-                        "offset": 136
-                      }
-                    },
-                    "name": "x"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": [
-                    {
-                      "kind": "attrgroup",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 24,
-                          "offset": 122
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 24,
-                          "offset": 122
-                        }
-                      },
-                      "attrs": [
-                        {
-                          "kind": "attribute",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 9,
-                              "column": 34,
-                              "offset": 132
-                            },
-                            "end": {
-                              "line": 9,
-                              "column": 34,
-                              "offset": 132
-                            }
-                          },
-                          "name": "Tag",
-                          "args": [
-                            {
-                              "kind": "string",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 9,
-                                  "column": 30,
-                                  "offset": 128
-                                },
-                                "end": {
-                                  "line": 9,
-                                  "column": 33,
-                                  "offset": 131
-                                }
-                              },
-                              "value": "x",
-                              "raw": "'x'",
-                              "unicode": false,
-                              "isDoubleQuote": false
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "byref": false,
-              "type": null,
-              "nullable": false,
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 10,
-                    "column": 4,
-                    "offset": 142
-                  },
-                  "end": {
-                    "line": 12,
-                    "column": 5,
-                    "offset": 189
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 11,
-                        "column": 8,
-                        "offset": 152
-                      },
-                      "end": {
-                        "line": 11,
-                        "column": 39,
-                        "offset": 183
-                      }
-                    },
-                    "expr": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 11,
-                          "column": 15,
-                          "offset": 159
-                        },
-                        "end": {
-                          "line": 11,
-                          "column": 38,
-                          "offset": 182
-                        }
-                      },
-                      "what": {
-                        "kind": "name",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 15,
-                            "offset": 159
-                          },
-                          "end": {
-                            "line": 11,
-                            "column": 18,
-                            "offset": 162
-                          }
-                        },
-                        "name": "foo",
-                        "resolution": "uqn"
-                      },
-                      "arguments": [
-                        {
-                          "kind": "namedargument",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 19,
-                              "offset": 163
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 27,
-                              "offset": 171
-                            }
-                          },
-                          "name": "name",
-                          "value": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 25,
-                                "offset": 169
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 27,
-                                "offset": 171
-                              }
-                            },
-                            "name": "x",
-                            "curly": false
-                          }
-                        },
-                        {
-                          "kind": "namedargument",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 29,
-                              "offset": 173
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 37,
-                              "offset": 181
-                            }
-                          },
-                          "name": "count",
-                          "value": {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 36,
-                                "offset": 180
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 37,
-                                "offset": 181
-                              }
-                            },
-                            "value": "1"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              },
-              "attrGroups": [
-                {
-                  "kind": "attrgroup",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 4,
-                      "offset": 76
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 32,
-                      "offset": 70
-                    }
-                  },
-                  "attrs": [
-                    {
-                      "kind": "attribute",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 8,
-                          "column": 24,
-                          "offset": 96
-                        },
-                        "end": {
-                          "line": 8,
-                          "column": 24,
-                          "offset": 96
-                        }
-                      },
-                      "name": "Inject",
-                      "args": [
-                        {
-                          "kind": "namedargument",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 8,
-                              "column": 13,
-                              "offset": 85
-                            },
-                            "end": {
-                              "line": 8,
-                              "column": 23,
-                              "offset": 95
-                            }
-                          },
-                          "name": "name",
-                          "value": {
-                            "kind": "string",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 8,
-                                "column": 19,
-                                "offset": 91
-                              },
-                              "end": {
-                                "line": 8,
-                                "column": 23,
-                                "offset": 95
-                              }
-                            },
-                            "value": "db",
-                            "raw": "'db'",
-                            "unicode": false,
-                            "isDoubleQuote": false
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "isAbstract": false,
-              "isFinal": false,
-              "isReadonly": false,
-              "visibility": "public",
-              "isStatic": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
             }
           },
           "loc": {
             "start": {
-              "line": 9,
+              "line": 8,
               "column": 5
             },
             "end": {
               "line": 12,
               "column": 6
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
           }
         }
       ],
       "supers": [],
       "_meta": {
-        "implements": [],
-        "isAbstract": false,
-        "isFinal": false,
-        "isReadonly": false,
-        "attributes": [
-          {
-            "type": "AttributeGroup",
-            "attributes": [
-              {
-                "name": "Route",
-                "args": [
-                  {
-                    "type": "Literal",
-                    "value": "/a",
-                    "literalType": "string",
-                    "_meta": {
-                      "loc": {
-                        "start": {
-                          "line": 3,
-                          "column": 9
-                        },
-                        "end": {
-                          "line": 3,
-                          "column": 13
-                        },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-                      },
-                      "origin": {
-                        "kind": "string",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 3,
-                            "column": 8,
-                            "offset": 15
-                          },
-                          "end": {
-                            "line": 3,
-                            "column": 12,
-                            "offset": 19
-                          }
-                        },
-                        "value": "/a",
-                        "raw": "'/a'",
-                        "unicode": false,
-                        "isDoubleQuote": false
-                      }
-                    },
-                    "loc": {
-                      "start": {
-                        "line": 3,
-                        "column": 9
-                      },
-                      "end": {
-                        "line": 3,
-                        "column": 13
-                      },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        ],
         "loc": {
           "start": {
-            "line": 4,
+            "line": 3,
             "column": 1
           },
           "end": {
             "line": 13,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-        },
-        "origin": {
-          "kind": "class",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 4,
-              "column": 0,
-              "offset": 22
-            },
-            "end": {
-              "line": 13,
-              "column": 1,
-              "offset": 191
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 4,
-                "column": 6,
-                "offset": 28
-              },
-              "end": {
-                "line": 4,
-                "column": 13,
-                "offset": 35
-              }
-            },
-            "name": "Service"
-          },
-          "isAnonymous": false,
-          "extends": null,
-          "implements": null,
-          "body": [
-            {
-              "kind": "traituse",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 6,
-                  "column": 4,
-                  "offset": 42
-                },
-                "end": {
-                  "line": 6,
-                  "column": 32,
-                  "offset": 70
-                }
-              },
-              "traits": [
-                {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 8,
-                      "offset": 46
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 19,
-                      "offset": 57
-                    }
-                  },
-                  "name": "LoggerTrait",
-                  "resolution": "uqn"
-                },
-                {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 21,
-                      "offset": 59
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 31,
-                      "offset": 69
-                    }
-                  },
-                  "name": "CacheTrait",
-                  "resolution": "uqn"
-                }
-              ],
-              "adaptations": null
-            },
-            {
-              "kind": "method",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 9,
-                  "column": 4,
-                  "offset": 102
-                },
-                "end": {
-                  "line": 12,
-                  "column": 5,
-                  "offset": 189
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 9,
-                    "column": 20,
-                    "offset": 118
-                  },
-                  "end": {
-                    "line": 9,
-                    "column": 23,
-                    "offset": 121
-                  }
-                },
-                "name": "run"
-              },
-              "arguments": [
-                {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 9,
-                      "column": 24,
-                      "offset": 122
-                    },
-                    "end": {
-                      "line": 9,
-                      "column": 38,
-                      "offset": 136
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 36,
-                        "offset": 134
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 38,
-                        "offset": 136
-                      }
-                    },
-                    "name": "x"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": [
-                    {
-                      "kind": "attrgroup",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 24,
-                          "offset": 122
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 24,
-                          "offset": 122
-                        }
-                      },
-                      "attrs": [
-                        {
-                          "kind": "attribute",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 9,
-                              "column": 34,
-                              "offset": 132
-                            },
-                            "end": {
-                              "line": 9,
-                              "column": 34,
-                              "offset": 132
-                            }
-                          },
-                          "name": "Tag",
-                          "args": [
-                            {
-                              "kind": "string",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 9,
-                                  "column": 30,
-                                  "offset": 128
-                                },
-                                "end": {
-                                  "line": 9,
-                                  "column": 33,
-                                  "offset": 131
-                                }
-                              },
-                              "value": "x",
-                              "raw": "'x'",
-                              "unicode": false,
-                              "isDoubleQuote": false
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "byref": false,
-              "type": null,
-              "nullable": false,
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 10,
-                    "column": 4,
-                    "offset": 142
-                  },
-                  "end": {
-                    "line": 12,
-                    "column": 5,
-                    "offset": 189
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 11,
-                        "column": 8,
-                        "offset": 152
-                      },
-                      "end": {
-                        "line": 11,
-                        "column": 39,
-                        "offset": 183
-                      }
-                    },
-                    "expr": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 11,
-                          "column": 15,
-                          "offset": 159
-                        },
-                        "end": {
-                          "line": 11,
-                          "column": 38,
-                          "offset": 182
-                        }
-                      },
-                      "what": {
-                        "kind": "name",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 15,
-                            "offset": 159
-                          },
-                          "end": {
-                            "line": 11,
-                            "column": 18,
-                            "offset": 162
-                          }
-                        },
-                        "name": "foo",
-                        "resolution": "uqn"
-                      },
-                      "arguments": [
-                        {
-                          "kind": "namedargument",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 19,
-                              "offset": 163
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 27,
-                              "offset": 171
-                            }
-                          },
-                          "name": "name",
-                          "value": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 25,
-                                "offset": 169
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 27,
-                                "offset": 171
-                              }
-                            },
-                            "name": "x",
-                            "curly": false
-                          }
-                        },
-                        {
-                          "kind": "namedargument",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 29,
-                              "offset": 173
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 37,
-                              "offset": 181
-                            }
-                          },
-                          "name": "count",
-                          "value": {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 36,
-                                "offset": 180
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 37,
-                                "offset": 181
-                              }
-                            },
-                            "value": "1"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              },
-              "attrGroups": [
-                {
-                  "kind": "attrgroup",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 4,
-                      "offset": 76
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 32,
-                      "offset": 70
-                    }
-                  },
-                  "attrs": [
-                    {
-                      "kind": "attribute",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 8,
-                          "column": 24,
-                          "offset": 96
-                        },
-                        "end": {
-                          "line": 8,
-                          "column": 24,
-                          "offset": 96
-                        }
-                      },
-                      "name": "Inject",
-                      "args": [
-                        {
-                          "kind": "namedargument",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 8,
-                              "column": 13,
-                              "offset": 85
-                            },
-                            "end": {
-                              "line": 8,
-                              "column": 23,
-                              "offset": 95
-                            }
-                          },
-                          "name": "name",
-                          "value": {
-                            "kind": "string",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 8,
-                                "column": 19,
-                                "offset": 91
-                              },
-                              "end": {
-                                "line": 8,
-                                "column": 23,
-                                "offset": 95
-                              }
-                            },
-                            "value": "db",
-                            "raw": "'db'",
-                            "unicode": false,
-                            "isDoubleQuote": false
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "isAbstract": false,
-              "isFinal": false,
-              "isReadonly": false,
-              "visibility": "public",
-              "isStatic": false
-            }
-          ],
-          "attrGroups": [
-            {
-              "kind": "attrgroup",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 0,
-                  "offset": 7
-                },
-                "end": {
-                  "line": 1,
-                  "column": 0,
-                  "offset": 0
-                }
-              },
-              "attrs": [
-                {
-                  "kind": "attribute",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 13,
-                      "offset": 20
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 13,
-                      "offset": 20
-                    }
-                  },
-                  "name": "Route",
-                  "args": [
-                    {
-                      "kind": "string",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 3,
-                          "column": 8,
-                          "offset": 15
-                        },
-                        "end": {
-                          "line": 3,
-                          "column": 12,
-                          "offset": 19
-                        }
-                      },
-                      "value": "/a",
-                      "raw": "'/a'",
-                      "unicode": false,
-                      "isDoubleQuote": false
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
-          "isAbstract": false,
-          "isFinal": false,
-          "isReadonly": false
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
         }
       },
       "loc": {
         "start": {
-          "line": 4,
+          "line": 3,
           "column": 1
         },
         "end": {
           "line": 13,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -2267,539 +491,7 @@
         "line": 14,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
-    },
-    "origin": {
-      "kind": "program",
-      "loc": {
-        "source": null,
-        "start": {
-          "line": 1,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "line": 14,
-          "column": 0,
-          "offset": 192
-        }
-      },
-      "children": [
-        {
-          "kind": "class",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 4,
-              "column": 0,
-              "offset": 22
-            },
-            "end": {
-              "line": 13,
-              "column": 1,
-              "offset": 191
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 4,
-                "column": 6,
-                "offset": 28
-              },
-              "end": {
-                "line": 4,
-                "column": 13,
-                "offset": 35
-              }
-            },
-            "name": "Service"
-          },
-          "isAnonymous": false,
-          "extends": null,
-          "implements": null,
-          "body": [
-            {
-              "kind": "traituse",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 6,
-                  "column": 4,
-                  "offset": 42
-                },
-                "end": {
-                  "line": 6,
-                  "column": 32,
-                  "offset": 70
-                }
-              },
-              "traits": [
-                {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 8,
-                      "offset": 46
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 19,
-                      "offset": 57
-                    }
-                  },
-                  "name": "LoggerTrait",
-                  "resolution": "uqn"
-                },
-                {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 21,
-                      "offset": 59
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 31,
-                      "offset": 69
-                    }
-                  },
-                  "name": "CacheTrait",
-                  "resolution": "uqn"
-                }
-              ],
-              "adaptations": null
-            },
-            {
-              "kind": "method",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 9,
-                  "column": 4,
-                  "offset": 102
-                },
-                "end": {
-                  "line": 12,
-                  "column": 5,
-                  "offset": 189
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 9,
-                    "column": 20,
-                    "offset": 118
-                  },
-                  "end": {
-                    "line": 9,
-                    "column": 23,
-                    "offset": 121
-                  }
-                },
-                "name": "run"
-              },
-              "arguments": [
-                {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 9,
-                      "column": 24,
-                      "offset": 122
-                    },
-                    "end": {
-                      "line": 9,
-                      "column": 38,
-                      "offset": 136
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 9,
-                        "column": 36,
-                        "offset": 134
-                      },
-                      "end": {
-                        "line": 9,
-                        "column": 38,
-                        "offset": 136
-                      }
-                    },
-                    "name": "x"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": [
-                    {
-                      "kind": "attrgroup",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 9,
-                          "column": 24,
-                          "offset": 122
-                        },
-                        "end": {
-                          "line": 9,
-                          "column": 24,
-                          "offset": 122
-                        }
-                      },
-                      "attrs": [
-                        {
-                          "kind": "attribute",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 9,
-                              "column": 34,
-                              "offset": 132
-                            },
-                            "end": {
-                              "line": 9,
-                              "column": 34,
-                              "offset": 132
-                            }
-                          },
-                          "name": "Tag",
-                          "args": [
-                            {
-                              "kind": "string",
-                              "loc": {
-                                "source": null,
-                                "start": {
-                                  "line": 9,
-                                  "column": 30,
-                                  "offset": 128
-                                },
-                                "end": {
-                                  "line": 9,
-                                  "column": 33,
-                                  "offset": 131
-                                }
-                              },
-                              "value": "x",
-                              "raw": "'x'",
-                              "unicode": false,
-                              "isDoubleQuote": false
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "byref": false,
-              "type": null,
-              "nullable": false,
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 10,
-                    "column": 4,
-                    "offset": 142
-                  },
-                  "end": {
-                    "line": 12,
-                    "column": 5,
-                    "offset": 189
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 11,
-                        "column": 8,
-                        "offset": 152
-                      },
-                      "end": {
-                        "line": 11,
-                        "column": 39,
-                        "offset": 183
-                      }
-                    },
-                    "expr": {
-                      "kind": "call",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 11,
-                          "column": 15,
-                          "offset": 159
-                        },
-                        "end": {
-                          "line": 11,
-                          "column": 38,
-                          "offset": 182
-                        }
-                      },
-                      "what": {
-                        "kind": "name",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 11,
-                            "column": 15,
-                            "offset": 159
-                          },
-                          "end": {
-                            "line": 11,
-                            "column": 18,
-                            "offset": 162
-                          }
-                        },
-                        "name": "foo",
-                        "resolution": "uqn"
-                      },
-                      "arguments": [
-                        {
-                          "kind": "namedargument",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 19,
-                              "offset": 163
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 27,
-                              "offset": 171
-                            }
-                          },
-                          "name": "name",
-                          "value": {
-                            "kind": "variable",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 25,
-                                "offset": 169
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 27,
-                                "offset": 171
-                              }
-                            },
-                            "name": "x",
-                            "curly": false
-                          }
-                        },
-                        {
-                          "kind": "namedargument",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 11,
-                              "column": 29,
-                              "offset": 173
-                            },
-                            "end": {
-                              "line": 11,
-                              "column": 37,
-                              "offset": 181
-                            }
-                          },
-                          "name": "count",
-                          "value": {
-                            "kind": "number",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 11,
-                                "column": 36,
-                                "offset": 180
-                              },
-                              "end": {
-                                "line": 11,
-                                "column": 37,
-                                "offset": 181
-                              }
-                            },
-                            "value": "1"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              },
-              "attrGroups": [
-                {
-                  "kind": "attrgroup",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 4,
-                      "offset": 76
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 32,
-                      "offset": 70
-                    }
-                  },
-                  "attrs": [
-                    {
-                      "kind": "attribute",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 8,
-                          "column": 24,
-                          "offset": 96
-                        },
-                        "end": {
-                          "line": 8,
-                          "column": 24,
-                          "offset": 96
-                        }
-                      },
-                      "name": "Inject",
-                      "args": [
-                        {
-                          "kind": "namedargument",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 8,
-                              "column": 13,
-                              "offset": 85
-                            },
-                            "end": {
-                              "line": 8,
-                              "column": 23,
-                              "offset": 95
-                            }
-                          },
-                          "name": "name",
-                          "value": {
-                            "kind": "string",
-                            "loc": {
-                              "source": null,
-                              "start": {
-                                "line": 8,
-                                "column": 19,
-                                "offset": 91
-                              },
-                              "end": {
-                                "line": 8,
-                                "column": 23,
-                                "offset": 95
-                              }
-                            },
-                            "value": "db",
-                            "raw": "'db'",
-                            "unicode": false,
-                            "isDoubleQuote": false
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "isAbstract": false,
-              "isFinal": false,
-              "isReadonly": false,
-              "visibility": "public",
-              "isStatic": false
-            }
-          ],
-          "attrGroups": [
-            {
-              "kind": "attrgroup",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 0,
-                  "offset": 7
-                },
-                "end": {
-                  "line": 1,
-                  "column": 0,
-                  "offset": 0
-                }
-              },
-              "attrs": [
-                {
-                  "kind": "attribute",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 13,
-                      "offset": 20
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 13,
-                      "offset": 20
-                    }
-                  },
-                  "name": "Route",
-                  "args": [
-                    {
-                      "kind": "string",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 3,
-                          "column": 8,
-                          "offset": 15
-                        },
-                        "end": {
-                          "line": 3,
-                          "column": 12,
-                          "offset": 19
-                        }
-                      },
-                      "value": "/a",
-                      "raw": "'/a'",
-                      "unicode": false,
-                      "isDoubleQuote": false
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
-          "isAbstract": false,
-          "isFinal": false,
-          "isReadonly": false
-        }
-      ],
-      "errors": [],
-      "comments": []
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
     }
   },
   "loc": {
@@ -2811,6 +503,6 @@
       "line": 14,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/modern-php.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/modern-php.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/namespace.php.json
+++ b/parser-PHP/tests/benchmark/base/namespace.php.json
@@ -18,7 +18,7 @@
             "line": 5,
             "column": 22
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
         },
         "origin": {
           "kind": "namespace",
@@ -213,7 +213,7 @@
           "line": 5,
           "column": 22
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
       }
     },
     {
@@ -239,7 +239,7 @@
                 "line": 3,
                 "column": 17
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
             },
             "origin": {
               "kind": "identifier",
@@ -268,7 +268,7 @@
               "line": 3,
               "column": 17
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
           }
         },
         "imported": null,
@@ -282,7 +282,7 @@
               "line": 3,
               "column": 17
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
           },
           "origin": {
             "kind": "useitem",
@@ -329,7 +329,7 @@
             "line": 3,
             "column": 17
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
         }
       },
       "_meta": {}
@@ -352,7 +352,7 @@
                 "line": 4,
                 "column": 16
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
             },
             "origin": {
               "kind": "string",
@@ -384,7 +384,7 @@
               "line": 4,
               "column": 16
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
           }
         },
         "local": null,
@@ -401,7 +401,7 @@
               "line": 4,
               "column": 17
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
           },
           "origin": {
             "kind": "include",
@@ -451,7 +451,7 @@
             "line": 4,
             "column": 17
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
         }
       },
       "_meta": {
@@ -464,7 +464,7 @@
             "line": 4,
             "column": 17
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
         },
         "origin": {
           "kind": "expressionstatement",
@@ -530,7 +530,7 @@
           "line": 4,
           "column": 17
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
       }
     },
     {
@@ -551,7 +551,7 @@
                 "line": 5,
                 "column": 21
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
             },
             "origin": {
               "kind": "string",
@@ -583,7 +583,7 @@
               "line": 5,
               "column": 21
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
           }
         },
         "local": null,
@@ -600,7 +600,7 @@
               "line": 5,
               "column": 22
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
           },
           "origin": {
             "kind": "include",
@@ -650,7 +650,7 @@
             "line": 5,
             "column": 22
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
         }
       },
       "_meta": {
@@ -663,7 +663,7 @@
             "line": 5,
             "column": 22
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
         },
         "origin": {
           "kind": "expressionstatement",
@@ -729,13 +729,13 @@
           "line": 5,
           "column": 22
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -747,7 +747,7 @@
         "line": 6,
         "column": 1
       },
-      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
     },
     "origin": {
       "kind": "program",
@@ -962,6 +962,6 @@
       "line": 6,
       "column": 1
     },
-    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/namespace.php.json
+++ b/parser-PHP/tests/benchmark/base/namespace.php.json
@@ -18,7 +18,7 @@
             "line": 2,
             "column": 18
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
         }
       },
       "loc": {
@@ -30,7 +30,7 @@
           "line": 2,
           "column": 18
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
       }
     },
     {
@@ -56,7 +56,7 @@
                 "line": 3,
                 "column": 17
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
             }
           },
           "loc": {
@@ -68,7 +68,7 @@
               "line": 3,
               "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
           }
         },
         "imported": null,
@@ -82,7 +82,7 @@
               "line": 3,
               "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
           }
         },
         "loc": {
@@ -94,7 +94,7 @@
             "line": 3,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
         }
       },
       "_meta": {}
@@ -117,7 +117,7 @@
                 "line": 4,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
             },
             "encapsed": true
           },
@@ -130,7 +130,7 @@
               "line": 4,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
           }
         },
         "local": null,
@@ -147,7 +147,7 @@
               "line": 4,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
           }
         },
         "loc": {
@@ -159,7 +159,7 @@
             "line": 4,
             "column": 16
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
         }
       },
       "_meta": {
@@ -172,7 +172,7 @@
             "line": 4,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
         }
       },
       "loc": {
@@ -184,7 +184,7 @@
           "line": 4,
           "column": 17
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
       }
     },
     {
@@ -205,7 +205,7 @@
                 "line": 5,
                 "column": 21
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
             },
             "encapsed": true
           },
@@ -218,7 +218,7 @@
               "line": 5,
               "column": 21
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
           }
         },
         "local": null,
@@ -235,7 +235,7 @@
               "line": 5,
               "column": 21
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
           }
         },
         "loc": {
@@ -247,7 +247,7 @@
             "line": 5,
             "column": 21
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
         }
       },
       "_meta": {
@@ -260,7 +260,7 @@
             "line": 5,
             "column": 22
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
         }
       },
       "loc": {
@@ -272,13 +272,13 @@
           "line": 5,
           "column": 22
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -290,7 +290,7 @@
         "line": 6,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
     }
   },
   "loc": {
@@ -302,6 +302,6 @@
       "line": 6,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/namespace.php.json
+++ b/parser-PHP/tests/benchmark/base/namespace.php.json
@@ -18,7 +18,7 @@
             "line": 2,
             "column": 18
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "namespace.php"
         }
       },
       "loc": {
@@ -30,7 +30,7 @@
           "line": 2,
           "column": 18
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+        "sourcefile": "namespace.php"
       }
     },
     {
@@ -56,7 +56,7 @@
                 "line": 3,
                 "column": 17
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+              "sourcefile": "namespace.php"
             }
           },
           "loc": {
@@ -68,7 +68,7 @@
               "line": 3,
               "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "namespace.php"
           }
         },
         "imported": null,
@@ -82,7 +82,7 @@
               "line": 3,
               "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "namespace.php"
           }
         },
         "loc": {
@@ -94,7 +94,7 @@
             "line": 3,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "namespace.php"
         }
       },
       "_meta": {}
@@ -117,7 +117,7 @@
                 "line": 4,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+              "sourcefile": "namespace.php"
             },
             "encapsed": true
           },
@@ -130,7 +130,7 @@
               "line": 4,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "namespace.php"
           }
         },
         "local": null,
@@ -147,7 +147,7 @@
               "line": 4,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "namespace.php"
           }
         },
         "loc": {
@@ -159,7 +159,7 @@
             "line": 4,
             "column": 16
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "namespace.php"
         }
       },
       "_meta": {
@@ -172,7 +172,7 @@
             "line": 4,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "namespace.php"
         }
       },
       "loc": {
@@ -184,7 +184,7 @@
           "line": 4,
           "column": 17
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+        "sourcefile": "namespace.php"
       }
     },
     {
@@ -205,7 +205,7 @@
                 "line": 5,
                 "column": 21
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+              "sourcefile": "namespace.php"
             },
             "encapsed": true
           },
@@ -218,7 +218,7 @@
               "line": 5,
               "column": 21
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "namespace.php"
           }
         },
         "local": null,
@@ -235,7 +235,7 @@
               "line": 5,
               "column": 21
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "namespace.php"
           }
         },
         "loc": {
@@ -247,7 +247,7 @@
             "line": 5,
             "column": 21
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "namespace.php"
         }
       },
       "_meta": {
@@ -260,7 +260,7 @@
             "line": 5,
             "column": 22
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "namespace.php"
         }
       },
       "loc": {
@@ -272,13 +272,13 @@
           "line": 5,
           "column": 22
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+        "sourcefile": "namespace.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php",
+  "uri": "namespace.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -290,7 +290,7 @@
         "line": 6,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+      "sourcefile": "namespace.php"
     }
   },
   "loc": {
@@ -302,6 +302,6 @@
       "line": 6,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+    "sourcefile": "namespace.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/namespace.php.json
+++ b/parser-PHP/tests/benchmark/base/namespace.php.json
@@ -12,208 +12,25 @@
         "loc": {
           "start": {
             "line": 2,
-            "column": 1
+            "column": 11
           },
           "end": {
-            "line": 5,
-            "column": 22
+            "line": 2,
+            "column": 18
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
-        },
-        "origin": {
-          "kind": "namespace",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 2,
-              "column": 0,
-              "offset": 6
-            },
-            "end": {
-              "line": 5,
-              "column": 21,
-              "offset": 81
-            }
-          },
-          "children": [
-            {
-              "kind": "usegroup",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 0,
-                  "offset": 25
-                },
-                "end": {
-                  "line": 3,
-                  "column": 16,
-                  "offset": 41
-                }
-              },
-              "name": null,
-              "type": null,
-              "items": [
-                {
-                  "kind": "useitem",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 4,
-                      "offset": 29
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 16,
-                      "offset": 41
-                    }
-                  },
-                  "name": "Baz\\Qux",
-                  "alias": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 3,
-                        "column": 15,
-                        "offset": 40
-                      },
-                      "end": {
-                        "line": 3,
-                        "column": 16,
-                        "offset": 41
-                      }
-                    },
-                    "name": "Q"
-                  },
-                  "type": null
-                }
-              ]
-            },
-            {
-              "kind": "expressionstatement",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 4,
-                  "column": 0,
-                  "offset": 43
-                },
-                "end": {
-                  "line": 4,
-                  "column": 16,
-                  "offset": 59
-                }
-              },
-              "expression": {
-                "kind": "include",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 4,
-                    "column": 0,
-                    "offset": 43
-                  },
-                  "end": {
-                    "line": 4,
-                    "column": 16,
-                    "offset": 59
-                  }
-                },
-                "once": false,
-                "require": false,
-                "target": {
-                  "kind": "string",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 4,
-                      "column": 8,
-                      "offset": 51
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 15,
-                      "offset": 58
-                    }
-                  },
-                  "value": "a.php",
-                  "raw": "\"a.php\"",
-                  "unicode": false,
-                  "isDoubleQuote": true
-                }
-              }
-            },
-            {
-              "kind": "expressionstatement",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 5,
-                  "column": 0,
-                  "offset": 60
-                },
-                "end": {
-                  "line": 5,
-                  "column": 21,
-                  "offset": 81
-                }
-              },
-              "expression": {
-                "kind": "include",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 0,
-                    "offset": 60
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 21,
-                    "offset": 81
-                  }
-                },
-                "once": true,
-                "require": true,
-                "target": {
-                  "kind": "string",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 13,
-                      "offset": 73
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 20,
-                      "offset": 80
-                    }
-                  },
-                  "value": "b.php",
-                  "raw": "\"b.php\"",
-                  "unicode": false,
-                  "isDoubleQuote": true
-                }
-              }
-            }
-          ],
-          "name": "Foo\\Bar",
-          "withBrackets": false
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
         }
       },
       "loc": {
         "start": {
           "line": 2,
-          "column": 1
+          "column": 11
         },
         "end": {
-          "line": 5,
-          "column": 22
+          "line": 2,
+          "column": 18
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
       }
     },
     {
@@ -239,24 +56,7 @@
                 "line": 3,
                 "column": 17
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
-            },
-            "origin": {
-              "kind": "identifier",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 15,
-                  "offset": 40
-                },
-                "end": {
-                  "line": 3,
-                  "column": 16,
-                  "offset": 41
-                }
-              },
-              "name": "Q"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
             }
           },
           "loc": {
@@ -268,7 +68,7 @@
               "line": 3,
               "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
           }
         },
         "imported": null,
@@ -282,42 +82,7 @@
               "line": 3,
               "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
-          },
-          "origin": {
-            "kind": "useitem",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 4,
-                "offset": 29
-              },
-              "end": {
-                "line": 3,
-                "column": 16,
-                "offset": 41
-              }
-            },
-            "name": "Baz\\Qux",
-            "alias": {
-              "kind": "identifier",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 15,
-                  "offset": 40
-                },
-                "end": {
-                  "line": 3,
-                  "column": 16,
-                  "offset": 41
-                }
-              },
-              "name": "Q"
-            },
-            "type": null
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
           }
         },
         "loc": {
@@ -329,7 +94,7 @@
             "line": 3,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
         }
       },
       "_meta": {}
@@ -352,28 +117,9 @@
                 "line": 4,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
             },
-            "origin": {
-              "kind": "string",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 4,
-                  "column": 8,
-                  "offset": 51
-                },
-                "end": {
-                  "line": 4,
-                  "column": 15,
-                  "offset": 58
-                }
-              },
-              "value": "a.php",
-              "raw": "\"a.php\"",
-              "unicode": false,
-              "isDoubleQuote": true
-            }
+            "encapsed": true
           },
           "loc": {
             "start": {
@@ -384,7 +130,7 @@
               "line": 4,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
           }
         },
         "local": null,
@@ -399,47 +145,9 @@
             },
             "end": {
               "line": 4,
-              "column": 17
+              "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
-          },
-          "origin": {
-            "kind": "include",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 4,
-                "column": 0,
-                "offset": 43
-              },
-              "end": {
-                "line": 4,
-                "column": 16,
-                "offset": 59
-              }
-            },
-            "once": false,
-            "require": false,
-            "target": {
-              "kind": "string",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 4,
-                  "column": 8,
-                  "offset": 51
-                },
-                "end": {
-                  "line": 4,
-                  "column": 15,
-                  "offset": 58
-                }
-              },
-              "value": "a.php",
-              "raw": "\"a.php\"",
-              "unicode": false,
-              "isDoubleQuote": true
-            }
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
           }
         },
         "loc": {
@@ -449,9 +157,9 @@
           },
           "end": {
             "line": 4,
-            "column": 17
+            "column": 16
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
         }
       },
       "_meta": {
@@ -464,61 +172,7 @@
             "line": 4,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
-        },
-        "origin": {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 4,
-              "column": 0,
-              "offset": 43
-            },
-            "end": {
-              "line": 4,
-              "column": 16,
-              "offset": 59
-            }
-          },
-          "expression": {
-            "kind": "include",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 4,
-                "column": 0,
-                "offset": 43
-              },
-              "end": {
-                "line": 4,
-                "column": 16,
-                "offset": 59
-              }
-            },
-            "once": false,
-            "require": false,
-            "target": {
-              "kind": "string",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 4,
-                  "column": 8,
-                  "offset": 51
-                },
-                "end": {
-                  "line": 4,
-                  "column": 15,
-                  "offset": 58
-                }
-              },
-              "value": "a.php",
-              "raw": "\"a.php\"",
-              "unicode": false,
-              "isDoubleQuote": true
-            }
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
         }
       },
       "loc": {
@@ -530,7 +184,7 @@
           "line": 4,
           "column": 17
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
       }
     },
     {
@@ -551,28 +205,9 @@
                 "line": 5,
                 "column": 21
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
             },
-            "origin": {
-              "kind": "string",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 5,
-                  "column": 13,
-                  "offset": 73
-                },
-                "end": {
-                  "line": 5,
-                  "column": 20,
-                  "offset": 80
-                }
-              },
-              "value": "b.php",
-              "raw": "\"b.php\"",
-              "unicode": false,
-              "isDoubleQuote": true
-            }
+            "encapsed": true
           },
           "loc": {
             "start": {
@@ -583,7 +218,7 @@
               "line": 5,
               "column": 21
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
           }
         },
         "local": null,
@@ -598,47 +233,9 @@
             },
             "end": {
               "line": 5,
-              "column": 22
+              "column": 21
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
-          },
-          "origin": {
-            "kind": "include",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 5,
-                "column": 0,
-                "offset": 60
-              },
-              "end": {
-                "line": 5,
-                "column": 21,
-                "offset": 81
-              }
-            },
-            "once": true,
-            "require": true,
-            "target": {
-              "kind": "string",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 5,
-                  "column": 13,
-                  "offset": 73
-                },
-                "end": {
-                  "line": 5,
-                  "column": 20,
-                  "offset": 80
-                }
-              },
-              "value": "b.php",
-              "raw": "\"b.php\"",
-              "unicode": false,
-              "isDoubleQuote": true
-            }
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
           }
         },
         "loc": {
@@ -648,9 +245,9 @@
           },
           "end": {
             "line": 5,
-            "column": 22
+            "column": 21
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
         }
       },
       "_meta": {
@@ -663,61 +260,7 @@
             "line": 5,
             "column": 22
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
-        },
-        "origin": {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 5,
-              "column": 0,
-              "offset": 60
-            },
-            "end": {
-              "line": 5,
-              "column": 21,
-              "offset": 81
-            }
-          },
-          "expression": {
-            "kind": "include",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 5,
-                "column": 0,
-                "offset": 60
-              },
-              "end": {
-                "line": 5,
-                "column": 21,
-                "offset": 81
-              }
-            },
-            "once": true,
-            "require": true,
-            "target": {
-              "kind": "string",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 5,
-                  "column": 13,
-                  "offset": 73
-                },
-                "end": {
-                  "line": 5,
-                  "column": 20,
-                  "offset": 80
-                }
-              },
-              "value": "b.php",
-              "raw": "\"b.php\"",
-              "unicode": false,
-              "isDoubleQuote": true
-            }
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
         }
       },
       "loc": {
@@ -729,13 +272,13 @@
           "line": 5,
           "column": 22
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -747,210 +290,7 @@
         "line": 6,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
-    },
-    "origin": {
-      "kind": "program",
-      "loc": {
-        "source": null,
-        "start": {
-          "line": 1,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "line": 6,
-          "column": 0,
-          "offset": 82
-        }
-      },
-      "children": [
-        {
-          "kind": "namespace",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 2,
-              "column": 0,
-              "offset": 6
-            },
-            "end": {
-              "line": 5,
-              "column": 21,
-              "offset": 81
-            }
-          },
-          "children": [
-            {
-              "kind": "usegroup",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 0,
-                  "offset": 25
-                },
-                "end": {
-                  "line": 3,
-                  "column": 16,
-                  "offset": 41
-                }
-              },
-              "name": null,
-              "type": null,
-              "items": [
-                {
-                  "kind": "useitem",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 4,
-                      "offset": 29
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 16,
-                      "offset": 41
-                    }
-                  },
-                  "name": "Baz\\Qux",
-                  "alias": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 3,
-                        "column": 15,
-                        "offset": 40
-                      },
-                      "end": {
-                        "line": 3,
-                        "column": 16,
-                        "offset": 41
-                      }
-                    },
-                    "name": "Q"
-                  },
-                  "type": null
-                }
-              ]
-            },
-            {
-              "kind": "expressionstatement",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 4,
-                  "column": 0,
-                  "offset": 43
-                },
-                "end": {
-                  "line": 4,
-                  "column": 16,
-                  "offset": 59
-                }
-              },
-              "expression": {
-                "kind": "include",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 4,
-                    "column": 0,
-                    "offset": 43
-                  },
-                  "end": {
-                    "line": 4,
-                    "column": 16,
-                    "offset": 59
-                  }
-                },
-                "once": false,
-                "require": false,
-                "target": {
-                  "kind": "string",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 4,
-                      "column": 8,
-                      "offset": 51
-                    },
-                    "end": {
-                      "line": 4,
-                      "column": 15,
-                      "offset": 58
-                    }
-                  },
-                  "value": "a.php",
-                  "raw": "\"a.php\"",
-                  "unicode": false,
-                  "isDoubleQuote": true
-                }
-              }
-            },
-            {
-              "kind": "expressionstatement",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 5,
-                  "column": 0,
-                  "offset": 60
-                },
-                "end": {
-                  "line": 5,
-                  "column": 21,
-                  "offset": 81
-                }
-              },
-              "expression": {
-                "kind": "include",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 0,
-                    "offset": 60
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 21,
-                    "offset": 81
-                  }
-                },
-                "once": true,
-                "require": true,
-                "target": {
-                  "kind": "string",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 13,
-                      "offset": 73
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 20,
-                      "offset": 80
-                    }
-                  },
-                  "value": "b.php",
-                  "raw": "\"b.php\"",
-                  "unicode": false,
-                  "isDoubleQuote": true
-                }
-              }
-            }
-          ],
-          "name": "Foo\\Bar",
-          "withBrackets": false
-        }
-      ],
-      "errors": [],
-      "comments": []
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
     }
   },
   "loc": {
@@ -962,6 +302,6 @@
       "line": 6,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/namespace.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/namespace.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/new-static.php.json
+++ b/parser-PHP/tests/benchmark/base/new-static.php.json
@@ -18,7 +18,7 @@
                 "line": 2,
                 "column": 5
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
             },
             "origin": {
               "kind": "variable",
@@ -48,7 +48,7 @@
               "line": 2,
               "column": 5
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
           }
         },
         "right": {
@@ -66,7 +66,7 @@
                   "line": 2,
                   "column": 16
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
               },
               "origin": {
                 "kind": "name",
@@ -96,7 +96,7 @@
                 "line": 2,
                 "column": 16
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
             }
           },
           "arguments": [
@@ -113,7 +113,7 @@
                     "line": 2,
                     "column": 20
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
                 },
                 "origin": {
                   "kind": "variable",
@@ -143,7 +143,7 @@
                   "line": 2,
                   "column": 20
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
               }
             }
           ],
@@ -157,7 +157,7 @@
                 "line": 2,
                 "column": 21
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
             },
             "origin": {
               "kind": "new",
@@ -223,7 +223,7 @@
               "line": 2,
               "column": 21
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
           }
         },
         "operator": "=",
@@ -238,7 +238,7 @@
               "line": 2,
               "column": 22
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
           },
           "origin": {
             "kind": "assign",
@@ -339,7 +339,7 @@
             "line": 2,
             "column": 22
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
         }
       },
       "_meta": {
@@ -352,7 +352,7 @@
             "line": 2,
             "column": 22
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
         },
         "origin": {
           "kind": "expressionstatement",
@@ -469,7 +469,7 @@
           "line": 2,
           "column": 22
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
       }
     },
     {
@@ -489,7 +489,7 @@
                 "line": 3,
                 "column": 3
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
             },
             "origin": {
               "kind": "variable",
@@ -519,7 +519,7 @@
               "line": 3,
               "column": 3
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
           }
         },
         "right": {
@@ -539,7 +539,7 @@
                     "line": 3,
                     "column": 9
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
                 },
                 "origin": {
                   "kind": "name",
@@ -569,7 +569,7 @@
                   "line": 3,
                   "column": 9
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
               }
             },
             "property": {
@@ -585,7 +585,7 @@
                     "line": 3,
                     "column": 14
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
                 },
                 "origin": {
                   "kind": "identifier",
@@ -614,7 +614,7 @@
                   "line": 3,
                   "column": 14
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
               }
             },
             "computed": false,
@@ -629,7 +629,7 @@
                   "line": 3,
                   "column": 14
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
               },
               "origin": {
                 "kind": "staticlookup",
@@ -692,7 +692,7 @@
                 "line": 3,
                 "column": 14
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
             }
           },
           "arguments": [
@@ -709,7 +709,7 @@
                     "line": 3,
                     "column": 19
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
                 },
                 "origin": {
                   "kind": "variable",
@@ -739,7 +739,7 @@
                   "line": 3,
                   "column": 19
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
               }
             }
           ],
@@ -753,7 +753,7 @@
                 "line": 3,
                 "column": 20
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
             },
             "origin": {
               "kind": "call",
@@ -852,7 +852,7 @@
               "line": 3,
               "column": 20
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
           }
         },
         "operator": "=",
@@ -867,7 +867,7 @@
               "line": 3,
               "column": 21
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
           },
           "origin": {
             "kind": "assign",
@@ -1001,7 +1001,7 @@
             "line": 3,
             "column": 21
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
         }
       },
       "_meta": {
@@ -1014,7 +1014,7 @@
             "line": 3,
             "column": 21
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
         },
         "origin": {
           "kind": "expressionstatement",
@@ -1164,13 +1164,13 @@
           "line": 3,
           "column": 21
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -1182,7 +1182,7 @@
         "line": 4,
         "column": 1
       },
-      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
     },
     "origin": {
       "kind": "program",
@@ -1457,6 +1457,6 @@
       "line": 4,
       "column": 1
     },
-    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/new-static.php.json
+++ b/parser-PHP/tests/benchmark/base/new-static.php.json
@@ -18,25 +18,7 @@
                 "line": 2,
                 "column": 5
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
-            },
-            "origin": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 0,
-                  "offset": 6
-                },
-                "end": {
-                  "line": 2,
-                  "column": 4,
-                  "offset": 10
-                }
-              },
-              "name": "obj",
-              "curly": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
             }
           },
           "loc": {
@@ -48,7 +30,7 @@
               "line": 2,
               "column": 5
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
           }
         },
         "right": {
@@ -66,25 +48,7 @@
                   "line": 2,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
-              },
-              "origin": {
-                "kind": "name",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 11,
-                    "offset": 17
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 15,
-                    "offset": 21
-                  }
-                },
-                "name": "User",
-                "resolution": "uqn"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
               }
             },
             "loc": {
@@ -96,57 +60,10 @@
                 "line": 2,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
             }
           },
-          "arguments": [
-            {
-              "type": "Identifier",
-              "name": "id",
-              "_meta": {
-                "loc": {
-                  "start": {
-                    "line": 2,
-                    "column": 17
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 20
-                  },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
-                },
-                "origin": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 16,
-                      "offset": 22
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 19,
-                      "offset": 25
-                    }
-                  },
-                  "name": "id",
-                  "curly": false
-                }
-              },
-              "loc": {
-                "start": {
-                  "line": 2,
-                  "column": 17
-                },
-                "end": {
-                  "line": 2,
-                  "column": 20
-                },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
-              }
-            }
-          ],
+          "arguments": [],
           "_meta": {
             "loc": {
               "start": {
@@ -157,61 +74,7 @@
                 "line": 2,
                 "column": 21
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
-            },
-            "origin": {
-              "kind": "new",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 7,
-                  "offset": 13
-                },
-                "end": {
-                  "line": 2,
-                  "column": 20,
-                  "offset": 26
-                }
-              },
-              "what": {
-                "kind": "name",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 11,
-                    "offset": 17
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 15,
-                    "offset": 21
-                  }
-                },
-                "name": "User",
-                "resolution": "uqn"
-              },
-              "arguments": [
-                {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 16,
-                      "offset": 22
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 19,
-                      "offset": 25
-                    }
-                  },
-                  "name": "id",
-                  "curly": false
-                }
-              ]
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
             }
           },
           "loc": {
@@ -223,7 +86,7 @@
               "line": 2,
               "column": 21
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
           }
         },
         "operator": "=",
@@ -236,98 +99,9 @@
             },
             "end": {
               "line": 2,
-              "column": 22
+              "column": 21
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
-          },
-          "origin": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 2,
-                "column": 0,
-                "offset": 6
-              },
-              "end": {
-                "line": 2,
-                "column": 21,
-                "offset": 27
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 0,
-                  "offset": 6
-                },
-                "end": {
-                  "line": 2,
-                  "column": 4,
-                  "offset": 10
-                }
-              },
-              "name": "obj",
-              "curly": false
-            },
-            "right": {
-              "kind": "new",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 7,
-                  "offset": 13
-                },
-                "end": {
-                  "line": 2,
-                  "column": 20,
-                  "offset": 26
-                }
-              },
-              "what": {
-                "kind": "name",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 11,
-                    "offset": 17
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 15,
-                    "offset": 21
-                  }
-                },
-                "name": "User",
-                "resolution": "uqn"
-              },
-              "arguments": [
-                {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 16,
-                      "offset": 22
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 19,
-                      "offset": 25
-                    }
-                  },
-                  "name": "id",
-                  "curly": false
-                }
-              ]
-            },
-            "operator": "="
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
           }
         },
         "loc": {
@@ -337,9 +111,9 @@
           },
           "end": {
             "line": 2,
-            "column": 22
+            "column": 21
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
         }
       },
       "_meta": {
@@ -352,112 +126,7 @@
             "line": 2,
             "column": 22
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
-        },
-        "origin": {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 2,
-              "column": 0,
-              "offset": 6
-            },
-            "end": {
-              "line": 2,
-              "column": 21,
-              "offset": 27
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 2,
-                "column": 0,
-                "offset": 6
-              },
-              "end": {
-                "line": 2,
-                "column": 21,
-                "offset": 27
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 0,
-                  "offset": 6
-                },
-                "end": {
-                  "line": 2,
-                  "column": 4,
-                  "offset": 10
-                }
-              },
-              "name": "obj",
-              "curly": false
-            },
-            "right": {
-              "kind": "new",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 7,
-                  "offset": 13
-                },
-                "end": {
-                  "line": 2,
-                  "column": 20,
-                  "offset": 26
-                }
-              },
-              "what": {
-                "kind": "name",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 11,
-                    "offset": 17
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 15,
-                    "offset": 21
-                  }
-                },
-                "name": "User",
-                "resolution": "uqn"
-              },
-              "arguments": [
-                {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 16,
-                      "offset": 22
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 19,
-                      "offset": 25
-                    }
-                  },
-                  "name": "id",
-                  "curly": false
-                }
-              ]
-            },
-            "operator": "="
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
         }
       },
       "loc": {
@@ -469,7 +138,7 @@
           "line": 2,
           "column": 22
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
       }
     },
     {
@@ -489,25 +158,7 @@
                 "line": 3,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
-            },
-            "origin": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 0,
-                  "offset": 28
-                },
-                "end": {
-                  "line": 3,
-                  "column": 2,
-                  "offset": 30
-                }
-              },
-              "name": "v",
-              "curly": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
             }
           },
           "loc": {
@@ -519,7 +170,7 @@
               "line": 3,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
           }
         },
         "right": {
@@ -539,25 +190,7 @@
                     "line": 3,
                     "column": 9
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
-                },
-                "origin": {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 5,
-                      "offset": 33
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 8,
-                      "offset": 36
-                    }
-                  },
-                  "name": "Foo",
-                  "resolution": "uqn"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
                 }
               },
               "loc": {
@@ -569,7 +202,7 @@
                   "line": 3,
                   "column": 9
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
               }
             },
             "property": {
@@ -585,24 +218,7 @@
                     "line": 3,
                     "column": 14
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
-                },
-                "origin": {
-                  "kind": "identifier",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 10,
-                      "offset": 38
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 13,
-                      "offset": 41
-                    }
-                  },
-                  "name": "bar"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
                 }
               },
               "loc": {
@@ -614,7 +230,7 @@
                   "line": 3,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
               }
             },
             "computed": false,
@@ -627,60 +243,9 @@
                 },
                 "end": {
                   "line": 3,
-                  "column": 14
+                  "column": 20
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
-              },
-              "origin": {
-                "kind": "staticlookup",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 5,
-                    "offset": 33
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 13,
-                    "offset": 41
-                  }
-                },
-                "what": {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 5,
-                      "offset": 33
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 8,
-                      "offset": 36
-                    }
-                  },
-                  "name": "Foo",
-                  "resolution": "uqn"
-                },
-                "offset": {
-                  "kind": "identifier",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 10,
-                      "offset": 38
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 13,
-                      "offset": 41
-                    }
-                  },
-                  "name": "bar"
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
               }
             },
             "loc": {
@@ -690,9 +255,9 @@
               },
               "end": {
                 "line": 3,
-                "column": 14
+                "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
             }
           },
           "arguments": [
@@ -709,25 +274,7 @@
                     "line": 3,
                     "column": 19
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
-                },
-                "origin": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 14,
-                      "offset": 42
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 18,
-                      "offset": 46
-                    }
-                  },
-                  "name": "obj",
-                  "curly": false
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
                 }
               },
               "loc": {
@@ -739,7 +286,7 @@
                   "line": 3,
                   "column": 19
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
               }
             }
           ],
@@ -753,94 +300,7 @@
                 "line": 3,
                 "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
-            },
-            "origin": {
-              "kind": "call",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 5,
-                  "offset": 33
-                },
-                "end": {
-                  "line": 3,
-                  "column": 19,
-                  "offset": 47
-                }
-              },
-              "what": {
-                "kind": "staticlookup",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 5,
-                    "offset": 33
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 13,
-                    "offset": 41
-                  }
-                },
-                "what": {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 5,
-                      "offset": 33
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 8,
-                      "offset": 36
-                    }
-                  },
-                  "name": "Foo",
-                  "resolution": "uqn"
-                },
-                "offset": {
-                  "kind": "identifier",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 10,
-                      "offset": 38
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 13,
-                      "offset": 41
-                    }
-                  },
-                  "name": "bar"
-                }
-              },
-              "arguments": [
-                {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 14,
-                      "offset": 42
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 18,
-                      "offset": 46
-                    }
-                  },
-                  "name": "obj",
-                  "curly": false
-                }
-              ]
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
             }
           },
           "loc": {
@@ -852,7 +312,7 @@
               "line": 3,
               "column": 20
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
           }
         },
         "operator": "=",
@@ -865,131 +325,9 @@
             },
             "end": {
               "line": 3,
-              "column": 21
+              "column": 20
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
-          },
-          "origin": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 0,
-                "offset": 28
-              },
-              "end": {
-                "line": 3,
-                "column": 20,
-                "offset": 48
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 0,
-                  "offset": 28
-                },
-                "end": {
-                  "line": 3,
-                  "column": 2,
-                  "offset": 30
-                }
-              },
-              "name": "v",
-              "curly": false
-            },
-            "right": {
-              "kind": "call",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 5,
-                  "offset": 33
-                },
-                "end": {
-                  "line": 3,
-                  "column": 19,
-                  "offset": 47
-                }
-              },
-              "what": {
-                "kind": "staticlookup",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 5,
-                    "offset": 33
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 13,
-                    "offset": 41
-                  }
-                },
-                "what": {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 5,
-                      "offset": 33
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 8,
-                      "offset": 36
-                    }
-                  },
-                  "name": "Foo",
-                  "resolution": "uqn"
-                },
-                "offset": {
-                  "kind": "identifier",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 10,
-                      "offset": 38
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 13,
-                      "offset": 41
-                    }
-                  },
-                  "name": "bar"
-                }
-              },
-              "arguments": [
-                {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 14,
-                      "offset": 42
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 18,
-                      "offset": 46
-                    }
-                  },
-                  "name": "obj",
-                  "curly": false
-                }
-              ]
-            },
-            "operator": "="
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
           }
         },
         "loc": {
@@ -999,9 +337,9 @@
           },
           "end": {
             "line": 3,
-            "column": 21
+            "column": 20
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
         }
       },
       "_meta": {
@@ -1014,145 +352,7 @@
             "line": 3,
             "column": 21
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
-        },
-        "origin": {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 28
-            },
-            "end": {
-              "line": 3,
-              "column": 20,
-              "offset": 48
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 0,
-                "offset": 28
-              },
-              "end": {
-                "line": 3,
-                "column": 20,
-                "offset": 48
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 0,
-                  "offset": 28
-                },
-                "end": {
-                  "line": 3,
-                  "column": 2,
-                  "offset": 30
-                }
-              },
-              "name": "v",
-              "curly": false
-            },
-            "right": {
-              "kind": "call",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 5,
-                  "offset": 33
-                },
-                "end": {
-                  "line": 3,
-                  "column": 19,
-                  "offset": 47
-                }
-              },
-              "what": {
-                "kind": "staticlookup",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 5,
-                    "offset": 33
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 13,
-                    "offset": 41
-                  }
-                },
-                "what": {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 5,
-                      "offset": 33
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 8,
-                      "offset": 36
-                    }
-                  },
-                  "name": "Foo",
-                  "resolution": "uqn"
-                },
-                "offset": {
-                  "kind": "identifier",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 10,
-                      "offset": 38
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 13,
-                      "offset": 41
-                    }
-                  },
-                  "name": "bar"
-                }
-              },
-              "arguments": [
-                {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 14,
-                      "offset": 42
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 18,
-                      "offset": 46
-                    }
-                  },
-                  "name": "obj",
-                  "curly": false
-                }
-              ]
-            },
-            "operator": "="
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
         }
       },
       "loc": {
@@ -1164,13 +364,13 @@
           "line": 3,
           "column": 21
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -1182,270 +382,7 @@
         "line": 4,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
-    },
-    "origin": {
-      "kind": "program",
-      "loc": {
-        "source": null,
-        "start": {
-          "line": 1,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "line": 4,
-          "column": 0,
-          "offset": 49
-        }
-      },
-      "children": [
-        {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 2,
-              "column": 0,
-              "offset": 6
-            },
-            "end": {
-              "line": 2,
-              "column": 21,
-              "offset": 27
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 2,
-                "column": 0,
-                "offset": 6
-              },
-              "end": {
-                "line": 2,
-                "column": 21,
-                "offset": 27
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 0,
-                  "offset": 6
-                },
-                "end": {
-                  "line": 2,
-                  "column": 4,
-                  "offset": 10
-                }
-              },
-              "name": "obj",
-              "curly": false
-            },
-            "right": {
-              "kind": "new",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 2,
-                  "column": 7,
-                  "offset": 13
-                },
-                "end": {
-                  "line": 2,
-                  "column": 20,
-                  "offset": 26
-                }
-              },
-              "what": {
-                "kind": "name",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 2,
-                    "column": 11,
-                    "offset": 17
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 15,
-                    "offset": 21
-                  }
-                },
-                "name": "User",
-                "resolution": "uqn"
-              },
-              "arguments": [
-                {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 2,
-                      "column": 16,
-                      "offset": 22
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 19,
-                      "offset": 25
-                    }
-                  },
-                  "name": "id",
-                  "curly": false
-                }
-              ]
-            },
-            "operator": "="
-          }
-        },
-        {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 28
-            },
-            "end": {
-              "line": 3,
-              "column": 20,
-              "offset": 48
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 0,
-                "offset": 28
-              },
-              "end": {
-                "line": 3,
-                "column": 20,
-                "offset": 48
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 0,
-                  "offset": 28
-                },
-                "end": {
-                  "line": 3,
-                  "column": 2,
-                  "offset": 30
-                }
-              },
-              "name": "v",
-              "curly": false
-            },
-            "right": {
-              "kind": "call",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 5,
-                  "offset": 33
-                },
-                "end": {
-                  "line": 3,
-                  "column": 19,
-                  "offset": 47
-                }
-              },
-              "what": {
-                "kind": "staticlookup",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 5,
-                    "offset": 33
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 13,
-                    "offset": 41
-                  }
-                },
-                "what": {
-                  "kind": "name",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 5,
-                      "offset": 33
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 8,
-                      "offset": 36
-                    }
-                  },
-                  "name": "Foo",
-                  "resolution": "uqn"
-                },
-                "offset": {
-                  "kind": "identifier",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 10,
-                      "offset": 38
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 13,
-                      "offset": 41
-                    }
-                  },
-                  "name": "bar"
-                }
-              },
-              "arguments": [
-                {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 3,
-                      "column": 14,
-                      "offset": 42
-                    },
-                    "end": {
-                      "line": 3,
-                      "column": 18,
-                      "offset": 46
-                    }
-                  },
-                  "name": "obj",
-                  "curly": false
-                }
-              ]
-            },
-            "operator": "="
-          }
-        }
-      ],
-      "errors": [],
-      "comments": []
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
     }
   },
   "loc": {
@@ -1457,6 +394,6 @@
       "line": 4,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/new-static.php.json
+++ b/parser-PHP/tests/benchmark/base/new-static.php.json
@@ -18,7 +18,7 @@
                 "line": 2,
                 "column": 5
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+              "sourcefile": "new-static.php"
             }
           },
           "loc": {
@@ -30,7 +30,7 @@
               "line": 2,
               "column": 5
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "new-static.php"
           }
         },
         "right": {
@@ -48,7 +48,7 @@
                   "line": 2,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                "sourcefile": "new-static.php"
               }
             },
             "loc": {
@@ -60,7 +60,7 @@
                 "line": 2,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+              "sourcefile": "new-static.php"
             }
           },
           "arguments": [],
@@ -74,7 +74,7 @@
                 "line": 2,
                 "column": 21
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+              "sourcefile": "new-static.php"
             }
           },
           "loc": {
@@ -86,7 +86,7 @@
               "line": 2,
               "column": 21
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "new-static.php"
           }
         },
         "operator": "=",
@@ -101,7 +101,7 @@
               "line": 2,
               "column": 21
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "new-static.php"
           }
         },
         "loc": {
@@ -113,7 +113,7 @@
             "line": 2,
             "column": 21
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+          "sourcefile": "new-static.php"
         }
       },
       "_meta": {
@@ -126,7 +126,7 @@
             "line": 2,
             "column": 22
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+          "sourcefile": "new-static.php"
         }
       },
       "loc": {
@@ -138,7 +138,7 @@
           "line": 2,
           "column": 22
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+        "sourcefile": "new-static.php"
       }
     },
     {
@@ -158,7 +158,7 @@
                 "line": 3,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+              "sourcefile": "new-static.php"
             }
           },
           "loc": {
@@ -170,7 +170,7 @@
               "line": 3,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "new-static.php"
           }
         },
         "right": {
@@ -190,7 +190,7 @@
                     "line": 3,
                     "column": 9
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                  "sourcefile": "new-static.php"
                 }
               },
               "loc": {
@@ -202,7 +202,7 @@
                   "line": 3,
                   "column": 9
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                "sourcefile": "new-static.php"
               }
             },
             "property": {
@@ -218,7 +218,7 @@
                     "line": 3,
                     "column": 14
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                  "sourcefile": "new-static.php"
                 }
               },
               "loc": {
@@ -230,7 +230,7 @@
                   "line": 3,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                "sourcefile": "new-static.php"
               }
             },
             "computed": false,
@@ -245,7 +245,7 @@
                   "line": 3,
                   "column": 20
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                "sourcefile": "new-static.php"
               }
             },
             "loc": {
@@ -257,7 +257,7 @@
                 "line": 3,
                 "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+              "sourcefile": "new-static.php"
             }
           },
           "arguments": [
@@ -274,7 +274,7 @@
                     "line": 3,
                     "column": 19
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                  "sourcefile": "new-static.php"
                 }
               },
               "loc": {
@@ -286,7 +286,7 @@
                   "line": 3,
                   "column": 19
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+                "sourcefile": "new-static.php"
               }
             }
           ],
@@ -300,7 +300,7 @@
                 "line": 3,
                 "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+              "sourcefile": "new-static.php"
             }
           },
           "loc": {
@@ -312,7 +312,7 @@
               "line": 3,
               "column": 20
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "new-static.php"
           }
         },
         "operator": "=",
@@ -327,7 +327,7 @@
               "line": 3,
               "column": 20
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "new-static.php"
           }
         },
         "loc": {
@@ -339,7 +339,7 @@
             "line": 3,
             "column": 20
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+          "sourcefile": "new-static.php"
         }
       },
       "_meta": {
@@ -352,7 +352,7 @@
             "line": 3,
             "column": 21
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+          "sourcefile": "new-static.php"
         }
       },
       "loc": {
@@ -364,13 +364,13 @@
           "line": 3,
           "column": 21
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+        "sourcefile": "new-static.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php",
+  "uri": "new-static.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -382,7 +382,7 @@
         "line": 4,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+      "sourcefile": "new-static.php"
     }
   },
   "loc": {
@@ -394,6 +394,6 @@
       "line": 4,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
+    "sourcefile": "new-static.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/new-static.php.json
+++ b/parser-PHP/tests/benchmark/base/new-static.php.json
@@ -18,7 +18,7 @@
                 "line": 2,
                 "column": 5
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
             }
           },
           "loc": {
@@ -30,7 +30,7 @@
               "line": 2,
               "column": 5
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
           }
         },
         "right": {
@@ -48,7 +48,7 @@
                   "line": 2,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
               }
             },
             "loc": {
@@ -60,7 +60,7 @@
                 "line": 2,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
             }
           },
           "arguments": [],
@@ -74,7 +74,7 @@
                 "line": 2,
                 "column": 21
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
             }
           },
           "loc": {
@@ -86,7 +86,7 @@
               "line": 2,
               "column": 21
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
           }
         },
         "operator": "=",
@@ -101,7 +101,7 @@
               "line": 2,
               "column": 21
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
           }
         },
         "loc": {
@@ -113,7 +113,7 @@
             "line": 2,
             "column": 21
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
         }
       },
       "_meta": {
@@ -126,7 +126,7 @@
             "line": 2,
             "column": 22
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
         }
       },
       "loc": {
@@ -138,7 +138,7 @@
           "line": 2,
           "column": 22
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
       }
     },
     {
@@ -158,7 +158,7 @@
                 "line": 3,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
             }
           },
           "loc": {
@@ -170,7 +170,7 @@
               "line": 3,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
           }
         },
         "right": {
@@ -190,7 +190,7 @@
                     "line": 3,
                     "column": 9
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
                 }
               },
               "loc": {
@@ -202,7 +202,7 @@
                   "line": 3,
                   "column": 9
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
               }
             },
             "property": {
@@ -218,7 +218,7 @@
                     "line": 3,
                     "column": 14
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
                 }
               },
               "loc": {
@@ -230,7 +230,7 @@
                   "line": 3,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
               }
             },
             "computed": false,
@@ -245,7 +245,7 @@
                   "line": 3,
                   "column": 20
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
               }
             },
             "loc": {
@@ -257,7 +257,7 @@
                 "line": 3,
                 "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
             }
           },
           "arguments": [
@@ -274,7 +274,7 @@
                     "line": 3,
                     "column": 19
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
                 }
               },
               "loc": {
@@ -286,7 +286,7 @@
                   "line": 3,
                   "column": 19
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
               }
             }
           ],
@@ -300,7 +300,7 @@
                 "line": 3,
                 "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
             }
           },
           "loc": {
@@ -312,7 +312,7 @@
               "line": 3,
               "column": 20
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
           }
         },
         "operator": "=",
@@ -327,7 +327,7 @@
               "line": 3,
               "column": 20
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
           }
         },
         "loc": {
@@ -339,7 +339,7 @@
             "line": 3,
             "column": 20
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
         }
       },
       "_meta": {
@@ -352,7 +352,7 @@
             "line": 3,
             "column": 21
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
         }
       },
       "loc": {
@@ -364,13 +364,13 @@
           "line": 3,
           "column": 21
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -382,7 +382,7 @@
         "line": 4,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
     }
   },
   "loc": {
@@ -394,6 +394,6 @@
       "line": 4,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/new-static.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/new-static.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/runtime.php.json
+++ b/parser-PHP/tests/benchmark/base/runtime.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 13
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "runtime.php"
           }
         },
         "loc": {
@@ -28,7 +28,7 @@
             "line": 3,
             "column": 13
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+          "sourcefile": "runtime.php"
         }
       },
       "parameters": [
@@ -47,7 +47,7 @@
                   "line": 3,
                   "column": 19
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "runtime.php"
               }
             },
             "loc": {
@@ -59,7 +59,7 @@
                 "line": 3,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "runtime.php"
             }
           },
           "init": null,
@@ -80,7 +80,7 @@
                 "line": 3,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "runtime.php"
             }
           },
           "loc": {
@@ -92,7 +92,7 @@
               "line": 3,
               "column": 19
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "runtime.php"
           }
         },
         {
@@ -110,7 +110,7 @@
                   "line": 3,
                   "column": 23
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "runtime.php"
               }
             },
             "loc": {
@@ -122,7 +122,7 @@
                 "line": 3,
                 "column": 23
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "runtime.php"
             }
           },
           "init": null,
@@ -143,7 +143,7 @@
                 "line": 3,
                 "column": 23
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "runtime.php"
             }
           },
           "loc": {
@@ -155,7 +155,7 @@
               "line": 3,
               "column": 23
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "runtime.php"
           }
         }
       ],
@@ -190,7 +190,7 @@
                         "line": 5,
                         "column": 13
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "runtime.php"
                     }
                   },
                   "loc": {
@@ -202,7 +202,7 @@
                       "line": 5,
                       "column": 13
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "runtime.php"
                   }
                 }
               ],
@@ -216,7 +216,7 @@
                     "line": 5,
                     "column": 13
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "runtime.php"
                 }
               },
               "loc": {
@@ -228,7 +228,7 @@
                   "line": 5,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "runtime.php"
               }
             },
             "_meta": {
@@ -241,7 +241,7 @@
                   "line": 5,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "runtime.php"
               }
             },
             "loc": {
@@ -253,7 +253,7 @@
                 "line": 5,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "runtime.php"
             }
           },
           {
@@ -273,7 +273,7 @@
                       "line": 6,
                       "column": 9
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "runtime.php"
                   }
                 },
                 "loc": {
@@ -285,7 +285,7 @@
                     "line": 6,
                     "column": 9
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "runtime.php"
                 }
               },
               "arguments": [
@@ -302,7 +302,7 @@
                         "line": 6,
                         "column": 15
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "runtime.php"
                     }
                   },
                   "loc": {
@@ -314,7 +314,7 @@
                       "line": 6,
                       "column": 15
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "runtime.php"
                   }
                 }
               ],
@@ -328,7 +328,7 @@
                     "line": 6,
                     "column": 16
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "runtime.php"
                 }
               },
               "loc": {
@@ -340,7 +340,7 @@
                   "line": 6,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "runtime.php"
               }
             },
             "_meta": {
@@ -353,7 +353,7 @@
                   "line": 6,
                   "column": 17
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "runtime.php"
               }
             },
             "loc": {
@@ -365,7 +365,7 @@
                 "line": 6,
                 "column": 17
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "runtime.php"
             }
           },
           {
@@ -387,7 +387,7 @@
                         "line": 7,
                         "column": 11
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "runtime.php"
                     }
                   },
                   "loc": {
@@ -399,7 +399,7 @@
                       "line": 7,
                       "column": 11
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "runtime.php"
                   }
                 },
                 "property": {
@@ -415,7 +415,7 @@
                         "line": 7,
                         "column": 17
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "runtime.php"
                     }
                   },
                   "loc": {
@@ -427,7 +427,7 @@
                       "line": 7,
                       "column": 17
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "runtime.php"
                   }
                 },
                 "computed": false,
@@ -441,7 +441,7 @@
                       "line": 7,
                       "column": 19
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "runtime.php"
                   }
                 },
                 "loc": {
@@ -453,7 +453,7 @@
                     "line": 7,
                     "column": 19
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "runtime.php"
                 }
               },
               "arguments": [],
@@ -467,7 +467,7 @@
                     "line": 7,
                     "column": 19
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "runtime.php"
                 },
                 "silent": true
               },
@@ -480,7 +480,7 @@
                   "line": 7,
                   "column": 19
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "runtime.php"
               }
             },
             "_meta": {
@@ -493,7 +493,7 @@
                   "line": 7,
                   "column": 20
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "runtime.php"
               }
             },
             "loc": {
@@ -505,7 +505,7 @@
                 "line": 7,
                 "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "runtime.php"
             }
           },
           {
@@ -529,7 +529,7 @@
                       "line": 8,
                       "column": 15
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "runtime.php"
                   }
                 },
                 "loc": {
@@ -541,7 +541,7 @@
                     "line": 8,
                     "column": 15
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "runtime.php"
                 }
               }
             ],
@@ -555,7 +555,7 @@
                   "line": 8,
                   "column": 17
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "runtime.php"
               }
             },
             "loc": {
@@ -567,7 +567,7 @@
                 "line": 8,
                 "column": 17
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "runtime.php"
             }
           }
         ],
@@ -582,7 +582,7 @@
               "line": 9,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "runtime.php"
           }
         },
         "loc": {
@@ -594,7 +594,7 @@
             "line": 9,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+          "sourcefile": "runtime.php"
         }
       },
       "modifiers": [],
@@ -608,7 +608,7 @@
             "line": 9,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+          "sourcefile": "runtime.php"
         }
       },
       "loc": {
@@ -620,7 +620,7 @@
           "line": 9,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+        "sourcefile": "runtime.php"
       }
     },
     {
@@ -640,7 +640,7 @@
                 "line": 11,
                 "column": 4
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "runtime.php"
             }
           },
           "loc": {
@@ -652,7 +652,7 @@
               "line": 11,
               "column": 4
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "runtime.php"
           }
         },
         "right": {
@@ -674,7 +674,7 @@
                       "line": 11,
                       "column": 20
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "runtime.php"
                   }
                 },
                 "loc": {
@@ -686,7 +686,7 @@
                     "line": 11,
                     "column": 20
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "runtime.php"
                 }
               },
               "init": null,
@@ -707,7 +707,7 @@
                     "line": 11,
                     "column": 20
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "runtime.php"
                 }
               },
               "loc": {
@@ -719,7 +719,7 @@
                   "line": 11,
                   "column": 20
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "runtime.php"
               }
             }
           ],
@@ -752,7 +752,7 @@
                             "line": 12,
                             "column": 14
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                          "sourcefile": "runtime.php"
                         }
                       },
                       "loc": {
@@ -764,7 +764,7 @@
                           "line": 12,
                           "column": 14
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                        "sourcefile": "runtime.php"
                       }
                     },
                     "right": {
@@ -780,7 +780,7 @@
                             "line": 12,
                             "column": 19
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                          "sourcefile": "runtime.php"
                         }
                       },
                       "loc": {
@@ -792,7 +792,7 @@
                           "line": 12,
                           "column": 19
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                        "sourcefile": "runtime.php"
                       }
                     },
                     "_meta": {
@@ -805,7 +805,7 @@
                           "line": 12,
                           "column": 19
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                        "sourcefile": "runtime.php"
                       }
                     },
                     "loc": {
@@ -817,7 +817,7 @@
                         "line": 12,
                         "column": 19
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "runtime.php"
                     }
                   },
                   "right": {
@@ -833,7 +833,7 @@
                           "line": 12,
                           "column": 24
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                        "sourcefile": "runtime.php"
                       }
                     },
                     "loc": {
@@ -845,7 +845,7 @@
                         "line": 12,
                         "column": 24
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "runtime.php"
                     }
                   },
                   "_meta": {
@@ -858,7 +858,7 @@
                         "line": 12,
                         "column": 24
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "runtime.php"
                     }
                   },
                   "loc": {
@@ -870,7 +870,7 @@
                       "line": 12,
                       "column": 24
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "runtime.php"
                   }
                 },
                 "isYield": false,
@@ -884,7 +884,7 @@
                       "line": 12,
                       "column": 25
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "runtime.php"
                   }
                 },
                 "loc": {
@@ -896,7 +896,7 @@
                     "line": 12,
                     "column": 25
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "runtime.php"
                 }
               }
             ],
@@ -911,7 +911,7 @@
                   "line": 13,
                   "column": 2
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "runtime.php"
               }
             },
             "loc": {
@@ -923,7 +923,7 @@
                 "line": 13,
                 "column": 2
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "runtime.php"
             }
           },
           "modifiers": [],
@@ -937,7 +937,7 @@
                 "line": 13,
                 "column": 2
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "runtime.php"
             },
             "uses": [
               {
@@ -953,7 +953,7 @@
                       "line": 11,
                       "column": 30
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "runtime.php"
                   },
                   "byref": true
                 },
@@ -966,7 +966,7 @@
                     "line": 11,
                     "column": 30
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "runtime.php"
                 }
               },
               {
@@ -982,7 +982,7 @@
                       "line": 11,
                       "column": 34
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "runtime.php"
                   }
                 },
                 "loc": {
@@ -994,7 +994,7 @@
                     "line": 11,
                     "column": 34
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "runtime.php"
                 }
               }
             ]
@@ -1008,7 +1008,7 @@
               "line": 13,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "runtime.php"
           }
         },
         "operator": "=",
@@ -1023,7 +1023,7 @@
               "line": 13,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "runtime.php"
           }
         },
         "loc": {
@@ -1035,7 +1035,7 @@
             "line": 13,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+          "sourcefile": "runtime.php"
         }
       },
       "_meta": {
@@ -1048,7 +1048,7 @@
             "line": 13,
             "column": 3
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+          "sourcefile": "runtime.php"
         }
       },
       "loc": {
@@ -1060,13 +1060,13 @@
           "line": 13,
           "column": 3
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+        "sourcefile": "runtime.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php",
+  "uri": "runtime.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -1078,7 +1078,7 @@
         "line": 14,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+      "sourcefile": "runtime.php"
     }
   },
   "loc": {
@@ -1090,6 +1090,6 @@
       "line": 14,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+    "sourcefile": "runtime.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/runtime.php.json
+++ b/parser-PHP/tests/benchmark/base/runtime.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 13
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
           }
         },
         "loc": {
@@ -28,7 +28,7 @@
             "line": 3,
             "column": 13
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
         }
       },
       "parameters": [
@@ -47,7 +47,7 @@
                   "line": 3,
                   "column": 19
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "loc": {
@@ -59,7 +59,7 @@
                 "line": 3,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           "init": null,
@@ -80,7 +80,7 @@
                 "line": 3,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           "loc": {
@@ -92,7 +92,7 @@
               "line": 3,
               "column": 19
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
           }
         },
         {
@@ -110,7 +110,7 @@
                   "line": 3,
                   "column": 23
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "loc": {
@@ -122,7 +122,7 @@
                 "line": 3,
                 "column": 23
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           "init": null,
@@ -143,7 +143,7 @@
                 "line": 3,
                 "column": 23
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           "loc": {
@@ -155,7 +155,7 @@
               "line": 3,
               "column": 23
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
           }
         }
       ],
@@ -190,7 +190,7 @@
                         "line": 5,
                         "column": 13
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                     }
                   },
                   "loc": {
@@ -202,7 +202,7 @@
                       "line": 5,
                       "column": 13
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 }
               ],
@@ -216,7 +216,7 @@
                     "line": 5,
                     "column": 13
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               },
               "loc": {
@@ -228,7 +228,7 @@
                   "line": 5,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "_meta": {
@@ -241,7 +241,7 @@
                   "line": 5,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "loc": {
@@ -253,7 +253,7 @@
                 "line": 5,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           {
@@ -273,7 +273,7 @@
                       "line": 6,
                       "column": 9
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 },
                 "loc": {
@@ -285,7 +285,7 @@
                     "line": 6,
                     "column": 9
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               },
               "arguments": [
@@ -302,7 +302,7 @@
                         "line": 6,
                         "column": 15
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                     }
                   },
                   "loc": {
@@ -314,7 +314,7 @@
                       "line": 6,
                       "column": 15
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 }
               ],
@@ -328,7 +328,7 @@
                     "line": 6,
                     "column": 16
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               },
               "loc": {
@@ -340,7 +340,7 @@
                   "line": 6,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "_meta": {
@@ -353,7 +353,7 @@
                   "line": 6,
                   "column": 17
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "loc": {
@@ -365,7 +365,7 @@
                 "line": 6,
                 "column": 17
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           {
@@ -387,7 +387,7 @@
                         "line": 7,
                         "column": 11
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                     }
                   },
                   "loc": {
@@ -399,7 +399,7 @@
                       "line": 7,
                       "column": 11
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 },
                 "property": {
@@ -415,7 +415,7 @@
                         "line": 7,
                         "column": 17
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                     }
                   },
                   "loc": {
@@ -427,7 +427,7 @@
                       "line": 7,
                       "column": 17
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 },
                 "computed": false,
@@ -441,7 +441,7 @@
                       "line": 7,
                       "column": 19
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 },
                 "loc": {
@@ -453,7 +453,7 @@
                     "line": 7,
                     "column": 19
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               },
               "arguments": [],
@@ -467,7 +467,7 @@
                     "line": 7,
                     "column": 19
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 },
                 "silent": true
               },
@@ -480,7 +480,7 @@
                   "line": 7,
                   "column": 19
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "_meta": {
@@ -493,7 +493,7 @@
                   "line": 7,
                   "column": 20
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "loc": {
@@ -505,7 +505,7 @@
                 "line": 7,
                 "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           {
@@ -529,7 +529,7 @@
                       "line": 8,
                       "column": 15
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 },
                 "loc": {
@@ -541,7 +541,7 @@
                     "line": 8,
                     "column": 15
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               }
             ],
@@ -555,7 +555,7 @@
                   "line": 8,
                   "column": 17
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "loc": {
@@ -567,7 +567,7 @@
                 "line": 8,
                 "column": 17
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             }
           }
         ],
@@ -582,7 +582,7 @@
               "line": 9,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
           }
         },
         "loc": {
@@ -594,7 +594,7 @@
             "line": 9,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
         }
       },
       "modifiers": [],
@@ -608,7 +608,7 @@
             "line": 9,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
         }
       },
       "loc": {
@@ -620,7 +620,7 @@
           "line": 9,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
       }
     },
     {
@@ -640,7 +640,7 @@
                 "line": 11,
                 "column": 4
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           "loc": {
@@ -652,7 +652,7 @@
               "line": 11,
               "column": 4
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
           }
         },
         "right": {
@@ -674,7 +674,7 @@
                       "line": 11,
                       "column": 20
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 },
                 "loc": {
@@ -686,7 +686,7 @@
                     "line": 11,
                     "column": 20
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               },
               "init": null,
@@ -707,7 +707,7 @@
                     "line": 11,
                     "column": 20
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               },
               "loc": {
@@ -719,7 +719,7 @@
                   "line": 11,
                   "column": 20
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               }
             }
           ],
@@ -752,7 +752,7 @@
                             "line": 12,
                             "column": 14
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                         }
                       },
                       "loc": {
@@ -764,7 +764,7 @@
                           "line": 12,
                           "column": 14
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                       }
                     },
                     "right": {
@@ -780,7 +780,7 @@
                             "line": 12,
                             "column": 19
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                         }
                       },
                       "loc": {
@@ -792,7 +792,7 @@
                           "line": 12,
                           "column": 19
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                       }
                     },
                     "_meta": {
@@ -805,7 +805,7 @@
                           "line": 12,
                           "column": 19
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                       }
                     },
                     "loc": {
@@ -817,7 +817,7 @@
                         "line": 12,
                         "column": 19
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                     }
                   },
                   "right": {
@@ -833,7 +833,7 @@
                           "line": 12,
                           "column": 24
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                       }
                     },
                     "loc": {
@@ -845,7 +845,7 @@
                         "line": 12,
                         "column": 24
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                     }
                   },
                   "_meta": {
@@ -858,7 +858,7 @@
                         "line": 12,
                         "column": 24
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                     }
                   },
                   "loc": {
@@ -870,7 +870,7 @@
                       "line": 12,
                       "column": 24
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 },
                 "isYield": false,
@@ -884,7 +884,7 @@
                       "line": 12,
                       "column": 25
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 },
                 "loc": {
@@ -896,7 +896,7 @@
                     "line": 12,
                     "column": 25
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               }
             ],
@@ -911,7 +911,7 @@
                   "line": 13,
                   "column": 2
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "loc": {
@@ -923,7 +923,7 @@
                 "line": 13,
                 "column": 2
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           "modifiers": [],
@@ -937,7 +937,7 @@
                 "line": 13,
                 "column": 2
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             },
             "uses": [
               {
@@ -953,7 +953,7 @@
                       "line": 11,
                       "column": 30
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   },
                   "byref": true
                 },
@@ -966,7 +966,7 @@
                     "line": 11,
                     "column": 30
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               },
               {
@@ -982,7 +982,7 @@
                       "line": 11,
                       "column": 34
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 },
                 "loc": {
@@ -994,7 +994,7 @@
                     "line": 11,
                     "column": 34
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               }
             ]
@@ -1008,7 +1008,7 @@
               "line": 13,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
           }
         },
         "operator": "=",
@@ -1023,7 +1023,7 @@
               "line": 13,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
           }
         },
         "loc": {
@@ -1035,7 +1035,7 @@
             "line": 13,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
         }
       },
       "_meta": {
@@ -1048,7 +1048,7 @@
             "line": 13,
             "column": 3
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
         }
       },
       "loc": {
@@ -1060,13 +1060,13 @@
           "line": 13,
           "column": 3
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -1078,7 +1078,7 @@
         "line": 14,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
     }
   },
   "loc": {
@@ -1090,6 +1090,6 @@
       "line": 14,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/runtime.php.json
+++ b/parser-PHP/tests/benchmark/base/runtime.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 13
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
           },
           "origin": {
             "kind": "identifier",
@@ -45,7 +45,7 @@
             "line": 3,
             "column": 13
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
         }
       },
       "parameters": [
@@ -64,7 +64,7 @@
                   "line": 3,
                   "column": 19
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -93,7 +93,7 @@
                 "line": 3,
                 "column": 19
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           "init": null,
@@ -116,7 +116,7 @@
                 "line": 3,
                 "column": 19
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             },
             "origin": {
               "kind": "parameter",
@@ -169,7 +169,7 @@
               "line": 3,
               "column": 19
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
           }
         },
         {
@@ -187,7 +187,7 @@
                   "line": 3,
                   "column": 23
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -216,7 +216,7 @@
                 "line": 3,
                 "column": 23
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           "init": null,
@@ -239,7 +239,7 @@
                 "line": 3,
                 "column": 23
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             },
             "origin": {
               "kind": "parameter",
@@ -292,7 +292,7 @@
               "line": 3,
               "column": 23
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
           }
         }
       ],
@@ -327,7 +327,7 @@
                         "line": 5,
                         "column": 13
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                     },
                     "origin": {
                       "kind": "variable",
@@ -357,7 +357,7 @@
                       "line": 5,
                       "column": 13
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 }
               ],
@@ -372,7 +372,7 @@
                     "line": 5,
                     "column": 14
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 },
                 "origin": {
                   "kind": "print",
@@ -418,7 +418,7 @@
                   "line": 5,
                   "column": 14
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "_meta": {
@@ -431,7 +431,7 @@
                   "line": 5,
                   "column": 14
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               },
               "origin": {
                 "kind": "expressionstatement",
@@ -493,7 +493,7 @@
                 "line": 5,
                 "column": 14
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           {
@@ -519,7 +519,7 @@
                         "line": 6,
                         "column": 15
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                     },
                     "origin": {
                       "kind": "variable",
@@ -549,7 +549,7 @@
                       "line": 6,
                       "column": 15
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 }
               ],
@@ -564,7 +564,7 @@
                     "line": 6,
                     "column": 17
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 },
                 "origin": {
                   "kind": "eval",
@@ -610,7 +610,7 @@
                   "line": 6,
                   "column": 17
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "_meta": {
@@ -623,7 +623,7 @@
                   "line": 6,
                   "column": 17
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               },
               "origin": {
                 "kind": "expressionstatement",
@@ -685,7 +685,7 @@
                 "line": 6,
                 "column": 17
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           {
@@ -707,7 +707,7 @@
                         "line": 7,
                         "column": 11
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                     },
                     "origin": {
                       "kind": "variable",
@@ -737,7 +737,7 @@
                       "line": 7,
                       "column": 11
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 },
                 "property": {
@@ -753,7 +753,7 @@
                         "line": 7,
                         "column": 17
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                     },
                     "origin": {
                       "kind": "identifier",
@@ -782,7 +782,7 @@
                       "line": 7,
                       "column": 17
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 },
                 "computed": false,
@@ -796,7 +796,7 @@
                       "line": 7,
                       "column": 17
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   },
                   "origin": {
                     "kind": "propertylookup",
@@ -859,7 +859,7 @@
                     "line": 7,
                     "column": 17
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               },
               "arguments": [],
@@ -873,7 +873,7 @@
                     "line": 7,
                     "column": 19
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 },
                 "origin": {
                   "kind": "call",
@@ -954,7 +954,7 @@
                   "line": 7,
                   "column": 19
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "_meta": {
@@ -967,7 +967,7 @@
                   "line": 7,
                   "column": 20
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               },
               "origin": {
                 "kind": "expressionstatement",
@@ -1079,7 +1079,7 @@
                 "line": 7,
                 "column": 20
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           {
@@ -1105,7 +1105,7 @@
                         "line": 8,
                         "column": 15
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                     },
                     "origin": {
                       "kind": "variable",
@@ -1135,7 +1135,7 @@
                       "line": 8,
                       "column": 15
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 }
               ],
@@ -1150,7 +1150,7 @@
                     "line": 8,
                     "column": 17
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 },
                 "origin": {
                   "kind": "exit",
@@ -1198,7 +1198,7 @@
                   "line": 8,
                   "column": 17
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "_meta": {
@@ -1211,7 +1211,7 @@
                   "line": 8,
                   "column": 17
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               },
               "origin": {
                 "kind": "expressionstatement",
@@ -1274,7 +1274,7 @@
                 "line": 8,
                 "column": 17
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             }
           }
         ],
@@ -1289,7 +1289,7 @@
               "line": 9,
               "column": 2
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
           },
           "origin": {
             "kind": "block",
@@ -1570,7 +1570,7 @@
             "line": 9,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
         }
       },
       "modifiers": [],
@@ -1585,7 +1585,7 @@
             "line": 9,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
         },
         "origin": {
           "kind": "function",
@@ -1987,7 +1987,7 @@
           "line": 9,
           "column": 2
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
       }
     },
     {
@@ -2007,7 +2007,7 @@
                 "line": 11,
                 "column": 4
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             },
             "origin": {
               "kind": "variable",
@@ -2037,7 +2037,7 @@
               "line": 11,
               "column": 4
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
           }
         },
         "right": {
@@ -2059,7 +2059,7 @@
                       "line": 11,
                       "column": 20
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   },
                   "origin": {
                     "kind": "identifier",
@@ -2088,7 +2088,7 @@
                     "line": 11,
                     "column": 20
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               },
               "init": null,
@@ -2111,7 +2111,7 @@
                     "line": 11,
                     "column": 20
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 },
                 "origin": {
                   "kind": "parameter",
@@ -2164,7 +2164,7 @@
                   "line": 11,
                   "column": 20
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               }
             }
           ],
@@ -2197,7 +2197,7 @@
                             "line": 12,
                             "column": 14
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                         },
                         "origin": {
                           "kind": "variable",
@@ -2227,7 +2227,7 @@
                           "line": 12,
                           "column": 14
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                       }
                     },
                     "right": {
@@ -2243,7 +2243,7 @@
                             "line": 12,
                             "column": 19
                           },
-                          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                         },
                         "origin": {
                           "kind": "variable",
@@ -2273,7 +2273,7 @@
                           "line": 12,
                           "column": 19
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                       }
                     },
                     "_meta": {
@@ -2286,7 +2286,7 @@
                           "line": 12,
                           "column": 19
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                       },
                       "origin": {
                         "kind": "bin",
@@ -2351,7 +2351,7 @@
                         "line": 12,
                         "column": 19
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                     }
                   },
                   "right": {
@@ -2367,7 +2367,7 @@
                           "line": 12,
                           "column": 24
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                       },
                       "origin": {
                         "kind": "variable",
@@ -2397,7 +2397,7 @@
                         "line": 12,
                         "column": 24
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                     }
                   },
                   "_meta": {
@@ -2410,7 +2410,7 @@
                         "line": 12,
                         "column": 24
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                     },
                     "origin": {
                       "kind": "bin",
@@ -2510,7 +2510,7 @@
                       "line": 12,
                       "column": 24
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 },
                 "isYield": false,
@@ -2524,7 +2524,7 @@
                       "line": 12,
                       "column": 25
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   },
                   "origin": {
                     "kind": "return",
@@ -2640,7 +2640,7 @@
                     "line": 12,
                     "column": 25
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               }
             ],
@@ -2655,7 +2655,7 @@
                   "line": 13,
                   "column": 2
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
               },
               "origin": {
                 "kind": "block",
@@ -2789,7 +2789,7 @@
                 "line": 13,
                 "column": 2
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           "modifiers": [],
@@ -2804,7 +2804,7 @@
                 "line": 13,
                 "column": 2
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
             },
             "origin": {
               "kind": "closure",
@@ -3045,7 +3045,7 @@
                       "line": 11,
                       "column": 30
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   },
                   "origin": {
                     "kind": "variable",
@@ -3077,7 +3077,7 @@
                     "line": 11,
                     "column": 30
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               },
               {
@@ -3093,7 +3093,7 @@
                       "line": 11,
                       "column": 34
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                   },
                   "origin": {
                     "kind": "variable",
@@ -3124,7 +3124,7 @@
                     "line": 11,
                     "column": 34
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               }
             ],
@@ -3139,7 +3139,7 @@
               "line": 13,
               "column": 2
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
           }
         },
         "operator": "=",
@@ -3154,7 +3154,7 @@
               "line": 13,
               "column": 3
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
           },
           "origin": {
             "kind": "assign",
@@ -3426,7 +3426,7 @@
             "line": 13,
             "column": 3
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
         }
       },
       "_meta": {
@@ -3439,7 +3439,7 @@
             "line": 13,
             "column": 3
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
         },
         "origin": {
           "kind": "expressionstatement",
@@ -3727,13 +3727,13 @@
           "line": 13,
           "column": 3
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -3745,7 +3745,7 @@
         "line": 14,
         "column": 1
       },
-      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
     },
     "origin": {
       "kind": "program",
@@ -4443,6 +4443,6 @@
       "line": 14,
       "column": 1
     },
-    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/runtime.php.json
+++ b/parser-PHP/tests/benchmark/base/runtime.php.json
@@ -16,24 +16,7 @@
               "line": 3,
               "column": 13
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-          },
-          "origin": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 9,
-                "offset": 16
-              },
-              "end": {
-                "line": 3,
-                "column": 12,
-                "offset": 19
-              }
-            },
-            "name": "run"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
           }
         },
         "loc": {
@@ -45,7 +28,7 @@
             "line": 3,
             "column": 13
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
         }
       },
       "parameters": [
@@ -64,24 +47,7 @@
                   "line": 3,
                   "column": 19
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 13,
-                    "offset": 20
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 18,
-                    "offset": 25
-                  }
-                },
-                "name": "code"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "loc": {
@@ -93,7 +59,7 @@
                 "line": 3,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           "init": null,
@@ -104,9 +70,7 @@
             "_meta": {}
           },
           "_meta": {
-            "byref": false,
             "variadic": false,
-            "attributes": [],
             "loc": {
               "start": {
                 "line": 3,
@@ -116,48 +80,7 @@
                 "line": 3,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-            },
-            "origin": {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 13,
-                  "offset": 20
-                },
-                "end": {
-                  "line": 3,
-                  "column": 18,
-                  "offset": 25
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 13,
-                    "offset": 20
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 18,
-                    "offset": 25
-                  }
-                },
-                "name": "code"
-              },
-              "value": null,
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           "loc": {
@@ -169,7 +92,7 @@
               "line": 3,
               "column": 19
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
           }
         },
         {
@@ -187,24 +110,7 @@
                   "line": 3,
                   "column": 23
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 20,
-                    "offset": 27
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 22,
-                    "offset": 29
-                  }
-                },
-                "name": "x"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "loc": {
@@ -216,7 +122,7 @@
                 "line": 3,
                 "column": 23
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           "init": null,
@@ -227,9 +133,7 @@
             "_meta": {}
           },
           "_meta": {
-            "byref": false,
             "variadic": false,
-            "attributes": [],
             "loc": {
               "start": {
                 "line": 3,
@@ -239,48 +143,7 @@
                 "line": 3,
                 "column": 23
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-            },
-            "origin": {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 20,
-                  "offset": 27
-                },
-                "end": {
-                  "line": 3,
-                  "column": 22,
-                  "offset": 29
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 20,
-                    "offset": 27
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 22,
-                    "offset": 29
-                  }
-                },
-                "name": "x"
-              },
-              "value": null,
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           "loc": {
@@ -292,7 +155,7 @@
               "line": 3,
               "column": 23
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
           }
         }
       ],
@@ -327,25 +190,7 @@
                         "line": 5,
                         "column": 13
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-                    },
-                    "origin": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 5,
-                          "column": 10,
-                          "offset": 43
-                        },
-                        "end": {
-                          "line": 5,
-                          "column": 12,
-                          "offset": 45
-                        }
-                      },
-                      "name": "x",
-                      "curly": false
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                     }
                   },
                   "loc": {
@@ -357,12 +202,11 @@
                       "line": 5,
                       "column": 13
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 }
               ],
               "_meta": {
-                "synthetic": true,
                 "loc": {
                   "start": {
                     "line": 5,
@@ -370,43 +214,9 @@
                   },
                   "end": {
                     "line": 5,
-                    "column": 14
+                    "column": 13
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-                },
-                "origin": {
-                  "kind": "print",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 4,
-                      "offset": 37
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 13,
-                      "offset": 46
-                    }
-                  },
-                  "expression": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 10,
-                        "offset": 43
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 12,
-                        "offset": 45
-                      }
-                    },
-                    "name": "x",
-                    "curly": false
-                  }
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               },
               "loc": {
@@ -416,9 +226,9 @@
                 },
                 "end": {
                   "line": 5,
-                  "column": 14
+                  "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "_meta": {
@@ -431,57 +241,7 @@
                   "line": 5,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-              },
-              "origin": {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 4,
-                    "offset": 37
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 13,
-                    "offset": 46
-                  }
-                },
-                "expression": {
-                  "kind": "print",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 4,
-                      "offset": 37
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 13,
-                      "offset": 46
-                    }
-                  },
-                  "expression": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 10,
-                        "offset": 43
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 12,
-                        "offset": 45
-                      }
-                    },
-                    "name": "x",
-                    "curly": false
-                  }
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "loc": {
@@ -493,7 +253,7 @@
                 "line": 5,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           {
@@ -503,7 +263,30 @@
               "callee": {
                 "type": "Identifier",
                 "name": "eval",
-                "_meta": {}
+                "_meta": {
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 9
+                    },
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                  }
+                },
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 9
+                  },
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                }
               },
               "arguments": [
                 {
@@ -519,25 +302,7 @@
                         "line": 6,
                         "column": 15
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-                    },
-                    "origin": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 6,
-                          "column": 9,
-                          "offset": 56
-                        },
-                        "end": {
-                          "line": 6,
-                          "column": 14,
-                          "offset": 61
-                        }
-                      },
-                      "name": "code",
-                      "curly": false
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                     }
                   },
                   "loc": {
@@ -549,12 +314,11 @@
                       "line": 6,
                       "column": 15
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 }
               ],
               "_meta": {
-                "synthetic": true,
                 "loc": {
                   "start": {
                     "line": 6,
@@ -562,43 +326,9 @@
                   },
                   "end": {
                     "line": 6,
-                    "column": 17
+                    "column": 16
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-                },
-                "origin": {
-                  "kind": "eval",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 4,
-                      "offset": 51
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 16,
-                      "offset": 63
-                    }
-                  },
-                  "source": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 9,
-                        "offset": 56
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 14,
-                        "offset": 61
-                      }
-                    },
-                    "name": "code",
-                    "curly": false
-                  }
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               },
               "loc": {
@@ -608,9 +338,9 @@
                 },
                 "end": {
                   "line": 6,
-                  "column": 17
+                  "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "_meta": {
@@ -623,57 +353,7 @@
                   "line": 6,
                   "column": 17
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-              },
-              "origin": {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 4,
-                    "offset": 51
-                  },
-                  "end": {
-                    "line": 6,
-                    "column": 16,
-                    "offset": 63
-                  }
-                },
-                "expression": {
-                  "kind": "eval",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 4,
-                      "offset": 51
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 16,
-                      "offset": 63
-                    }
-                  },
-                  "source": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 9,
-                        "offset": 56
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 14,
-                        "offset": 61
-                      }
-                    },
-                    "name": "code",
-                    "curly": false
-                  }
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "loc": {
@@ -685,7 +365,7 @@
                 "line": 6,
                 "column": 17
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           {
@@ -707,25 +387,7 @@
                         "line": 7,
                         "column": 11
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-                    },
-                    "origin": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 7,
-                          "column": 5,
-                          "offset": 69
-                        },
-                        "end": {
-                          "line": 7,
-                          "column": 10,
-                          "offset": 74
-                        }
-                      },
-                      "name": "this",
-                      "curly": false
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                     }
                   },
                   "loc": {
@@ -737,7 +399,7 @@
                       "line": 7,
                       "column": 11
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 },
                 "property": {
@@ -753,24 +415,7 @@
                         "line": 7,
                         "column": 17
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-                    },
-                    "origin": {
-                      "kind": "identifier",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 7,
-                          "column": 12,
-                          "offset": 76
-                        },
-                        "end": {
-                          "line": 7,
-                          "column": 16,
-                          "offset": 80
-                        }
-                      },
-                      "name": "call"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                     }
                   },
                   "loc": {
@@ -782,7 +427,7 @@
                       "line": 7,
                       "column": 17
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 },
                 "computed": false,
@@ -794,60 +439,9 @@
                     },
                     "end": {
                       "line": 7,
-                      "column": 17
+                      "column": 19
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-                  },
-                  "origin": {
-                    "kind": "propertylookup",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 7,
-                        "column": 5,
-                        "offset": 69
-                      },
-                      "end": {
-                        "line": 7,
-                        "column": 16,
-                        "offset": 80
-                      }
-                    },
-                    "what": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 7,
-                          "column": 5,
-                          "offset": 69
-                        },
-                        "end": {
-                          "line": 7,
-                          "column": 10,
-                          "offset": 74
-                        }
-                      },
-                      "name": "this",
-                      "curly": false
-                    },
-                    "offset": {
-                      "kind": "identifier",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 7,
-                          "column": 12,
-                          "offset": 76
-                        },
-                        "end": {
-                          "line": 7,
-                          "column": 16,
-                          "offset": 80
-                        }
-                      },
-                      "name": "call"
-                    }
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 },
                 "loc": {
@@ -857,9 +451,9 @@
                   },
                   "end": {
                     "line": 7,
-                    "column": 17
+                    "column": 19
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               },
               "arguments": [],
@@ -873,75 +467,7 @@
                     "line": 7,
                     "column": 19
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-                },
-                "origin": {
-                  "kind": "call",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 7,
-                      "column": 5,
-                      "offset": 69
-                    },
-                    "end": {
-                      "line": 7,
-                      "column": 18,
-                      "offset": 82
-                    }
-                  },
-                  "what": {
-                    "kind": "propertylookup",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 7,
-                        "column": 5,
-                        "offset": 69
-                      },
-                      "end": {
-                        "line": 7,
-                        "column": 16,
-                        "offset": 80
-                      }
-                    },
-                    "what": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 7,
-                          "column": 5,
-                          "offset": 69
-                        },
-                        "end": {
-                          "line": 7,
-                          "column": 10,
-                          "offset": 74
-                        }
-                      },
-                      "name": "this",
-                      "curly": false
-                    },
-                    "offset": {
-                      "kind": "identifier",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 7,
-                          "column": 12,
-                          "offset": 76
-                        },
-                        "end": {
-                          "line": 7,
-                          "column": 16,
-                          "offset": 80
-                        }
-                      },
-                      "name": "call"
-                    }
-                  },
-                  "arguments": []
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                 },
                 "silent": true
               },
@@ -954,7 +480,7 @@
                   "line": 7,
                   "column": 19
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "_meta": {
@@ -967,107 +493,7 @@
                   "line": 7,
                   "column": 20
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-              },
-              "origin": {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 7,
-                    "column": 4,
-                    "offset": 68
-                  },
-                  "end": {
-                    "line": 7,
-                    "column": 19,
-                    "offset": 83
-                  }
-                },
-                "expression": {
-                  "kind": "silent",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 7,
-                      "column": 4,
-                      "offset": 68
-                    },
-                    "end": {
-                      "line": 7,
-                      "column": 19,
-                      "offset": 83
-                    }
-                  },
-                  "expr": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 7,
-                        "column": 5,
-                        "offset": 69
-                      },
-                      "end": {
-                        "line": 7,
-                        "column": 18,
-                        "offset": 82
-                      }
-                    },
-                    "what": {
-                      "kind": "propertylookup",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 7,
-                          "column": 5,
-                          "offset": 69
-                        },
-                        "end": {
-                          "line": 7,
-                          "column": 16,
-                          "offset": 80
-                        }
-                      },
-                      "what": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 7,
-                            "column": 5,
-                            "offset": 69
-                          },
-                          "end": {
-                            "line": 7,
-                            "column": 10,
-                            "offset": 74
-                          }
-                        },
-                        "name": "this",
-                        "curly": false
-                      },
-                      "offset": {
-                        "kind": "identifier",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 7,
-                            "column": 12,
-                            "offset": 76
-                          },
-                          "end": {
-                            "line": 7,
-                            "column": 16,
-                            "offset": 80
-                          }
-                        },
-                        "name": "call"
-                      }
-                    },
-                    "arguments": []
-                  }
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "loc": {
@@ -1079,53 +505,21 @@
                 "line": 7,
                 "column": 20
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           {
-            "type": "ExpressionStatement",
-            "expression": {
-              "type": "CallExpression",
-              "callee": {
+            "type": "CallExpression",
+            "callee": {
+              "type": "Identifier",
+              "name": "exit",
+              "_meta": {}
+            },
+            "arguments": [
+              {
                 "type": "Identifier",
-                "name": "exit",
-                "_meta": {}
-              },
-              "arguments": [
-                {
-                  "type": "Identifier",
-                  "name": "code",
-                  "_meta": {
-                    "loc": {
-                      "start": {
-                        "line": 8,
-                        "column": 10
-                      },
-                      "end": {
-                        "line": 8,
-                        "column": 15
-                      },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-                    },
-                    "origin": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 8,
-                          "column": 9,
-                          "offset": 93
-                        },
-                        "end": {
-                          "line": 8,
-                          "column": 14,
-                          "offset": 98
-                        }
-                      },
-                      "name": "code",
-                      "curly": false
-                    }
-                  },
+                "name": "code",
+                "_meta": {
                   "loc": {
                     "start": {
                       "line": 8,
@@ -1135,72 +529,22 @@
                       "line": 8,
                       "column": 15
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                   }
-                }
-              ],
-              "_meta": {
-                "synthetic": true,
+                },
                 "loc": {
                   "start": {
                     "line": 8,
-                    "column": 5
+                    "column": 10
                   },
                   "end": {
                     "line": 8,
-                    "column": 17
+                    "column": 15
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-                },
-                "origin": {
-                  "kind": "exit",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 4,
-                      "offset": 88
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 16,
-                      "offset": 100
-                    }
-                  },
-                  "expression": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 8,
-                        "column": 9,
-                        "offset": 93
-                      },
-                      "end": {
-                        "line": 8,
-                        "column": 14,
-                        "offset": 98
-                      }
-                    },
-                    "name": "code",
-                    "curly": false
-                  },
-                  "useDie": false
-                },
-                "useDie": false
-              },
-              "loc": {
-                "start": {
-                  "line": 8,
-                  "column": 5
-                },
-                "end": {
-                  "line": 8,
-                  "column": 17
-                },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                }
               }
-            },
+            ],
             "_meta": {
               "loc": {
                 "start": {
@@ -1211,58 +555,7 @@
                   "line": 8,
                   "column": 17
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-              },
-              "origin": {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 8,
-                    "column": 4,
-                    "offset": 88
-                  },
-                  "end": {
-                    "line": 8,
-                    "column": 16,
-                    "offset": 100
-                  }
-                },
-                "expression": {
-                  "kind": "exit",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 4,
-                      "offset": 88
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 16,
-                      "offset": 100
-                    }
-                  },
-                  "expression": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 8,
-                        "column": 9,
-                        "offset": 93
-                      },
-                      "end": {
-                        "line": 8,
-                        "column": 14,
-                        "offset": 98
-                      }
-                    },
-                    "name": "code",
-                    "curly": false
-                  },
-                  "useDie": false
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "loc": {
@@ -1274,7 +567,7 @@
                 "line": 8,
                 "column": 17
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
             }
           }
         ],
@@ -1289,276 +582,7 @@
               "line": 9,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-          },
-          "origin": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 4,
-                "column": 0,
-                "offset": 31
-              },
-              "end": {
-                "line": 9,
-                "column": 1,
-                "offset": 102
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 4,
-                    "offset": 37
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 13,
-                    "offset": 46
-                  }
-                },
-                "expression": {
-                  "kind": "print",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 4,
-                      "offset": 37
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 13,
-                      "offset": 46
-                    }
-                  },
-                  "expression": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 10,
-                        "offset": 43
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 12,
-                        "offset": 45
-                      }
-                    },
-                    "name": "x",
-                    "curly": false
-                  }
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 4,
-                    "offset": 51
-                  },
-                  "end": {
-                    "line": 6,
-                    "column": 16,
-                    "offset": 63
-                  }
-                },
-                "expression": {
-                  "kind": "eval",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 4,
-                      "offset": 51
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 16,
-                      "offset": 63
-                    }
-                  },
-                  "source": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 9,
-                        "offset": 56
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 14,
-                        "offset": 61
-                      }
-                    },
-                    "name": "code",
-                    "curly": false
-                  }
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 7,
-                    "column": 4,
-                    "offset": 68
-                  },
-                  "end": {
-                    "line": 7,
-                    "column": 19,
-                    "offset": 83
-                  }
-                },
-                "expression": {
-                  "kind": "silent",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 7,
-                      "column": 4,
-                      "offset": 68
-                    },
-                    "end": {
-                      "line": 7,
-                      "column": 19,
-                      "offset": 83
-                    }
-                  },
-                  "expr": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 7,
-                        "column": 5,
-                        "offset": 69
-                      },
-                      "end": {
-                        "line": 7,
-                        "column": 18,
-                        "offset": 82
-                      }
-                    },
-                    "what": {
-                      "kind": "propertylookup",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 7,
-                          "column": 5,
-                          "offset": 69
-                        },
-                        "end": {
-                          "line": 7,
-                          "column": 16,
-                          "offset": 80
-                        }
-                      },
-                      "what": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 7,
-                            "column": 5,
-                            "offset": 69
-                          },
-                          "end": {
-                            "line": 7,
-                            "column": 10,
-                            "offset": 74
-                          }
-                        },
-                        "name": "this",
-                        "curly": false
-                      },
-                      "offset": {
-                        "kind": "identifier",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 7,
-                            "column": 12,
-                            "offset": 76
-                          },
-                          "end": {
-                            "line": 7,
-                            "column": 16,
-                            "offset": 80
-                          }
-                        },
-                        "name": "call"
-                      }
-                    },
-                    "arguments": []
-                  }
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 8,
-                    "column": 4,
-                    "offset": 88
-                  },
-                  "end": {
-                    "line": 8,
-                    "column": 16,
-                    "offset": 100
-                  }
-                },
-                "expression": {
-                  "kind": "exit",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 4,
-                      "offset": 88
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 16,
-                      "offset": 100
-                    }
-                  },
-                  "expression": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 8,
-                        "column": 9,
-                        "offset": 93
-                      },
-                      "end": {
-                        "line": 8,
-                        "column": 14,
-                        "offset": 98
-                      }
-                    },
-                    "name": "code",
-                    "curly": false
-                  },
-                  "useDie": false
-                }
-              }
-            ]
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
           }
         },
         "loc": {
@@ -1570,12 +594,11 @@
             "line": 9,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
         }
       },
       "modifiers": [],
       "_meta": {
-        "attributes": [],
         "loc": {
           "start": {
             "line": 3,
@@ -1585,397 +608,7 @@
             "line": 9,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-        },
-        "origin": {
-          "kind": "function",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 7
-            },
-            "end": {
-              "line": 9,
-              "column": 1,
-              "offset": 102
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 9,
-                "offset": 16
-              },
-              "end": {
-                "line": 3,
-                "column": 12,
-                "offset": 19
-              }
-            },
-            "name": "run"
-          },
-          "arguments": [
-            {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 13,
-                  "offset": 20
-                },
-                "end": {
-                  "line": 3,
-                  "column": 18,
-                  "offset": 25
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 13,
-                    "offset": 20
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 18,
-                    "offset": 25
-                  }
-                },
-                "name": "code"
-              },
-              "value": null,
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
-            },
-            {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 20,
-                  "offset": 27
-                },
-                "end": {
-                  "line": 3,
-                  "column": 22,
-                  "offset": 29
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 20,
-                    "offset": 27
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 22,
-                    "offset": 29
-                  }
-                },
-                "name": "x"
-              },
-              "value": null,
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
-            }
-          ],
-          "byref": false,
-          "type": null,
-          "nullable": false,
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 4,
-                "column": 0,
-                "offset": 31
-              },
-              "end": {
-                "line": 9,
-                "column": 1,
-                "offset": 102
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 4,
-                    "offset": 37
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 13,
-                    "offset": 46
-                  }
-                },
-                "expression": {
-                  "kind": "print",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 4,
-                      "offset": 37
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 13,
-                      "offset": 46
-                    }
-                  },
-                  "expression": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 10,
-                        "offset": 43
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 12,
-                        "offset": 45
-                      }
-                    },
-                    "name": "x",
-                    "curly": false
-                  }
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 4,
-                    "offset": 51
-                  },
-                  "end": {
-                    "line": 6,
-                    "column": 16,
-                    "offset": 63
-                  }
-                },
-                "expression": {
-                  "kind": "eval",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 4,
-                      "offset": 51
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 16,
-                      "offset": 63
-                    }
-                  },
-                  "source": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 9,
-                        "offset": 56
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 14,
-                        "offset": 61
-                      }
-                    },
-                    "name": "code",
-                    "curly": false
-                  }
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 7,
-                    "column": 4,
-                    "offset": 68
-                  },
-                  "end": {
-                    "line": 7,
-                    "column": 19,
-                    "offset": 83
-                  }
-                },
-                "expression": {
-                  "kind": "silent",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 7,
-                      "column": 4,
-                      "offset": 68
-                    },
-                    "end": {
-                      "line": 7,
-                      "column": 19,
-                      "offset": 83
-                    }
-                  },
-                  "expr": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 7,
-                        "column": 5,
-                        "offset": 69
-                      },
-                      "end": {
-                        "line": 7,
-                        "column": 18,
-                        "offset": 82
-                      }
-                    },
-                    "what": {
-                      "kind": "propertylookup",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 7,
-                          "column": 5,
-                          "offset": 69
-                        },
-                        "end": {
-                          "line": 7,
-                          "column": 16,
-                          "offset": 80
-                        }
-                      },
-                      "what": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 7,
-                            "column": 5,
-                            "offset": 69
-                          },
-                          "end": {
-                            "line": 7,
-                            "column": 10,
-                            "offset": 74
-                          }
-                        },
-                        "name": "this",
-                        "curly": false
-                      },
-                      "offset": {
-                        "kind": "identifier",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 7,
-                            "column": 12,
-                            "offset": 76
-                          },
-                          "end": {
-                            "line": 7,
-                            "column": 16,
-                            "offset": 80
-                          }
-                        },
-                        "name": "call"
-                      }
-                    },
-                    "arguments": []
-                  }
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 8,
-                    "column": 4,
-                    "offset": 88
-                  },
-                  "end": {
-                    "line": 8,
-                    "column": 16,
-                    "offset": 100
-                  }
-                },
-                "expression": {
-                  "kind": "exit",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 4,
-                      "offset": 88
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 16,
-                      "offset": 100
-                    }
-                  },
-                  "expression": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 8,
-                        "column": 9,
-                        "offset": 93
-                      },
-                      "end": {
-                        "line": 8,
-                        "column": 14,
-                        "offset": 98
-                      }
-                    },
-                    "name": "code",
-                    "curly": false
-                  },
-                  "useDie": false
-                }
-              }
-            ]
-          },
-          "attrGroups": []
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
         }
       },
       "loc": {
@@ -1987,7 +620,7 @@
           "line": 9,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
       }
     },
     {
@@ -2007,25 +640,7 @@
                 "line": 11,
                 "column": 4
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-            },
-            "origin": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 11,
-                  "column": 0,
-                  "offset": 104
-                },
-                "end": {
-                  "line": 11,
-                  "column": 3,
-                  "offset": 107
-                }
-              },
-              "name": "fn",
-              "curly": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           "loc": {
@@ -2037,7 +652,7 @@
               "line": 11,
               "column": 4
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
           }
         },
         "right": {
@@ -2059,24 +674,7 @@
                       "line": 11,
                       "column": 20
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-                  },
-                  "origin": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 11,
-                        "column": 17,
-                        "offset": 121
-                      },
-                      "end": {
-                        "line": 11,
-                        "column": 19,
-                        "offset": 123
-                      }
-                    },
-                    "name": "a"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 },
                 "loc": {
@@ -2088,7 +686,7 @@
                     "line": 11,
                     "column": 20
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               },
               "init": null,
@@ -2099,9 +697,7 @@
                 "_meta": {}
               },
               "_meta": {
-                "byref": false,
                 "variadic": false,
-                "attributes": [],
                 "loc": {
                   "start": {
                     "line": 11,
@@ -2111,48 +707,7 @@
                     "line": 11,
                     "column": 20
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-                },
-                "origin": {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 11,
-                      "column": 17,
-                      "offset": 121
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 19,
-                      "offset": 123
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 11,
-                        "column": 17,
-                        "offset": 121
-                      },
-                      "end": {
-                        "line": 11,
-                        "column": 19,
-                        "offset": 123
-                      }
-                    },
-                    "name": "a"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": []
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               },
               "loc": {
@@ -2164,7 +719,7 @@
                   "line": 11,
                   "column": 20
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
               }
             }
           ],
@@ -2197,25 +752,7 @@
                             "line": 12,
                             "column": 14
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-                        },
-                        "origin": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 11,
-                              "offset": 152
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 13,
-                              "offset": 154
-                            }
-                          },
-                          "name": "a",
-                          "curly": false
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                         }
                       },
                       "loc": {
@@ -2227,7 +764,7 @@
                           "line": 12,
                           "column": 14
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                       }
                     },
                     "right": {
@@ -2243,25 +780,7 @@
                             "line": 12,
                             "column": 19
                           },
-                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-                        },
-                        "origin": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 16,
-                              "offset": 157
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 18,
-                              "offset": 159
-                            }
-                          },
-                          "name": "x",
-                          "curly": false
+                          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                         }
                       },
                       "loc": {
@@ -2273,7 +792,7 @@
                           "line": 12,
                           "column": 19
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                       }
                     },
                     "_meta": {
@@ -2286,60 +805,7 @@
                           "line": 12,
                           "column": 19
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-                      },
-                      "origin": {
-                        "kind": "bin",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 11,
-                            "offset": 152
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 18,
-                            "offset": 159
-                          }
-                        },
-                        "type": "+",
-                        "left": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 11,
-                              "offset": 152
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 13,
-                              "offset": 154
-                            }
-                          },
-                          "name": "a",
-                          "curly": false
-                        },
-                        "right": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 16,
-                              "offset": 157
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 18,
-                              "offset": 159
-                            }
-                          },
-                          "name": "x",
-                          "curly": false
-                        }
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                       }
                     },
                     "loc": {
@@ -2351,7 +817,7 @@
                         "line": 12,
                         "column": 19
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                     }
                   },
                   "right": {
@@ -2367,25 +833,7 @@
                           "line": 12,
                           "column": 24
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-                      },
-                      "origin": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 21,
-                            "offset": 162
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 23,
-                            "offset": 164
-                          }
-                        },
-                        "name": "y",
-                        "curly": false
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                       }
                     },
                     "loc": {
@@ -2397,7 +845,7 @@
                         "line": 12,
                         "column": 24
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                     }
                   },
                   "_meta": {
@@ -2410,95 +858,7 @@
                         "line": 12,
                         "column": 24
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-                    },
-                    "origin": {
-                      "kind": "bin",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 12,
-                          "column": 11,
-                          "offset": 152
-                        },
-                        "end": {
-                          "line": 12,
-                          "column": 23,
-                          "offset": 164
-                        }
-                      },
-                      "type": "+",
-                      "left": {
-                        "kind": "bin",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 11,
-                            "offset": 152
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 18,
-                            "offset": 159
-                          }
-                        },
-                        "type": "+",
-                        "left": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 11,
-                              "offset": 152
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 13,
-                              "offset": 154
-                            }
-                          },
-                          "name": "a",
-                          "curly": false
-                        },
-                        "right": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 16,
-                              "offset": 157
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 18,
-                              "offset": 159
-                            }
-                          },
-                          "name": "x",
-                          "curly": false
-                        }
-                      },
-                      "right": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 21,
-                            "offset": 162
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 23,
-                            "offset": 164
-                          }
-                        },
-                        "name": "y",
-                        "curly": false
-                      }
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                     }
                   },
                   "loc": {
@@ -2510,7 +870,7 @@
                       "line": 12,
                       "column": 24
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 },
                 "isYield": false,
@@ -2524,111 +884,7 @@
                       "line": 12,
                       "column": 25
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-                  },
-                  "origin": {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 12,
-                        "column": 4,
-                        "offset": 145
-                      },
-                      "end": {
-                        "line": 12,
-                        "column": 24,
-                        "offset": 165
-                      }
-                    },
-                    "expr": {
-                      "kind": "bin",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 12,
-                          "column": 11,
-                          "offset": 152
-                        },
-                        "end": {
-                          "line": 12,
-                          "column": 23,
-                          "offset": 164
-                        }
-                      },
-                      "type": "+",
-                      "left": {
-                        "kind": "bin",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 11,
-                            "offset": 152
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 18,
-                            "offset": 159
-                          }
-                        },
-                        "type": "+",
-                        "left": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 11,
-                              "offset": 152
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 13,
-                              "offset": 154
-                            }
-                          },
-                          "name": "a",
-                          "curly": false
-                        },
-                        "right": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 16,
-                              "offset": 157
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 18,
-                              "offset": 159
-                            }
-                          },
-                          "name": "x",
-                          "curly": false
-                        }
-                      },
-                      "right": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 21,
-                            "offset": 162
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 23,
-                            "offset": 164
-                          }
-                        },
-                        "name": "y",
-                        "curly": false
-                      }
-                    }
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                   }
                 },
                 "loc": {
@@ -2640,7 +896,7 @@
                     "line": 12,
                     "column": 25
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               }
             ],
@@ -2655,129 +911,7 @@
                   "line": 13,
                   "column": 2
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-              },
-              "origin": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 11,
-                    "column": 35,
-                    "offset": 139
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 1,
-                    "offset": 167
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 12,
-                        "column": 4,
-                        "offset": 145
-                      },
-                      "end": {
-                        "line": 12,
-                        "column": 24,
-                        "offset": 165
-                      }
-                    },
-                    "expr": {
-                      "kind": "bin",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 12,
-                          "column": 11,
-                          "offset": 152
-                        },
-                        "end": {
-                          "line": 12,
-                          "column": 23,
-                          "offset": 164
-                        }
-                      },
-                      "type": "+",
-                      "left": {
-                        "kind": "bin",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 11,
-                            "offset": 152
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 18,
-                            "offset": 159
-                          }
-                        },
-                        "type": "+",
-                        "left": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 11,
-                              "offset": 152
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 13,
-                              "offset": 154
-                            }
-                          },
-                          "name": "a",
-                          "curly": false
-                        },
-                        "right": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 16,
-                              "offset": 157
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 18,
-                              "offset": 159
-                            }
-                          },
-                          "name": "x",
-                          "curly": false
-                        }
-                      },
-                      "right": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 21,
-                            "offset": 162
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 23,
-                            "offset": 164
-                          }
-                        },
-                        "name": "y",
-                        "curly": false
-                      }
-                    }
-                  }
-                ]
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
               }
             },
             "loc": {
@@ -2789,12 +923,11 @@
                 "line": 13,
                 "column": 2
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
             }
           },
           "modifiers": [],
           "_meta": {
-            "attributes": [],
             "loc": {
               "start": {
                 "line": 11,
@@ -2804,232 +937,7 @@
                 "line": 13,
                 "column": 2
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-            },
-            "origin": {
-              "kind": "closure",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 11,
-                  "column": 6,
-                  "offset": 110
-                },
-                "end": {
-                  "line": 13,
-                  "column": 1,
-                  "offset": 167
-                }
-              },
-              "uses": [
-                {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 11,
-                      "column": 26,
-                      "offset": 130
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 29,
-                      "offset": 133
-                    }
-                  },
-                  "name": "x",
-                  "curly": false,
-                  "byref": true
-                },
-                {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 11,
-                      "column": 31,
-                      "offset": 135
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 33,
-                      "offset": 137
-                    }
-                  },
-                  "name": "y",
-                  "curly": false
-                }
-              ],
-              "arguments": [
-                {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 11,
-                      "column": 17,
-                      "offset": 121
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 19,
-                      "offset": 123
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 11,
-                        "column": 17,
-                        "offset": 121
-                      },
-                      "end": {
-                        "line": 11,
-                        "column": 19,
-                        "offset": 123
-                      }
-                    },
-                    "name": "a"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": []
-                }
-              ],
-              "byref": true,
-              "type": null,
-              "nullable": false,
-              "isStatic": false,
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 11,
-                    "column": 35,
-                    "offset": 139
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 1,
-                    "offset": 167
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 12,
-                        "column": 4,
-                        "offset": 145
-                      },
-                      "end": {
-                        "line": 12,
-                        "column": 24,
-                        "offset": 165
-                      }
-                    },
-                    "expr": {
-                      "kind": "bin",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 12,
-                          "column": 11,
-                          "offset": 152
-                        },
-                        "end": {
-                          "line": 12,
-                          "column": 23,
-                          "offset": 164
-                        }
-                      },
-                      "type": "+",
-                      "left": {
-                        "kind": "bin",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 11,
-                            "offset": 152
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 18,
-                            "offset": 159
-                          }
-                        },
-                        "type": "+",
-                        "left": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 11,
-                              "offset": 152
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 13,
-                              "offset": 154
-                            }
-                          },
-                          "name": "a",
-                          "curly": false
-                        },
-                        "right": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 16,
-                              "offset": 157
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 18,
-                              "offset": 159
-                            }
-                          },
-                          "name": "x",
-                          "curly": false
-                        }
-                      },
-                      "right": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 21,
-                            "offset": 162
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 23,
-                            "offset": 164
-                          }
-                        },
-                        "name": "y",
-                        "curly": false
-                      }
-                    }
-                  }
-                ]
-              },
-              "attrGroups": []
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
             },
             "uses": [
               {
@@ -3039,45 +947,26 @@
                   "loc": {
                     "start": {
                       "line": 11,
-                      "column": 27
+                      "column": 28
                     },
                     "end": {
                       "line": 11,
                       "column": 30
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-                  },
-                  "origin": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 11,
-                        "column": 26,
-                        "offset": 130
-                      },
-                      "end": {
-                        "line": 11,
-                        "column": 29,
-                        "offset": 133
-                      }
-                    },
-                    "name": "x",
-                    "curly": false,
-                    "byref": true
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                   },
                   "byref": true
                 },
                 "loc": {
                   "start": {
                     "line": 11,
-                    "column": 27
+                    "column": 28
                   },
                   "end": {
                     "line": 11,
                     "column": 30
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               },
               {
@@ -3093,27 +982,8 @@
                       "line": 11,
                       "column": 34
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-                  },
-                  "origin": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 11,
-                        "column": 31,
-                        "offset": 135
-                      },
-                      "end": {
-                        "line": 11,
-                        "column": 33,
-                        "offset": 137
-                      }
-                    },
-                    "name": "y",
-                    "curly": false
-                  },
-                  "byref": false
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
+                  }
                 },
                 "loc": {
                   "start": {
@@ -3124,11 +994,10 @@
                     "line": 11,
                     "column": 34
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
                 }
               }
-            ],
-            "byref": true
+            ]
           },
           "loc": {
             "start": {
@@ -3139,7 +1008,7 @@
               "line": 13,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
           }
         },
         "operator": "=",
@@ -3152,269 +1021,9 @@
             },
             "end": {
               "line": 13,
-              "column": 3
+              "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-          },
-          "origin": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 11,
-                "column": 0,
-                "offset": 104
-              },
-              "end": {
-                "line": 13,
-                "column": 2,
-                "offset": 168
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 11,
-                  "column": 0,
-                  "offset": 104
-                },
-                "end": {
-                  "line": 11,
-                  "column": 3,
-                  "offset": 107
-                }
-              },
-              "name": "fn",
-              "curly": false
-            },
-            "right": {
-              "kind": "closure",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 11,
-                  "column": 6,
-                  "offset": 110
-                },
-                "end": {
-                  "line": 13,
-                  "column": 1,
-                  "offset": 167
-                }
-              },
-              "uses": [
-                {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 11,
-                      "column": 26,
-                      "offset": 130
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 29,
-                      "offset": 133
-                    }
-                  },
-                  "name": "x",
-                  "curly": false,
-                  "byref": true
-                },
-                {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 11,
-                      "column": 31,
-                      "offset": 135
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 33,
-                      "offset": 137
-                    }
-                  },
-                  "name": "y",
-                  "curly": false
-                }
-              ],
-              "arguments": [
-                {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 11,
-                      "column": 17,
-                      "offset": 121
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 19,
-                      "offset": 123
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 11,
-                        "column": 17,
-                        "offset": 121
-                      },
-                      "end": {
-                        "line": 11,
-                        "column": 19,
-                        "offset": 123
-                      }
-                    },
-                    "name": "a"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": []
-                }
-              ],
-              "byref": true,
-              "type": null,
-              "nullable": false,
-              "isStatic": false,
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 11,
-                    "column": 35,
-                    "offset": 139
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 1,
-                    "offset": 167
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 12,
-                        "column": 4,
-                        "offset": 145
-                      },
-                      "end": {
-                        "line": 12,
-                        "column": 24,
-                        "offset": 165
-                      }
-                    },
-                    "expr": {
-                      "kind": "bin",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 12,
-                          "column": 11,
-                          "offset": 152
-                        },
-                        "end": {
-                          "line": 12,
-                          "column": 23,
-                          "offset": 164
-                        }
-                      },
-                      "type": "+",
-                      "left": {
-                        "kind": "bin",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 11,
-                            "offset": 152
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 18,
-                            "offset": 159
-                          }
-                        },
-                        "type": "+",
-                        "left": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 11,
-                              "offset": 152
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 13,
-                              "offset": 154
-                            }
-                          },
-                          "name": "a",
-                          "curly": false
-                        },
-                        "right": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 16,
-                              "offset": 157
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 18,
-                              "offset": 159
-                            }
-                          },
-                          "name": "x",
-                          "curly": false
-                        }
-                      },
-                      "right": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 21,
-                            "offset": 162
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 23,
-                            "offset": 164
-                          }
-                        },
-                        "name": "y",
-                        "curly": false
-                      }
-                    }
-                  }
-                ]
-              },
-              "attrGroups": []
-            },
-            "operator": "="
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
           }
         },
         "loc": {
@@ -3424,9 +1033,9 @@
           },
           "end": {
             "line": 13,
-            "column": 3
+            "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
         }
       },
       "_meta": {
@@ -3439,283 +1048,7 @@
             "line": 13,
             "column": 3
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-        },
-        "origin": {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 11,
-              "column": 0,
-              "offset": 104
-            },
-            "end": {
-              "line": 13,
-              "column": 2,
-              "offset": 168
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 11,
-                "column": 0,
-                "offset": 104
-              },
-              "end": {
-                "line": 13,
-                "column": 2,
-                "offset": 168
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 11,
-                  "column": 0,
-                  "offset": 104
-                },
-                "end": {
-                  "line": 11,
-                  "column": 3,
-                  "offset": 107
-                }
-              },
-              "name": "fn",
-              "curly": false
-            },
-            "right": {
-              "kind": "closure",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 11,
-                  "column": 6,
-                  "offset": 110
-                },
-                "end": {
-                  "line": 13,
-                  "column": 1,
-                  "offset": 167
-                }
-              },
-              "uses": [
-                {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 11,
-                      "column": 26,
-                      "offset": 130
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 29,
-                      "offset": 133
-                    }
-                  },
-                  "name": "x",
-                  "curly": false,
-                  "byref": true
-                },
-                {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 11,
-                      "column": 31,
-                      "offset": 135
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 33,
-                      "offset": 137
-                    }
-                  },
-                  "name": "y",
-                  "curly": false
-                }
-              ],
-              "arguments": [
-                {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 11,
-                      "column": 17,
-                      "offset": 121
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 19,
-                      "offset": 123
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 11,
-                        "column": 17,
-                        "offset": 121
-                      },
-                      "end": {
-                        "line": 11,
-                        "column": 19,
-                        "offset": 123
-                      }
-                    },
-                    "name": "a"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": []
-                }
-              ],
-              "byref": true,
-              "type": null,
-              "nullable": false,
-              "isStatic": false,
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 11,
-                    "column": 35,
-                    "offset": 139
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 1,
-                    "offset": 167
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 12,
-                        "column": 4,
-                        "offset": 145
-                      },
-                      "end": {
-                        "line": 12,
-                        "column": 24,
-                        "offset": 165
-                      }
-                    },
-                    "expr": {
-                      "kind": "bin",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 12,
-                          "column": 11,
-                          "offset": 152
-                        },
-                        "end": {
-                          "line": 12,
-                          "column": 23,
-                          "offset": 164
-                        }
-                      },
-                      "type": "+",
-                      "left": {
-                        "kind": "bin",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 11,
-                            "offset": 152
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 18,
-                            "offset": 159
-                          }
-                        },
-                        "type": "+",
-                        "left": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 11,
-                              "offset": 152
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 13,
-                              "offset": 154
-                            }
-                          },
-                          "name": "a",
-                          "curly": false
-                        },
-                        "right": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 16,
-                              "offset": 157
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 18,
-                              "offset": 159
-                            }
-                          },
-                          "name": "x",
-                          "curly": false
-                        }
-                      },
-                      "right": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 21,
-                            "offset": 162
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 23,
-                            "offset": 164
-                          }
-                        },
-                        "name": "y",
-                        "curly": false
-                      }
-                    }
-                  }
-                ]
-              },
-              "attrGroups": []
-            },
-            "operator": "="
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
         }
       },
       "loc": {
@@ -3727,13 +1060,13 @@
           "line": 13,
           "column": 3
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -3745,693 +1078,7 @@
         "line": 14,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
-    },
-    "origin": {
-      "kind": "program",
-      "loc": {
-        "source": null,
-        "start": {
-          "line": 1,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "line": 14,
-          "column": 0,
-          "offset": 169
-        }
-      },
-      "children": [
-        {
-          "kind": "function",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 7
-            },
-            "end": {
-              "line": 9,
-              "column": 1,
-              "offset": 102
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 9,
-                "offset": 16
-              },
-              "end": {
-                "line": 3,
-                "column": 12,
-                "offset": 19
-              }
-            },
-            "name": "run"
-          },
-          "arguments": [
-            {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 13,
-                  "offset": 20
-                },
-                "end": {
-                  "line": 3,
-                  "column": 18,
-                  "offset": 25
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 13,
-                    "offset": 20
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 18,
-                    "offset": 25
-                  }
-                },
-                "name": "code"
-              },
-              "value": null,
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
-            },
-            {
-              "kind": "parameter",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 3,
-                  "column": 20,
-                  "offset": 27
-                },
-                "end": {
-                  "line": 3,
-                  "column": 22,
-                  "offset": 29
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 3,
-                    "column": 20,
-                    "offset": 27
-                  },
-                  "end": {
-                    "line": 3,
-                    "column": 22,
-                    "offset": 29
-                  }
-                },
-                "name": "x"
-              },
-              "value": null,
-              "type": null,
-              "byref": false,
-              "variadic": false,
-              "readonly": false,
-              "nullable": false,
-              "flags": 0,
-              "attrGroups": []
-            }
-          ],
-          "byref": false,
-          "type": null,
-          "nullable": false,
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 4,
-                "column": 0,
-                "offset": 31
-              },
-              "end": {
-                "line": 9,
-                "column": 1,
-                "offset": 102
-              }
-            },
-            "children": [
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 4,
-                    "offset": 37
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 13,
-                    "offset": 46
-                  }
-                },
-                "expression": {
-                  "kind": "print",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 4,
-                      "offset": 37
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 13,
-                      "offset": 46
-                    }
-                  },
-                  "expression": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 10,
-                        "offset": 43
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 12,
-                        "offset": 45
-                      }
-                    },
-                    "name": "x",
-                    "curly": false
-                  }
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 6,
-                    "column": 4,
-                    "offset": 51
-                  },
-                  "end": {
-                    "line": 6,
-                    "column": 16,
-                    "offset": 63
-                  }
-                },
-                "expression": {
-                  "kind": "eval",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 6,
-                      "column": 4,
-                      "offset": 51
-                    },
-                    "end": {
-                      "line": 6,
-                      "column": 16,
-                      "offset": 63
-                    }
-                  },
-                  "source": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 6,
-                        "column": 9,
-                        "offset": 56
-                      },
-                      "end": {
-                        "line": 6,
-                        "column": 14,
-                        "offset": 61
-                      }
-                    },
-                    "name": "code",
-                    "curly": false
-                  }
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 7,
-                    "column": 4,
-                    "offset": 68
-                  },
-                  "end": {
-                    "line": 7,
-                    "column": 19,
-                    "offset": 83
-                  }
-                },
-                "expression": {
-                  "kind": "silent",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 7,
-                      "column": 4,
-                      "offset": 68
-                    },
-                    "end": {
-                      "line": 7,
-                      "column": 19,
-                      "offset": 83
-                    }
-                  },
-                  "expr": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 7,
-                        "column": 5,
-                        "offset": 69
-                      },
-                      "end": {
-                        "line": 7,
-                        "column": 18,
-                        "offset": 82
-                      }
-                    },
-                    "what": {
-                      "kind": "propertylookup",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 7,
-                          "column": 5,
-                          "offset": 69
-                        },
-                        "end": {
-                          "line": 7,
-                          "column": 16,
-                          "offset": 80
-                        }
-                      },
-                      "what": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 7,
-                            "column": 5,
-                            "offset": 69
-                          },
-                          "end": {
-                            "line": 7,
-                            "column": 10,
-                            "offset": 74
-                          }
-                        },
-                        "name": "this",
-                        "curly": false
-                      },
-                      "offset": {
-                        "kind": "identifier",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 7,
-                            "column": 12,
-                            "offset": 76
-                          },
-                          "end": {
-                            "line": 7,
-                            "column": 16,
-                            "offset": 80
-                          }
-                        },
-                        "name": "call"
-                      }
-                    },
-                    "arguments": []
-                  }
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 8,
-                    "column": 4,
-                    "offset": 88
-                  },
-                  "end": {
-                    "line": 8,
-                    "column": 16,
-                    "offset": 100
-                  }
-                },
-                "expression": {
-                  "kind": "exit",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 4,
-                      "offset": 88
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 16,
-                      "offset": 100
-                    }
-                  },
-                  "expression": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 8,
-                        "column": 9,
-                        "offset": 93
-                      },
-                      "end": {
-                        "line": 8,
-                        "column": 14,
-                        "offset": 98
-                      }
-                    },
-                    "name": "code",
-                    "curly": false
-                  },
-                  "useDie": false
-                }
-              }
-            ]
-          },
-          "attrGroups": []
-        },
-        {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 11,
-              "column": 0,
-              "offset": 104
-            },
-            "end": {
-              "line": 13,
-              "column": 2,
-              "offset": 168
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 11,
-                "column": 0,
-                "offset": 104
-              },
-              "end": {
-                "line": 13,
-                "column": 2,
-                "offset": 168
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 11,
-                  "column": 0,
-                  "offset": 104
-                },
-                "end": {
-                  "line": 11,
-                  "column": 3,
-                  "offset": 107
-                }
-              },
-              "name": "fn",
-              "curly": false
-            },
-            "right": {
-              "kind": "closure",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 11,
-                  "column": 6,
-                  "offset": 110
-                },
-                "end": {
-                  "line": 13,
-                  "column": 1,
-                  "offset": 167
-                }
-              },
-              "uses": [
-                {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 11,
-                      "column": 26,
-                      "offset": 130
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 29,
-                      "offset": 133
-                    }
-                  },
-                  "name": "x",
-                  "curly": false,
-                  "byref": true
-                },
-                {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 11,
-                      "column": 31,
-                      "offset": 135
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 33,
-                      "offset": 137
-                    }
-                  },
-                  "name": "y",
-                  "curly": false
-                }
-              ],
-              "arguments": [
-                {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 11,
-                      "column": 17,
-                      "offset": 121
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 19,
-                      "offset": 123
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 11,
-                        "column": 17,
-                        "offset": 121
-                      },
-                      "end": {
-                        "line": 11,
-                        "column": 19,
-                        "offset": 123
-                      }
-                    },
-                    "name": "a"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": []
-                }
-              ],
-              "byref": true,
-              "type": null,
-              "nullable": false,
-              "isStatic": false,
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 11,
-                    "column": 35,
-                    "offset": 139
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 1,
-                    "offset": 167
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 12,
-                        "column": 4,
-                        "offset": 145
-                      },
-                      "end": {
-                        "line": 12,
-                        "column": 24,
-                        "offset": 165
-                      }
-                    },
-                    "expr": {
-                      "kind": "bin",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 12,
-                          "column": 11,
-                          "offset": 152
-                        },
-                        "end": {
-                          "line": 12,
-                          "column": 23,
-                          "offset": 164
-                        }
-                      },
-                      "type": "+",
-                      "left": {
-                        "kind": "bin",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 11,
-                            "offset": 152
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 18,
-                            "offset": 159
-                          }
-                        },
-                        "type": "+",
-                        "left": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 11,
-                              "offset": 152
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 13,
-                              "offset": 154
-                            }
-                          },
-                          "name": "a",
-                          "curly": false
-                        },
-                        "right": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 12,
-                              "column": 16,
-                              "offset": 157
-                            },
-                            "end": {
-                              "line": 12,
-                              "column": 18,
-                              "offset": 159
-                            }
-                          },
-                          "name": "x",
-                          "curly": false
-                        }
-                      },
-                      "right": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 12,
-                            "column": 21,
-                            "offset": 162
-                          },
-                          "end": {
-                            "line": 12,
-                            "column": 23,
-                            "offset": 164
-                          }
-                        },
-                        "name": "y",
-                        "curly": false
-                      }
-                    }
-                  }
-                ]
-              },
-              "attrGroups": []
-            },
-            "operator": "="
-          }
-        }
-      ],
-      "errors": [],
-      "comments": []
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
     }
   },
   "loc": {
@@ -4443,6 +1090,6 @@
       "line": 14,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/runtime.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/runtime.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/strings-casts.php.json
+++ b/parser-PHP/tests/benchmark/base/strings-casts.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 11
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           },
           "origin": {
             "kind": "identifier",
@@ -45,7 +45,7 @@
             "line": 3,
             "column": 11
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "body": [
@@ -64,7 +64,7 @@
                   "line": 5,
                   "column": 15
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -93,7 +93,7 @@
                 "line": 5,
                 "column": 15
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "init": {
@@ -110,7 +110,7 @@
                   "line": 5,
                   "column": 24
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               },
               "origin": {
                 "kind": "string",
@@ -142,7 +142,7 @@
                 "line": 5,
                 "column": 24
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "cloned": false,
@@ -161,7 +161,7 @@
                 "line": 5,
                 "column": 24
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             },
             "origin": {
               "kind": "constant",
@@ -230,7 +230,7 @@
               "line": 5,
               "column": 24
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         }
       ],
@@ -250,7 +250,7 @@
             "line": 6,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         },
         "origin": {
           "kind": "class",
@@ -380,7 +380,7 @@
           "line": 6,
           "column": 2
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -400,7 +400,7 @@
                 "line": 8,
                 "column": 3
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             },
             "origin": {
               "kind": "variable",
@@ -430,7 +430,7 @@
               "line": 8,
               "column": 3
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
@@ -450,7 +450,7 @@
                   "line": 8,
                   "column": 13
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               },
               "origin": {
                 "kind": "string",
@@ -482,7 +482,7 @@
                 "line": 8,
                 "column": 13
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "right": {
@@ -498,7 +498,7 @@
                   "line": 8,
                   "column": 18
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               },
               "origin": {
                 "kind": "variable",
@@ -528,7 +528,7 @@
                 "line": 8,
                 "column": 18
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "_meta": {
@@ -541,7 +541,7 @@
                 "line": 8,
                 "column": 19
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             },
             "origin": {
               "kind": "encapsed",
@@ -648,7 +648,7 @@
               "line": 8,
               "column": 19
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -663,7 +663,7 @@
               "line": 8,
               "column": 20
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           },
           "origin": {
             "kind": "assign",
@@ -804,7 +804,7 @@
             "line": 8,
             "column": 20
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -817,7 +817,7 @@
             "line": 8,
             "column": 20
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         },
         "origin": {
           "kind": "expressionstatement",
@@ -974,7 +974,7 @@
           "line": 8,
           "column": 20
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -994,7 +994,7 @@
                 "line": 9,
                 "column": 3
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             },
             "origin": {
               "kind": "variable",
@@ -1024,7 +1024,7 @@
               "line": 9,
               "column": 3
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
@@ -1043,7 +1043,7 @@
                 "line": 11,
                 "column": 4
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             },
             "origin": {
               "kind": "nowdoc",
@@ -1074,7 +1074,7 @@
               "line": 11,
               "column": 4
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -1089,7 +1089,7 @@
               "line": 11,
               "column": 5
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           },
           "origin": {
             "kind": "assign",
@@ -1155,7 +1155,7 @@
             "line": 11,
             "column": 5
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -1168,7 +1168,7 @@
             "line": 11,
             "column": 5
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         },
         "origin": {
           "kind": "expressionstatement",
@@ -1250,7 +1250,7 @@
           "line": 11,
           "column": 5
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -1270,7 +1270,7 @@
                 "line": 12,
                 "column": 3
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             },
             "origin": {
               "kind": "variable",
@@ -1300,7 +1300,7 @@
               "line": 12,
               "column": 3
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
@@ -1319,7 +1319,7 @@
                 "line": 12,
                 "column": 14
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             },
             "origin": {
               "kind": "magic",
@@ -1349,7 +1349,7 @@
               "line": 12,
               "column": 14
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -1364,7 +1364,7 @@
               "line": 12,
               "column": 15
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           },
           "origin": {
             "kind": "assign",
@@ -1429,7 +1429,7 @@
             "line": 12,
             "column": 15
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -1442,7 +1442,7 @@
             "line": 12,
             "column": 15
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         },
         "origin": {
           "kind": "expressionstatement",
@@ -1523,7 +1523,7 @@
           "line": 12,
           "column": 15
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -1543,7 +1543,7 @@
                 "line": 13,
                 "column": 3
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             },
             "origin": {
               "kind": "variable",
@@ -1573,7 +1573,7 @@
               "line": 13,
               "column": 3
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
@@ -1591,7 +1591,7 @@
                   "line": 13,
                   "column": 10
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               },
               "origin": {
                 "kind": "name",
@@ -1621,7 +1621,7 @@
                 "line": 13,
                 "column": 10
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "property": {
@@ -1637,7 +1637,7 @@
                   "line": 13,
                   "column": 16
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -1666,7 +1666,7 @@
                 "line": 13,
                 "column": 16
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "computed": false,
@@ -1681,7 +1681,7 @@
                 "line": 13,
                 "column": 16
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             },
             "origin": {
               "kind": "staticlookup",
@@ -1744,7 +1744,7 @@
               "line": 13,
               "column": 16
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -1759,7 +1759,7 @@
               "line": 13,
               "column": 17
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           },
           "origin": {
             "kind": "assign",
@@ -1857,7 +1857,7 @@
             "line": 13,
             "column": 17
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -1870,7 +1870,7 @@
             "line": 13,
             "column": 17
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         },
         "origin": {
           "kind": "expressionstatement",
@@ -1984,7 +1984,7 @@
           "line": 13,
           "column": 17
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -2004,7 +2004,7 @@
                 "line": 14,
                 "column": 3
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             },
             "origin": {
               "kind": "variable",
@@ -2034,7 +2034,7 @@
               "line": 14,
               "column": 3
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
@@ -2052,7 +2052,7 @@
                   "line": 14,
                   "column": 10
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               },
               "origin": {
                 "kind": "selfreference",
@@ -2081,7 +2081,7 @@
                 "line": 14,
                 "column": 10
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "property": {
@@ -2097,7 +2097,7 @@
                   "line": 14,
                   "column": 16
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -2126,7 +2126,7 @@
                 "line": 14,
                 "column": 16
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "computed": false,
@@ -2141,7 +2141,7 @@
                 "line": 14,
                 "column": 16
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             },
             "origin": {
               "kind": "staticlookup",
@@ -2203,7 +2203,7 @@
               "line": 14,
               "column": 16
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -2218,7 +2218,7 @@
               "line": 14,
               "column": 17
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           },
           "origin": {
             "kind": "assign",
@@ -2315,7 +2315,7 @@
             "line": 14,
             "column": 17
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -2328,7 +2328,7 @@
             "line": 14,
             "column": 17
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         },
         "origin": {
           "kind": "expressionstatement",
@@ -2441,7 +2441,7 @@
           "line": 14,
           "column": 17
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -2461,7 +2461,7 @@
                 "line": 15,
                 "column": 3
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             },
             "origin": {
               "kind": "variable",
@@ -2491,7 +2491,7 @@
               "line": 15,
               "column": 3
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
@@ -2509,7 +2509,7 @@
                   "line": 15,
                   "column": 13
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               },
               "origin": {
                 "kind": "variable",
@@ -2539,7 +2539,7 @@
                 "line": 15,
                 "column": 13
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "as": {
@@ -2562,7 +2562,7 @@
                 "line": 15,
                 "column": 13
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             },
             "origin": {
               "kind": "cast",
@@ -2610,7 +2610,7 @@
               "line": 15,
               "column": 13
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -2625,7 +2625,7 @@
               "line": 15,
               "column": 14
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           },
           "origin": {
             "kind": "assign",
@@ -2708,7 +2708,7 @@
             "line": 15,
             "column": 14
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -2721,7 +2721,7 @@
             "line": 15,
             "column": 14
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         },
         "origin": {
           "kind": "expressionstatement",
@@ -2820,7 +2820,7 @@
           "line": 15,
           "column": 14
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -2840,7 +2840,7 @@
                 "line": 16,
                 "column": 3
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             },
             "origin": {
               "kind": "variable",
@@ -2870,7 +2870,7 @@
               "line": 16,
               "column": 3
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
@@ -2888,7 +2888,7 @@
                   "line": 16,
                   "column": 16
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               },
               "origin": {
                 "kind": "variable",
@@ -2918,7 +2918,7 @@
                 "line": 16,
                 "column": 16
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "as": {
@@ -2941,7 +2941,7 @@
                 "line": 16,
                 "column": 16
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             },
             "origin": {
               "kind": "cast",
@@ -2989,7 +2989,7 @@
               "line": 16,
               "column": 16
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -3004,7 +3004,7 @@
               "line": 16,
               "column": 17
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           },
           "origin": {
             "kind": "assign",
@@ -3087,7 +3087,7 @@
             "line": 16,
             "column": 17
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -3100,7 +3100,7 @@
             "line": 16,
             "column": 17
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         },
         "origin": {
           "kind": "expressionstatement",
@@ -3199,7 +3199,7 @@
           "line": 16,
           "column": 17
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -3219,7 +3219,7 @@
                 "line": 17,
                 "column": 5
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             },
             "origin": {
               "kind": "variable",
@@ -3249,7 +3249,7 @@
               "line": 17,
               "column": 5
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
@@ -3267,7 +3267,7 @@
                   "line": 17,
                   "column": 17
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               },
               "origin": {
                 "kind": "variable",
@@ -3297,7 +3297,7 @@
                 "line": 17,
                 "column": 17
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "as": {
@@ -3320,7 +3320,7 @@
                 "line": 17,
                 "column": 17
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             },
             "origin": {
               "kind": "cast",
@@ -3368,7 +3368,7 @@
               "line": 17,
               "column": 17
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -3383,7 +3383,7 @@
               "line": 17,
               "column": 18
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           },
           "origin": {
             "kind": "assign",
@@ -3466,7 +3466,7 @@
             "line": 17,
             "column": 18
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -3479,7 +3479,7 @@
             "line": 17,
             "column": 18
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         },
         "origin": {
           "kind": "expressionstatement",
@@ -3578,13 +3578,13 @@
           "line": 17,
           "column": 18
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -3596,7 +3596,7 @@
         "line": 18,
         "column": 1
       },
-      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
     },
     "origin": {
       "kind": "program",
@@ -4494,6 +4494,6 @@
       "line": 18,
       "column": 1
     },
-    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/strings-casts.php.json
+++ b/parser-PHP/tests/benchmark/base/strings-casts.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 11
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "loc": {
@@ -28,7 +28,7 @@
             "line": 3,
             "column": 11
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "strings-casts.php"
         }
       },
       "body": [
@@ -47,7 +47,7 @@
                   "line": 5,
                   "column": 15
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "strings-casts.php"
               }
             },
             "loc": {
@@ -59,7 +59,7 @@
                 "line": 5,
                 "column": 15
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "init": {
@@ -76,7 +76,7 @@
                   "line": 5,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "strings-casts.php"
               }
             },
             "loc": {
@@ -88,7 +88,7 @@
                 "line": 5,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "cloned": false,
@@ -108,7 +108,7 @@
                 "line": 5,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "loc": {
@@ -120,7 +120,7 @@
               "line": 5,
               "column": 24
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         }
       ],
@@ -135,7 +135,7 @@
             "line": 6,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "strings-casts.php"
         }
       },
       "loc": {
@@ -147,7 +147,7 @@
           "line": 6,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "strings-casts.php"
       }
     },
     {
@@ -167,7 +167,7 @@
                 "line": 8,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "loc": {
@@ -179,7 +179,7 @@
               "line": 8,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "right": {
@@ -199,7 +199,7 @@
                   "line": 8,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "strings-casts.php"
               }
             },
             "loc": {
@@ -211,7 +211,7 @@
                 "line": 8,
                 "column": 13
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "right": {
@@ -227,7 +227,7 @@
                   "line": 8,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "strings-casts.php"
               }
             },
             "loc": {
@@ -239,7 +239,7 @@
                 "line": 8,
                 "column": 18
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "_meta": {
@@ -252,7 +252,7 @@
                 "line": 8,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             },
             "encapsed": true
           },
@@ -265,7 +265,7 @@
               "line": 8,
               "column": 19
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "operator": "=",
@@ -280,7 +280,7 @@
               "line": 8,
               "column": 19
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "loc": {
@@ -292,7 +292,7 @@
             "line": 8,
             "column": 19
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "strings-casts.php"
         }
       },
       "_meta": {
@@ -305,7 +305,7 @@
             "line": 8,
             "column": 20
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "strings-casts.php"
         }
       },
       "loc": {
@@ -317,7 +317,7 @@
           "line": 8,
           "column": 20
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "strings-casts.php"
       }
     },
     {
@@ -337,7 +337,7 @@
                 "line": 9,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "loc": {
@@ -349,7 +349,7 @@
               "line": 9,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "right": {
@@ -367,7 +367,7 @@
                 "line": 11,
                 "column": 4
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "loc": {
@@ -379,7 +379,7 @@
               "line": 11,
               "column": 4
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "operator": "=",
@@ -394,7 +394,7 @@
               "line": 11,
               "column": 4
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "loc": {
@@ -406,7 +406,7 @@
             "line": 11,
             "column": 4
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "strings-casts.php"
         }
       },
       "_meta": {
@@ -419,7 +419,7 @@
             "line": 11,
             "column": 5
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "strings-casts.php"
         }
       },
       "loc": {
@@ -431,7 +431,7 @@
           "line": 11,
           "column": 5
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "strings-casts.php"
       }
     },
     {
@@ -451,7 +451,7 @@
                 "line": 12,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "loc": {
@@ -463,7 +463,7 @@
               "line": 12,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "right": {
@@ -479,7 +479,7 @@
                 "line": 12,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "loc": {
@@ -491,7 +491,7 @@
               "line": 12,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "operator": "=",
@@ -506,7 +506,7 @@
               "line": 12,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "loc": {
@@ -518,7 +518,7 @@
             "line": 12,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "strings-casts.php"
         }
       },
       "_meta": {
@@ -531,7 +531,7 @@
             "line": 12,
             "column": 15
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "strings-casts.php"
         }
       },
       "loc": {
@@ -543,7 +543,7 @@
           "line": 12,
           "column": 15
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "strings-casts.php"
       }
     },
     {
@@ -563,7 +563,7 @@
                 "line": 13,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "loc": {
@@ -575,7 +575,7 @@
               "line": 13,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "right": {
@@ -593,7 +593,7 @@
                   "line": 13,
                   "column": 10
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "strings-casts.php"
               }
             },
             "loc": {
@@ -605,7 +605,7 @@
                 "line": 13,
                 "column": 10
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "property": {
@@ -621,7 +621,7 @@
                   "line": 13,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "strings-casts.php"
               }
             },
             "loc": {
@@ -633,7 +633,7 @@
                 "line": 13,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "computed": false,
@@ -648,7 +648,7 @@
                 "line": 13,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "loc": {
@@ -660,7 +660,7 @@
               "line": 13,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "operator": "=",
@@ -675,7 +675,7 @@
               "line": 13,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "loc": {
@@ -687,7 +687,7 @@
             "line": 13,
             "column": 16
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "strings-casts.php"
         }
       },
       "_meta": {
@@ -700,7 +700,7 @@
             "line": 13,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "strings-casts.php"
         }
       },
       "loc": {
@@ -712,7 +712,7 @@
           "line": 13,
           "column": 17
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "strings-casts.php"
       }
     },
     {
@@ -732,7 +732,7 @@
                 "line": 14,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "loc": {
@@ -744,7 +744,7 @@
               "line": 14,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "right": {
@@ -762,7 +762,7 @@
                   "line": 14,
                   "column": 10
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "strings-casts.php"
               }
             },
             "loc": {
@@ -774,7 +774,7 @@
                 "line": 14,
                 "column": 10
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "property": {
@@ -790,7 +790,7 @@
                   "line": 14,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "strings-casts.php"
               }
             },
             "loc": {
@@ -802,7 +802,7 @@
                 "line": 14,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "computed": false,
@@ -817,7 +817,7 @@
                 "line": 14,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "loc": {
@@ -829,7 +829,7 @@
               "line": 14,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "operator": "=",
@@ -844,7 +844,7 @@
               "line": 14,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "loc": {
@@ -856,7 +856,7 @@
             "line": 14,
             "column": 16
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "strings-casts.php"
         }
       },
       "_meta": {
@@ -869,7 +869,7 @@
             "line": 14,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "strings-casts.php"
         }
       },
       "loc": {
@@ -881,7 +881,7 @@
           "line": 14,
           "column": 17
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "strings-casts.php"
       }
     },
     {
@@ -901,7 +901,7 @@
                 "line": 15,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "loc": {
@@ -913,7 +913,7 @@
               "line": 15,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "right": {
@@ -937,7 +937,7 @@
                     "line": 15,
                     "column": 13
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                  "sourcefile": "strings-casts.php"
                 }
               },
               "loc": {
@@ -949,7 +949,7 @@
                   "line": 15,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "strings-casts.php"
               }
             }
           ],
@@ -964,7 +964,7 @@
                 "line": 15,
                 "column": 13
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "loc": {
@@ -976,7 +976,7 @@
               "line": 15,
               "column": 13
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "operator": "=",
@@ -991,7 +991,7 @@
               "line": 15,
               "column": 13
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "loc": {
@@ -1003,7 +1003,7 @@
             "line": 15,
             "column": 13
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "strings-casts.php"
         }
       },
       "_meta": {
@@ -1016,7 +1016,7 @@
             "line": 15,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "strings-casts.php"
         }
       },
       "loc": {
@@ -1028,7 +1028,7 @@
           "line": 15,
           "column": 14
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "strings-casts.php"
       }
     },
     {
@@ -1048,7 +1048,7 @@
                 "line": 16,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "loc": {
@@ -1060,7 +1060,7 @@
               "line": 16,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "right": {
@@ -1084,7 +1084,7 @@
                     "line": 16,
                     "column": 16
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                  "sourcefile": "strings-casts.php"
                 }
               },
               "loc": {
@@ -1096,7 +1096,7 @@
                   "line": 16,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "strings-casts.php"
               }
             }
           ],
@@ -1111,7 +1111,7 @@
                 "line": 16,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "loc": {
@@ -1123,7 +1123,7 @@
               "line": 16,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "operator": "=",
@@ -1138,7 +1138,7 @@
               "line": 16,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "loc": {
@@ -1150,7 +1150,7 @@
             "line": 16,
             "column": 16
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "strings-casts.php"
         }
       },
       "_meta": {
@@ -1163,7 +1163,7 @@
             "line": 16,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "strings-casts.php"
         }
       },
       "loc": {
@@ -1175,7 +1175,7 @@
           "line": 16,
           "column": 17
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "strings-casts.php"
       }
     },
     {
@@ -1195,7 +1195,7 @@
                 "line": 17,
                 "column": 5
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "loc": {
@@ -1207,7 +1207,7 @@
               "line": 17,
               "column": 5
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "right": {
@@ -1231,7 +1231,7 @@
                     "line": 17,
                     "column": 17
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                  "sourcefile": "strings-casts.php"
                 }
               },
               "loc": {
@@ -1243,7 +1243,7 @@
                   "line": 17,
                   "column": 17
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "strings-casts.php"
               }
             }
           ],
@@ -1258,7 +1258,7 @@
                 "line": 17,
                 "column": 17
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "strings-casts.php"
             }
           },
           "loc": {
@@ -1270,7 +1270,7 @@
               "line": 17,
               "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "operator": "=",
@@ -1285,7 +1285,7 @@
               "line": 17,
               "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "strings-casts.php"
           }
         },
         "loc": {
@@ -1297,7 +1297,7 @@
             "line": 17,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "strings-casts.php"
         }
       },
       "_meta": {
@@ -1310,7 +1310,7 @@
             "line": 17,
             "column": 18
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "strings-casts.php"
         }
       },
       "loc": {
@@ -1322,13 +1322,13 @@
           "line": 17,
           "column": 18
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "strings-casts.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php",
+  "uri": "strings-casts.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -1340,7 +1340,7 @@
         "line": 18,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+      "sourcefile": "strings-casts.php"
     }
   },
   "loc": {
@@ -1352,6 +1352,6 @@
       "line": 18,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+    "sourcefile": "strings-casts.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/strings-casts.php.json
+++ b/parser-PHP/tests/benchmark/base/strings-casts.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 11
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "loc": {
@@ -28,7 +28,7 @@
             "line": 3,
             "column": 11
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "body": [
@@ -47,7 +47,7 @@
                   "line": 5,
                   "column": 15
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
             },
             "loc": {
@@ -59,7 +59,7 @@
                 "line": 5,
                 "column": 15
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "init": {
@@ -76,7 +76,7 @@
                   "line": 5,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
             },
             "loc": {
@@ -88,7 +88,7 @@
                 "line": 5,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "cloned": false,
@@ -108,7 +108,7 @@
                 "line": 5,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -120,7 +120,7 @@
               "line": 5,
               "column": 24
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         }
       ],
@@ -135,7 +135,7 @@
             "line": 6,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "loc": {
@@ -147,7 +147,7 @@
           "line": 6,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -167,7 +167,7 @@
                 "line": 8,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -179,7 +179,7 @@
               "line": 8,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
@@ -199,7 +199,7 @@
                   "line": 8,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
             },
             "loc": {
@@ -211,7 +211,7 @@
                 "line": 8,
                 "column": 13
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "right": {
@@ -227,7 +227,7 @@
                   "line": 8,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
             },
             "loc": {
@@ -239,7 +239,7 @@
                 "line": 8,
                 "column": 18
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "_meta": {
@@ -252,7 +252,7 @@
                 "line": 8,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             },
             "encapsed": true
           },
@@ -265,7 +265,7 @@
               "line": 8,
               "column": 19
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -280,7 +280,7 @@
               "line": 8,
               "column": 19
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "loc": {
@@ -292,7 +292,7 @@
             "line": 8,
             "column": 19
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -305,7 +305,7 @@
             "line": 8,
             "column": 20
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "loc": {
@@ -317,7 +317,7 @@
           "line": 8,
           "column": 20
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -337,7 +337,7 @@
                 "line": 9,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -349,7 +349,7 @@
               "line": 9,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
@@ -367,7 +367,7 @@
                 "line": 11,
                 "column": 4
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -379,7 +379,7 @@
               "line": 11,
               "column": 4
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -394,7 +394,7 @@
               "line": 11,
               "column": 4
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "loc": {
@@ -406,7 +406,7 @@
             "line": 11,
             "column": 4
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -419,7 +419,7 @@
             "line": 11,
             "column": 5
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "loc": {
@@ -431,7 +431,7 @@
           "line": 11,
           "column": 5
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -451,7 +451,7 @@
                 "line": 12,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -463,7 +463,7 @@
               "line": 12,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
@@ -479,7 +479,7 @@
                 "line": 12,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -491,7 +491,7 @@
               "line": 12,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -506,7 +506,7 @@
               "line": 12,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "loc": {
@@ -518,7 +518,7 @@
             "line": 12,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -531,7 +531,7 @@
             "line": 12,
             "column": 15
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "loc": {
@@ -543,7 +543,7 @@
           "line": 12,
           "column": 15
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -563,7 +563,7 @@
                 "line": 13,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -575,7 +575,7 @@
               "line": 13,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
@@ -593,7 +593,7 @@
                   "line": 13,
                   "column": 10
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
             },
             "loc": {
@@ -605,7 +605,7 @@
                 "line": 13,
                 "column": 10
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "property": {
@@ -621,7 +621,7 @@
                   "line": 13,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
             },
             "loc": {
@@ -633,7 +633,7 @@
                 "line": 13,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "computed": false,
@@ -648,7 +648,7 @@
                 "line": 13,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -660,7 +660,7 @@
               "line": 13,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -675,7 +675,7 @@
               "line": 13,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "loc": {
@@ -687,7 +687,7 @@
             "line": 13,
             "column": 16
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -700,7 +700,7 @@
             "line": 13,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "loc": {
@@ -712,7 +712,7 @@
           "line": 13,
           "column": 17
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -732,7 +732,7 @@
                 "line": 14,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -744,7 +744,7 @@
               "line": 14,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
@@ -762,7 +762,7 @@
                   "line": 14,
                   "column": 10
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
             },
             "loc": {
@@ -774,7 +774,7 @@
                 "line": 14,
                 "column": 10
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "property": {
@@ -790,7 +790,7 @@
                   "line": 14,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
             },
             "loc": {
@@ -802,7 +802,7 @@
                 "line": 14,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "computed": false,
@@ -817,7 +817,7 @@
                 "line": 14,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -829,7 +829,7 @@
               "line": 14,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -844,7 +844,7 @@
               "line": 14,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "loc": {
@@ -856,7 +856,7 @@
             "line": 14,
             "column": 16
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -869,7 +869,7 @@
             "line": 14,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "loc": {
@@ -881,7 +881,7 @@
           "line": 14,
           "column": 17
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -901,7 +901,7 @@
                 "line": 15,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -913,7 +913,7 @@
               "line": 15,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
@@ -937,7 +937,7 @@
                     "line": 15,
                     "column": 13
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
                 }
               },
               "loc": {
@@ -949,7 +949,7 @@
                   "line": 15,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
             }
           ],
@@ -964,7 +964,7 @@
                 "line": 15,
                 "column": 13
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -976,7 +976,7 @@
               "line": 15,
               "column": 13
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -991,7 +991,7 @@
               "line": 15,
               "column": 13
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "loc": {
@@ -1003,7 +1003,7 @@
             "line": 15,
             "column": 13
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -1016,7 +1016,7 @@
             "line": 15,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "loc": {
@@ -1028,7 +1028,7 @@
           "line": 15,
           "column": 14
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -1048,7 +1048,7 @@
                 "line": 16,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -1060,7 +1060,7 @@
               "line": 16,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
@@ -1084,7 +1084,7 @@
                     "line": 16,
                     "column": 16
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
                 }
               },
               "loc": {
@@ -1096,7 +1096,7 @@
                   "line": 16,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
             }
           ],
@@ -1111,7 +1111,7 @@
                 "line": 16,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -1123,7 +1123,7 @@
               "line": 16,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -1138,7 +1138,7 @@
               "line": 16,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "loc": {
@@ -1150,7 +1150,7 @@
             "line": 16,
             "column": 16
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -1163,7 +1163,7 @@
             "line": 16,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "loc": {
@@ -1175,7 +1175,7 @@
           "line": 16,
           "column": 17
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -1195,7 +1195,7 @@
                 "line": 17,
                 "column": 5
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -1207,7 +1207,7 @@
               "line": 17,
               "column": 5
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
@@ -1231,7 +1231,7 @@
                     "line": 17,
                     "column": 17
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
                 }
               },
               "loc": {
@@ -1243,7 +1243,7 @@
                   "line": 17,
                   "column": 17
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
             }
           ],
@@ -1258,7 +1258,7 @@
                 "line": 17,
                 "column": 17
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -1270,7 +1270,7 @@
               "line": 17,
               "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -1285,7 +1285,7 @@
               "line": 17,
               "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "loc": {
@@ -1297,7 +1297,7 @@
             "line": 17,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -1310,7 +1310,7 @@
             "line": 17,
             "column": 18
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "loc": {
@@ -1322,13 +1322,13 @@
           "line": 17,
           "column": 18
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -1340,7 +1340,7 @@
         "line": 18,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
     }
   },
   "loc": {
@@ -1352,6 +1352,6 @@
       "line": 18,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/strings-casts.php.json
+++ b/parser-PHP/tests/benchmark/base/strings-casts.php.json
@@ -16,24 +16,7 @@
               "line": 3,
               "column": 11
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-          },
-          "origin": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 6,
-                "offset": 13
-              },
-              "end": {
-                "line": 3,
-                "column": 10,
-                "offset": 17
-              }
-            },
-            "name": "Demo"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "loc": {
@@ -45,7 +28,7 @@
             "line": 3,
             "column": 11
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "body": [
@@ -64,24 +47,7 @@
                   "line": 5,
                   "column": 15
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 10,
-                    "offset": 30
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 14,
-                    "offset": 34
-                  }
-                },
-                "name": "NAME"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
             },
             "loc": {
@@ -93,7 +59,7 @@
                 "line": 5,
                 "column": 15
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "init": {
@@ -110,27 +76,7 @@
                   "line": 5,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-              },
-              "origin": {
-                "kind": "string",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 17,
-                    "offset": 37
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 23,
-                    "offset": 43
-                  }
-                },
-                "value": "demo",
-                "raw": "'demo'",
-                "unicode": false,
-                "isDoubleQuote": false
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
             },
             "loc": {
@@ -142,7 +88,7 @@
                 "line": 5,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "cloned": false,
@@ -152,6 +98,7 @@
             "_meta": {}
           },
           "_meta": {
+            "constant": true,
             "loc": {
               "start": {
                 "line": 5,
@@ -161,65 +108,8 @@
                 "line": 5,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-            },
-            "origin": {
-              "kind": "constant",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 5,
-                  "column": 10,
-                  "offset": 30
-                },
-                "end": {
-                  "line": 5,
-                  "column": 23,
-                  "offset": 43
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 10,
-                    "offset": 30
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 14,
-                    "offset": 34
-                  }
-                },
-                "name": "NAME"
-              },
-              "value": {
-                "kind": "string",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 17,
-                    "offset": 37
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 23,
-                    "offset": 43
-                  }
-                },
-                "value": "demo",
-                "raw": "'demo'",
-                "unicode": false,
-                "isDoubleQuote": false
-              }
-            },
-            "constant": true,
-            "visibility": null,
-            "final": false,
-            "attributes": []
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+            }
           },
           "loc": {
             "start": {
@@ -230,17 +120,12 @@
               "line": 5,
               "column": 24
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         }
       ],
       "supers": [],
       "_meta": {
-        "implements": [],
-        "isAbstract": false,
-        "isFinal": false,
-        "isReadonly": false,
-        "attributes": [],
         "loc": {
           "start": {
             "line": 3,
@@ -250,125 +135,7 @@
             "line": 6,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-        },
-        "origin": {
-          "kind": "class",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 7
-            },
-            "end": {
-              "line": 6,
-              "column": 1,
-              "offset": 46
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 6,
-                "offset": 13
-              },
-              "end": {
-                "line": 3,
-                "column": 10,
-                "offset": 17
-              }
-            },
-            "name": "Demo"
-          },
-          "isAnonymous": false,
-          "extends": null,
-          "implements": null,
-          "body": [
-            {
-              "kind": "classconstant",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 5,
-                  "column": 10,
-                  "offset": 30
-                },
-                "end": {
-                  "line": 5,
-                  "column": 23,
-                  "offset": 43
-                }
-              },
-              "constants": [
-                {
-                  "kind": "constant",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 10,
-                      "offset": 30
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 23,
-                      "offset": 43
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 10,
-                        "offset": 30
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 14,
-                        "offset": 34
-                      }
-                    },
-                    "name": "NAME"
-                  },
-                  "value": {
-                    "kind": "string",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 17,
-                        "offset": 37
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 23,
-                        "offset": 43
-                      }
-                    },
-                    "value": "demo",
-                    "raw": "'demo'",
-                    "unicode": false,
-                    "isDoubleQuote": false
-                  }
-                }
-              ],
-              "visibility": "",
-              "final": false,
-              "nullable": false,
-              "type": null,
-              "attrGroups": []
-            }
-          ],
-          "attrGroups": [],
-          "isAbstract": false,
-          "isFinal": false,
-          "isReadonly": false
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "loc": {
@@ -380,7 +147,7 @@
           "line": 6,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -400,25 +167,7 @@
                 "line": 8,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-            },
-            "origin": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 8,
-                  "column": 0,
-                  "offset": 48
-                },
-                "end": {
-                  "line": 8,
-                  "column": 2,
-                  "offset": 50
-                }
-              },
-              "name": "a",
-              "curly": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -430,7 +179,7 @@
               "line": 8,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
@@ -450,27 +199,7 @@
                   "line": 8,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-              },
-              "origin": {
-                "kind": "string",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 8,
-                    "column": 6,
-                    "offset": 54
-                  },
-                  "end": {
-                    "line": 8,
-                    "column": 12,
-                    "offset": 60
-                  }
-                },
-                "value": "Hello ",
-                "raw": "Hello ",
-                "unicode": false,
-                "isDoubleQuote": false
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
             },
             "loc": {
@@ -482,7 +211,7 @@
                 "line": 8,
                 "column": 13
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "right": {
@@ -498,25 +227,7 @@
                   "line": 8,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-              },
-              "origin": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 8,
-                    "column": 12,
-                    "offset": 60
-                  },
-                  "end": {
-                    "line": 8,
-                    "column": 17,
-                    "offset": 65
-                  }
-                },
-                "name": "name",
-                "curly": false
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
             },
             "loc": {
@@ -528,7 +239,7 @@
                 "line": 8,
                 "column": 18
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "_meta": {
@@ -541,101 +252,7 @@
                 "line": 8,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-            },
-            "origin": {
-              "kind": "encapsed",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 8,
-                  "column": 5,
-                  "offset": 53
-                },
-                "end": {
-                  "line": 8,
-                  "column": 18,
-                  "offset": 66
-                }
-              },
-              "value": [
-                {
-                  "kind": "encapsedpart",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 6,
-                      "offset": 54
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 12,
-                      "offset": 60
-                    }
-                  },
-                  "expression": {
-                    "kind": "string",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 8,
-                        "column": 6,
-                        "offset": 54
-                      },
-                      "end": {
-                        "line": 8,
-                        "column": 12,
-                        "offset": 60
-                      }
-                    },
-                    "value": "Hello ",
-                    "raw": "Hello ",
-                    "unicode": false,
-                    "isDoubleQuote": false
-                  },
-                  "syntax": null,
-                  "curly": false
-                },
-                {
-                  "kind": "encapsedpart",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 12,
-                      "offset": 60
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 17,
-                      "offset": 65
-                    }
-                  },
-                  "expression": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 8,
-                        "column": 12,
-                        "offset": 60
-                      },
-                      "end": {
-                        "line": 8,
-                        "column": 17,
-                        "offset": 65
-                      }
-                    },
-                    "name": "name",
-                    "curly": false
-                  },
-                  "syntax": "simple",
-                  "curly": false
-                }
-              ],
-              "raw": "\"Hello $name\"",
-              "type": "string"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             },
             "encapsed": true
           },
@@ -648,7 +265,7 @@
               "line": 8,
               "column": 19
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -661,138 +278,9 @@
             },
             "end": {
               "line": 8,
-              "column": 20
+              "column": 19
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-          },
-          "origin": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 8,
-                "column": 0,
-                "offset": 48
-              },
-              "end": {
-                "line": 8,
-                "column": 19,
-                "offset": 67
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 8,
-                  "column": 0,
-                  "offset": 48
-                },
-                "end": {
-                  "line": 8,
-                  "column": 2,
-                  "offset": 50
-                }
-              },
-              "name": "a",
-              "curly": false
-            },
-            "right": {
-              "kind": "encapsed",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 8,
-                  "column": 5,
-                  "offset": 53
-                },
-                "end": {
-                  "line": 8,
-                  "column": 18,
-                  "offset": 66
-                }
-              },
-              "value": [
-                {
-                  "kind": "encapsedpart",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 6,
-                      "offset": 54
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 12,
-                      "offset": 60
-                    }
-                  },
-                  "expression": {
-                    "kind": "string",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 8,
-                        "column": 6,
-                        "offset": 54
-                      },
-                      "end": {
-                        "line": 8,
-                        "column": 12,
-                        "offset": 60
-                      }
-                    },
-                    "value": "Hello ",
-                    "raw": "Hello ",
-                    "unicode": false,
-                    "isDoubleQuote": false
-                  },
-                  "syntax": null,
-                  "curly": false
-                },
-                {
-                  "kind": "encapsedpart",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 12,
-                      "offset": 60
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 17,
-                      "offset": 65
-                    }
-                  },
-                  "expression": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 8,
-                        "column": 12,
-                        "offset": 60
-                      },
-                      "end": {
-                        "line": 8,
-                        "column": 17,
-                        "offset": 65
-                      }
-                    },
-                    "name": "name",
-                    "curly": false
-                  },
-                  "syntax": "simple",
-                  "curly": false
-                }
-              ],
-              "raw": "\"Hello $name\"",
-              "type": "string"
-            },
-            "operator": "="
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "loc": {
@@ -802,9 +290,9 @@
           },
           "end": {
             "line": 8,
-            "column": 20
+            "column": 19
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -817,152 +305,7 @@
             "line": 8,
             "column": 20
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-        },
-        "origin": {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 8,
-              "column": 0,
-              "offset": 48
-            },
-            "end": {
-              "line": 8,
-              "column": 19,
-              "offset": 67
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 8,
-                "column": 0,
-                "offset": 48
-              },
-              "end": {
-                "line": 8,
-                "column": 19,
-                "offset": 67
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 8,
-                  "column": 0,
-                  "offset": 48
-                },
-                "end": {
-                  "line": 8,
-                  "column": 2,
-                  "offset": 50
-                }
-              },
-              "name": "a",
-              "curly": false
-            },
-            "right": {
-              "kind": "encapsed",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 8,
-                  "column": 5,
-                  "offset": 53
-                },
-                "end": {
-                  "line": 8,
-                  "column": 18,
-                  "offset": 66
-                }
-              },
-              "value": [
-                {
-                  "kind": "encapsedpart",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 6,
-                      "offset": 54
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 12,
-                      "offset": 60
-                    }
-                  },
-                  "expression": {
-                    "kind": "string",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 8,
-                        "column": 6,
-                        "offset": 54
-                      },
-                      "end": {
-                        "line": 8,
-                        "column": 12,
-                        "offset": 60
-                      }
-                    },
-                    "value": "Hello ",
-                    "raw": "Hello ",
-                    "unicode": false,
-                    "isDoubleQuote": false
-                  },
-                  "syntax": null,
-                  "curly": false
-                },
-                {
-                  "kind": "encapsedpart",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 12,
-                      "offset": 60
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 17,
-                      "offset": 65
-                    }
-                  },
-                  "expression": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 8,
-                        "column": 12,
-                        "offset": 60
-                      },
-                      "end": {
-                        "line": 8,
-                        "column": 17,
-                        "offset": 65
-                      }
-                    },
-                    "name": "name",
-                    "curly": false
-                  },
-                  "syntax": "simple",
-                  "curly": false
-                }
-              ],
-              "raw": "\"Hello $name\"",
-              "type": "string"
-            },
-            "operator": "="
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "loc": {
@@ -974,7 +317,7 @@
           "line": 8,
           "column": 20
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -994,25 +337,7 @@
                 "line": 9,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-            },
-            "origin": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 9,
-                  "column": 0,
-                  "offset": 68
-                },
-                "end": {
-                  "line": 9,
-                  "column": 2,
-                  "offset": 70
-                }
-              },
-              "name": "b",
-              "curly": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -1024,7 +349,7 @@
               "line": 9,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
@@ -1032,7 +357,6 @@
           "value": "raw",
           "literalType": "string",
           "_meta": {
-            "label": "TXT",
             "nowdoc": true,
             "loc": {
               "start": {
@@ -1043,26 +367,7 @@
                 "line": 11,
                 "column": 4
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-            },
-            "origin": {
-              "kind": "nowdoc",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 9,
-                  "column": 5,
-                  "offset": 73
-                },
-                "end": {
-                  "line": 11,
-                  "column": 3,
-                  "offset": 89
-                }
-              },
-              "value": "raw",
-              "raw": "<<<'TXT'\nraw\nTXT",
-              "label": "TXT"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -1074,7 +379,7 @@
               "line": 11,
               "column": 4
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -1087,63 +392,9 @@
             },
             "end": {
               "line": 11,
-              "column": 5
+              "column": 4
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-          },
-          "origin": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 9,
-                "column": 0,
-                "offset": 68
-              },
-              "end": {
-                "line": 11,
-                "column": 4,
-                "offset": 90
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 9,
-                  "column": 0,
-                  "offset": 68
-                },
-                "end": {
-                  "line": 9,
-                  "column": 2,
-                  "offset": 70
-                }
-              },
-              "name": "b",
-              "curly": false
-            },
-            "right": {
-              "kind": "nowdoc",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 9,
-                  "column": 5,
-                  "offset": 73
-                },
-                "end": {
-                  "line": 11,
-                  "column": 3,
-                  "offset": 89
-                }
-              },
-              "value": "raw",
-              "raw": "<<<'TXT'\nraw\nTXT",
-              "label": "TXT"
-            },
-            "operator": "="
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "loc": {
@@ -1153,9 +404,9 @@
           },
           "end": {
             "line": 11,
-            "column": 5
+            "column": 4
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -1168,77 +419,7 @@
             "line": 11,
             "column": 5
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-        },
-        "origin": {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 9,
-              "column": 0,
-              "offset": 68
-            },
-            "end": {
-              "line": 11,
-              "column": 4,
-              "offset": 90
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 9,
-                "column": 0,
-                "offset": 68
-              },
-              "end": {
-                "line": 11,
-                "column": 4,
-                "offset": 90
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 9,
-                  "column": 0,
-                  "offset": 68
-                },
-                "end": {
-                  "line": 9,
-                  "column": 2,
-                  "offset": 70
-                }
-              },
-              "name": "b",
-              "curly": false
-            },
-            "right": {
-              "kind": "nowdoc",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 9,
-                  "column": 5,
-                  "offset": 73
-                },
-                "end": {
-                  "line": 11,
-                  "column": 3,
-                  "offset": 89
-                }
-              },
-              "value": "raw",
-              "raw": "<<<'TXT'\nraw\nTXT",
-              "label": "TXT"
-            },
-            "operator": "="
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "loc": {
@@ -1250,7 +431,7 @@
           "line": 11,
           "column": 5
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -1270,25 +451,7 @@
                 "line": 12,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-            },
-            "origin": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 12,
-                  "column": 0,
-                  "offset": 91
-                },
-                "end": {
-                  "line": 12,
-                  "column": 2,
-                  "offset": 93
-                }
-              },
-              "name": "c",
-              "curly": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -1300,16 +463,13 @@
               "line": 12,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
-          "type": "Literal",
-          "value": "__FILE__",
-          "literalType": "string",
+          "type": "Identifier",
+          "name": "__FILE__",
           "_meta": {
-            "magic": true,
-            "raw": "__FILE__",
             "loc": {
               "start": {
                 "line": 12,
@@ -1319,25 +479,7 @@
                 "line": 12,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-            },
-            "origin": {
-              "kind": "magic",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 12,
-                  "column": 5,
-                  "offset": 96
-                },
-                "end": {
-                  "line": 12,
-                  "column": 13,
-                  "offset": 104
-                }
-              },
-              "value": "__FILE__",
-              "raw": "__FILE__"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -1349,7 +491,7 @@
               "line": 12,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -1362,62 +504,9 @@
             },
             "end": {
               "line": 12,
-              "column": 15
+              "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-          },
-          "origin": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 12,
-                "column": 0,
-                "offset": 91
-              },
-              "end": {
-                "line": 12,
-                "column": 14,
-                "offset": 105
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 12,
-                  "column": 0,
-                  "offset": 91
-                },
-                "end": {
-                  "line": 12,
-                  "column": 2,
-                  "offset": 93
-                }
-              },
-              "name": "c",
-              "curly": false
-            },
-            "right": {
-              "kind": "magic",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 12,
-                  "column": 5,
-                  "offset": 96
-                },
-                "end": {
-                  "line": 12,
-                  "column": 13,
-                  "offset": 104
-                }
-              },
-              "value": "__FILE__",
-              "raw": "__FILE__"
-            },
-            "operator": "="
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "loc": {
@@ -1427,9 +516,9 @@
           },
           "end": {
             "line": 12,
-            "column": 15
+            "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -1442,76 +531,7 @@
             "line": 12,
             "column": 15
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-        },
-        "origin": {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 12,
-              "column": 0,
-              "offset": 91
-            },
-            "end": {
-              "line": 12,
-              "column": 14,
-              "offset": 105
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 12,
-                "column": 0,
-                "offset": 91
-              },
-              "end": {
-                "line": 12,
-                "column": 14,
-                "offset": 105
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 12,
-                  "column": 0,
-                  "offset": 91
-                },
-                "end": {
-                  "line": 12,
-                  "column": 2,
-                  "offset": 93
-                }
-              },
-              "name": "c",
-              "curly": false
-            },
-            "right": {
-              "kind": "magic",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 12,
-                  "column": 5,
-                  "offset": 96
-                },
-                "end": {
-                  "line": 12,
-                  "column": 13,
-                  "offset": 104
-                }
-              },
-              "value": "__FILE__",
-              "raw": "__FILE__"
-            },
-            "operator": "="
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "loc": {
@@ -1523,7 +543,7 @@
           "line": 12,
           "column": 15
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -1543,25 +563,7 @@
                 "line": 13,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-            },
-            "origin": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 13,
-                  "column": 0,
-                  "offset": 106
-                },
-                "end": {
-                  "line": 13,
-                  "column": 2,
-                  "offset": 108
-                }
-              },
-              "name": "d",
-              "curly": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -1573,7 +575,7 @@
               "line": 13,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
@@ -1591,25 +593,7 @@
                   "line": 13,
                   "column": 10
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-              },
-              "origin": {
-                "kind": "name",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 13,
-                    "column": 5,
-                    "offset": 111
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 9,
-                    "offset": 115
-                  }
-                },
-                "name": "Demo",
-                "resolution": "uqn"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
             },
             "loc": {
@@ -1621,7 +605,7 @@
                 "line": 13,
                 "column": 10
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "property": {
@@ -1637,24 +621,7 @@
                   "line": 13,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 13,
-                    "column": 11,
-                    "offset": 117
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 15,
-                    "offset": 121
-                  }
-                },
-                "name": "NAME"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
             },
             "loc": {
@@ -1666,7 +633,7 @@
                 "line": 13,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "computed": false,
@@ -1681,58 +648,7 @@
                 "line": 13,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-            },
-            "origin": {
-              "kind": "staticlookup",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 13,
-                  "column": 5,
-                  "offset": 111
-                },
-                "end": {
-                  "line": 13,
-                  "column": 15,
-                  "offset": 121
-                }
-              },
-              "what": {
-                "kind": "name",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 13,
-                    "column": 5,
-                    "offset": 111
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 9,
-                    "offset": 115
-                  }
-                },
-                "name": "Demo",
-                "resolution": "uqn"
-              },
-              "offset": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 13,
-                    "column": 11,
-                    "offset": 117
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 15,
-                    "offset": 121
-                  }
-                },
-                "name": "NAME"
-              }
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -1744,7 +660,7 @@
               "line": 13,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -1757,95 +673,9 @@
             },
             "end": {
               "line": 13,
-              "column": 17
+              "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-          },
-          "origin": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 13,
-                "column": 0,
-                "offset": 106
-              },
-              "end": {
-                "line": 13,
-                "column": 16,
-                "offset": 122
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 13,
-                  "column": 0,
-                  "offset": 106
-                },
-                "end": {
-                  "line": 13,
-                  "column": 2,
-                  "offset": 108
-                }
-              },
-              "name": "d",
-              "curly": false
-            },
-            "right": {
-              "kind": "staticlookup",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 13,
-                  "column": 5,
-                  "offset": 111
-                },
-                "end": {
-                  "line": 13,
-                  "column": 15,
-                  "offset": 121
-                }
-              },
-              "what": {
-                "kind": "name",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 13,
-                    "column": 5,
-                    "offset": 111
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 9,
-                    "offset": 115
-                  }
-                },
-                "name": "Demo",
-                "resolution": "uqn"
-              },
-              "offset": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 13,
-                    "column": 11,
-                    "offset": 117
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 15,
-                    "offset": 121
-                  }
-                },
-                "name": "NAME"
-              }
-            },
-            "operator": "="
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "loc": {
@@ -1855,9 +685,9 @@
           },
           "end": {
             "line": 13,
-            "column": 17
+            "column": 16
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -1870,109 +700,7 @@
             "line": 13,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-        },
-        "origin": {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 13,
-              "column": 0,
-              "offset": 106
-            },
-            "end": {
-              "line": 13,
-              "column": 16,
-              "offset": 122
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 13,
-                "column": 0,
-                "offset": 106
-              },
-              "end": {
-                "line": 13,
-                "column": 16,
-                "offset": 122
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 13,
-                  "column": 0,
-                  "offset": 106
-                },
-                "end": {
-                  "line": 13,
-                  "column": 2,
-                  "offset": 108
-                }
-              },
-              "name": "d",
-              "curly": false
-            },
-            "right": {
-              "kind": "staticlookup",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 13,
-                  "column": 5,
-                  "offset": 111
-                },
-                "end": {
-                  "line": 13,
-                  "column": 15,
-                  "offset": 121
-                }
-              },
-              "what": {
-                "kind": "name",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 13,
-                    "column": 5,
-                    "offset": 111
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 9,
-                    "offset": 115
-                  }
-                },
-                "name": "Demo",
-                "resolution": "uqn"
-              },
-              "offset": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 13,
-                    "column": 11,
-                    "offset": 117
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 15,
-                    "offset": 121
-                  }
-                },
-                "name": "NAME"
-              }
-            },
-            "operator": "="
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "loc": {
@@ -1984,7 +712,7 @@
           "line": 13,
           "column": 17
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -2004,25 +732,7 @@
                 "line": 14,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-            },
-            "origin": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 14,
-                  "column": 0,
-                  "offset": 123
-                },
-                "end": {
-                  "line": 14,
-                  "column": 2,
-                  "offset": 125
-                }
-              },
-              "name": "e",
-              "curly": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -2034,7 +744,7 @@
               "line": 14,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
@@ -2052,24 +762,7 @@
                   "line": 14,
                   "column": 10
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-              },
-              "origin": {
-                "kind": "selfreference",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 14,
-                    "column": 5,
-                    "offset": 128
-                  },
-                  "end": {
-                    "line": 14,
-                    "column": 9,
-                    "offset": 132
-                  }
-                },
-                "raw": "self"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
             },
             "loc": {
@@ -2081,7 +774,7 @@
                 "line": 14,
                 "column": 10
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "property": {
@@ -2097,24 +790,7 @@
                   "line": 14,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 14,
-                    "column": 11,
-                    "offset": 134
-                  },
-                  "end": {
-                    "line": 14,
-                    "column": 15,
-                    "offset": 138
-                  }
-                },
-                "name": "NAME"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
             },
             "loc": {
@@ -2126,7 +802,7 @@
                 "line": 14,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "computed": false,
@@ -2141,57 +817,7 @@
                 "line": 14,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-            },
-            "origin": {
-              "kind": "staticlookup",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 14,
-                  "column": 5,
-                  "offset": 128
-                },
-                "end": {
-                  "line": 14,
-                  "column": 15,
-                  "offset": 138
-                }
-              },
-              "what": {
-                "kind": "selfreference",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 14,
-                    "column": 5,
-                    "offset": 128
-                  },
-                  "end": {
-                    "line": 14,
-                    "column": 9,
-                    "offset": 132
-                  }
-                },
-                "raw": "self"
-              },
-              "offset": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 14,
-                    "column": 11,
-                    "offset": 134
-                  },
-                  "end": {
-                    "line": 14,
-                    "column": 15,
-                    "offset": 138
-                  }
-                },
-                "name": "NAME"
-              }
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -2203,7 +829,7 @@
               "line": 14,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -2216,94 +842,9 @@
             },
             "end": {
               "line": 14,
-              "column": 17
+              "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-          },
-          "origin": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 14,
-                "column": 0,
-                "offset": 123
-              },
-              "end": {
-                "line": 14,
-                "column": 16,
-                "offset": 139
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 14,
-                  "column": 0,
-                  "offset": 123
-                },
-                "end": {
-                  "line": 14,
-                  "column": 2,
-                  "offset": 125
-                }
-              },
-              "name": "e",
-              "curly": false
-            },
-            "right": {
-              "kind": "staticlookup",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 14,
-                  "column": 5,
-                  "offset": 128
-                },
-                "end": {
-                  "line": 14,
-                  "column": 15,
-                  "offset": 138
-                }
-              },
-              "what": {
-                "kind": "selfreference",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 14,
-                    "column": 5,
-                    "offset": 128
-                  },
-                  "end": {
-                    "line": 14,
-                    "column": 9,
-                    "offset": 132
-                  }
-                },
-                "raw": "self"
-              },
-              "offset": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 14,
-                    "column": 11,
-                    "offset": 134
-                  },
-                  "end": {
-                    "line": 14,
-                    "column": 15,
-                    "offset": 138
-                  }
-                },
-                "name": "NAME"
-              }
-            },
-            "operator": "="
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "loc": {
@@ -2313,9 +854,9 @@
           },
           "end": {
             "line": 14,
-            "column": 17
+            "column": 16
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -2328,108 +869,7 @@
             "line": 14,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-        },
-        "origin": {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 14,
-              "column": 0,
-              "offset": 123
-            },
-            "end": {
-              "line": 14,
-              "column": 16,
-              "offset": 139
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 14,
-                "column": 0,
-                "offset": 123
-              },
-              "end": {
-                "line": 14,
-                "column": 16,
-                "offset": 139
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 14,
-                  "column": 0,
-                  "offset": 123
-                },
-                "end": {
-                  "line": 14,
-                  "column": 2,
-                  "offset": 125
-                }
-              },
-              "name": "e",
-              "curly": false
-            },
-            "right": {
-              "kind": "staticlookup",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 14,
-                  "column": 5,
-                  "offset": 128
-                },
-                "end": {
-                  "line": 14,
-                  "column": 15,
-                  "offset": 138
-                }
-              },
-              "what": {
-                "kind": "selfreference",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 14,
-                    "column": 5,
-                    "offset": 128
-                  },
-                  "end": {
-                    "line": 14,
-                    "column": 9,
-                    "offset": 132
-                  }
-                },
-                "raw": "self"
-              },
-              "offset": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 14,
-                    "column": 11,
-                    "offset": 134
-                  },
-                  "end": {
-                    "line": 14,
-                    "column": 15,
-                    "offset": 138
-                  }
-                },
-                "name": "NAME"
-              }
-            },
-            "operator": "="
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "loc": {
@@ -2441,7 +881,7 @@
           "line": 14,
           "column": 17
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -2461,25 +901,7 @@
                 "line": 15,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-            },
-            "origin": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 15,
-                  "column": 0,
-                  "offset": 140
-                },
-                "end": {
-                  "line": 15,
-                  "column": 2,
-                  "offset": 142
-                }
-              },
-              "name": "i",
-              "curly": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -2491,15 +913,33 @@
               "line": 15,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
-          "type": "CastExpression",
-          "expression": {
+          "type": "CallExpression",
+          "callee": {
             "type": "Identifier",
-            "name": "x",
-            "_meta": {
+            "name": "int",
+            "_meta": {}
+          },
+          "arguments": [
+            {
+              "type": "Identifier",
+              "name": "x",
+              "_meta": {
+                "loc": {
+                  "start": {
+                    "line": 15,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 15,
+                    "column": 13
+                  },
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+                }
+              },
               "loc": {
                 "start": {
                   "line": 15,
@@ -2509,50 +949,12 @@
                   "line": 15,
                   "column": 13
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-              },
-              "origin": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 15,
-                    "column": 10,
-                    "offset": 150
-                  },
-                  "end": {
-                    "line": 15,
-                    "column": 12,
-                    "offset": 152
-                  }
-                },
-                "name": "x",
-                "curly": false
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
-            },
-            "loc": {
-              "start": {
-                "line": 15,
-                "column": 11
-              },
-              "end": {
-                "line": 15,
-                "column": 13
-              },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
-          },
-          "as": {
-            "type": "DynamicType",
-            "id": {
-              "type": "Identifier",
-              "name": "int",
-              "_meta": {}
-            },
-            "_meta": {}
-          },
+          ],
           "_meta": {
-            "raw": "(int)",
+            "isCast": true,
             "loc": {
               "start": {
                 "line": 15,
@@ -2562,43 +964,7 @@
                 "line": 15,
                 "column": 13
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-            },
-            "origin": {
-              "kind": "cast",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 15,
-                  "column": 5,
-                  "offset": 145
-                },
-                "end": {
-                  "line": 15,
-                  "column": 12,
-                  "offset": 152
-                }
-              },
-              "type": "int",
-              "raw": "(int)",
-              "expr": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 15,
-                    "column": 10,
-                    "offset": 150
-                  },
-                  "end": {
-                    "line": 15,
-                    "column": 12,
-                    "offset": 152
-                  }
-                },
-                "name": "x",
-                "curly": false
-              }
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -2610,7 +976,7 @@
               "line": 15,
               "column": 13
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -2623,80 +989,9 @@
             },
             "end": {
               "line": 15,
-              "column": 14
+              "column": 13
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-          },
-          "origin": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 15,
-                "column": 0,
-                "offset": 140
-              },
-              "end": {
-                "line": 15,
-                "column": 13,
-                "offset": 153
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 15,
-                  "column": 0,
-                  "offset": 140
-                },
-                "end": {
-                  "line": 15,
-                  "column": 2,
-                  "offset": 142
-                }
-              },
-              "name": "i",
-              "curly": false
-            },
-            "right": {
-              "kind": "cast",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 15,
-                  "column": 5,
-                  "offset": 145
-                },
-                "end": {
-                  "line": 15,
-                  "column": 12,
-                  "offset": 152
-                }
-              },
-              "type": "int",
-              "raw": "(int)",
-              "expr": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 15,
-                    "column": 10,
-                    "offset": 150
-                  },
-                  "end": {
-                    "line": 15,
-                    "column": 12,
-                    "offset": 152
-                  }
-                },
-                "name": "x",
-                "curly": false
-              }
-            },
-            "operator": "="
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "loc": {
@@ -2706,9 +1001,9 @@
           },
           "end": {
             "line": 15,
-            "column": 14
+            "column": 13
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -2721,94 +1016,7 @@
             "line": 15,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-        },
-        "origin": {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 15,
-              "column": 0,
-              "offset": 140
-            },
-            "end": {
-              "line": 15,
-              "column": 13,
-              "offset": 153
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 15,
-                "column": 0,
-                "offset": 140
-              },
-              "end": {
-                "line": 15,
-                "column": 13,
-                "offset": 153
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 15,
-                  "column": 0,
-                  "offset": 140
-                },
-                "end": {
-                  "line": 15,
-                  "column": 2,
-                  "offset": 142
-                }
-              },
-              "name": "i",
-              "curly": false
-            },
-            "right": {
-              "kind": "cast",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 15,
-                  "column": 5,
-                  "offset": 145
-                },
-                "end": {
-                  "line": 15,
-                  "column": 12,
-                  "offset": 152
-                }
-              },
-              "type": "int",
-              "raw": "(int)",
-              "expr": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 15,
-                    "column": 10,
-                    "offset": 150
-                  },
-                  "end": {
-                    "line": 15,
-                    "column": 12,
-                    "offset": 152
-                  }
-                },
-                "name": "x",
-                "curly": false
-              }
-            },
-            "operator": "="
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "loc": {
@@ -2820,7 +1028,7 @@
           "line": 15,
           "column": 14
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -2840,25 +1048,7 @@
                 "line": 16,
                 "column": 3
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-            },
-            "origin": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 16,
-                  "column": 0,
-                  "offset": 154
-                },
-                "end": {
-                  "line": 16,
-                  "column": 2,
-                  "offset": 156
-                }
-              },
-              "name": "s",
-              "curly": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -2870,15 +1060,33 @@
               "line": 16,
               "column": 3
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
-          "type": "CastExpression",
-          "expression": {
+          "type": "CallExpression",
+          "callee": {
             "type": "Identifier",
-            "name": "y",
-            "_meta": {
+            "name": "string",
+            "_meta": {}
+          },
+          "arguments": [
+            {
+              "type": "Identifier",
+              "name": "y",
+              "_meta": {
+                "loc": {
+                  "start": {
+                    "line": 16,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 16,
+                    "column": 16
+                  },
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+                }
+              },
               "loc": {
                 "start": {
                   "line": 16,
@@ -2888,50 +1096,12 @@
                   "line": 16,
                   "column": 16
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-              },
-              "origin": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 16,
-                    "column": 13,
-                    "offset": 167
-                  },
-                  "end": {
-                    "line": 16,
-                    "column": 15,
-                    "offset": 169
-                  }
-                },
-                "name": "y",
-                "curly": false
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
-            },
-            "loc": {
-              "start": {
-                "line": 16,
-                "column": 14
-              },
-              "end": {
-                "line": 16,
-                "column": 16
-              },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
-          },
-          "as": {
-            "type": "DynamicType",
-            "id": {
-              "type": "Identifier",
-              "name": "string",
-              "_meta": {}
-            },
-            "_meta": {}
-          },
+          ],
           "_meta": {
-            "raw": "(string)",
+            "isCast": true,
             "loc": {
               "start": {
                 "line": 16,
@@ -2941,43 +1111,7 @@
                 "line": 16,
                 "column": 16
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-            },
-            "origin": {
-              "kind": "cast",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 16,
-                  "column": 5,
-                  "offset": 159
-                },
-                "end": {
-                  "line": 16,
-                  "column": 15,
-                  "offset": 169
-                }
-              },
-              "type": "string",
-              "raw": "(string)",
-              "expr": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 16,
-                    "column": 13,
-                    "offset": 167
-                  },
-                  "end": {
-                    "line": 16,
-                    "column": 15,
-                    "offset": 169
-                  }
-                },
-                "name": "y",
-                "curly": false
-              }
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -2989,7 +1123,7 @@
               "line": 16,
               "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -3002,80 +1136,9 @@
             },
             "end": {
               "line": 16,
-              "column": 17
+              "column": 16
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-          },
-          "origin": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 16,
-                "column": 0,
-                "offset": 154
-              },
-              "end": {
-                "line": 16,
-                "column": 16,
-                "offset": 170
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 16,
-                  "column": 0,
-                  "offset": 154
-                },
-                "end": {
-                  "line": 16,
-                  "column": 2,
-                  "offset": 156
-                }
-              },
-              "name": "s",
-              "curly": false
-            },
-            "right": {
-              "kind": "cast",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 16,
-                  "column": 5,
-                  "offset": 159
-                },
-                "end": {
-                  "line": 16,
-                  "column": 15,
-                  "offset": 169
-                }
-              },
-              "type": "string",
-              "raw": "(string)",
-              "expr": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 16,
-                    "column": 13,
-                    "offset": 167
-                  },
-                  "end": {
-                    "line": 16,
-                    "column": 15,
-                    "offset": 169
-                  }
-                },
-                "name": "y",
-                "curly": false
-              }
-            },
-            "operator": "="
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "loc": {
@@ -3085,9 +1148,9 @@
           },
           "end": {
             "line": 16,
-            "column": 17
+            "column": 16
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -3100,94 +1163,7 @@
             "line": 16,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-        },
-        "origin": {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 16,
-              "column": 0,
-              "offset": 154
-            },
-            "end": {
-              "line": 16,
-              "column": 16,
-              "offset": 170
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 16,
-                "column": 0,
-                "offset": 154
-              },
-              "end": {
-                "line": 16,
-                "column": 16,
-                "offset": 170
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 16,
-                  "column": 0,
-                  "offset": 154
-                },
-                "end": {
-                  "line": 16,
-                  "column": 2,
-                  "offset": 156
-                }
-              },
-              "name": "s",
-              "curly": false
-            },
-            "right": {
-              "kind": "cast",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 16,
-                  "column": 5,
-                  "offset": 159
-                },
-                "end": {
-                  "line": 16,
-                  "column": 15,
-                  "offset": 169
-                }
-              },
-              "type": "string",
-              "raw": "(string)",
-              "expr": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 16,
-                    "column": 13,
-                    "offset": 167
-                  },
-                  "end": {
-                    "line": 16,
-                    "column": 15,
-                    "offset": 169
-                  }
-                },
-                "name": "y",
-                "curly": false
-              }
-            },
-            "operator": "="
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "loc": {
@@ -3199,7 +1175,7 @@
           "line": 16,
           "column": 17
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     },
     {
@@ -3219,25 +1195,7 @@
                 "line": 17,
                 "column": 5
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-            },
-            "origin": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 17,
-                  "column": 0,
-                  "offset": 171
-                },
-                "end": {
-                  "line": 17,
-                  "column": 4,
-                  "offset": 175
-                }
-              },
-              "name": "arr",
-              "curly": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -3249,15 +1207,33 @@
               "line": 17,
               "column": 5
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "right": {
-          "type": "CastExpression",
-          "expression": {
+          "type": "CallExpression",
+          "callee": {
             "type": "Identifier",
-            "name": "z",
-            "_meta": {
+            "name": "array",
+            "_meta": {}
+          },
+          "arguments": [
+            {
+              "type": "Identifier",
+              "name": "z",
+              "_meta": {
+                "loc": {
+                  "start": {
+                    "line": 17,
+                    "column": 15
+                  },
+                  "end": {
+                    "line": 17,
+                    "column": 17
+                  },
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
+                }
+              },
               "loc": {
                 "start": {
                   "line": 17,
@@ -3267,50 +1243,12 @@
                   "line": 17,
                   "column": 17
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-              },
-              "origin": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 17,
-                    "column": 14,
-                    "offset": 185
-                  },
-                  "end": {
-                    "line": 17,
-                    "column": 16,
-                    "offset": 187
-                  }
-                },
-                "name": "z",
-                "curly": false
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
               }
-            },
-            "loc": {
-              "start": {
-                "line": 17,
-                "column": 15
-              },
-              "end": {
-                "line": 17,
-                "column": 17
-              },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
-          },
-          "as": {
-            "type": "DynamicType",
-            "id": {
-              "type": "Identifier",
-              "name": "array",
-              "_meta": {}
-            },
-            "_meta": {}
-          },
+          ],
           "_meta": {
-            "raw": "(array)",
+            "isCast": true,
             "loc": {
               "start": {
                 "line": 17,
@@ -3320,43 +1258,7 @@
                 "line": 17,
                 "column": 17
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-            },
-            "origin": {
-              "kind": "cast",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 17,
-                  "column": 7,
-                  "offset": 178
-                },
-                "end": {
-                  "line": 17,
-                  "column": 16,
-                  "offset": 187
-                }
-              },
-              "type": "array",
-              "raw": "(array)",
-              "expr": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 17,
-                    "column": 14,
-                    "offset": 185
-                  },
-                  "end": {
-                    "line": 17,
-                    "column": 16,
-                    "offset": 187
-                  }
-                },
-                "name": "z",
-                "curly": false
-              }
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
             }
           },
           "loc": {
@@ -3368,7 +1270,7 @@
               "line": 17,
               "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "operator": "=",
@@ -3381,80 +1283,9 @@
             },
             "end": {
               "line": 17,
-              "column": 18
+              "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-          },
-          "origin": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 17,
-                "column": 0,
-                "offset": 171
-              },
-              "end": {
-                "line": 17,
-                "column": 17,
-                "offset": 188
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 17,
-                  "column": 0,
-                  "offset": 171
-                },
-                "end": {
-                  "line": 17,
-                  "column": 4,
-                  "offset": 175
-                }
-              },
-              "name": "arr",
-              "curly": false
-            },
-            "right": {
-              "kind": "cast",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 17,
-                  "column": 7,
-                  "offset": 178
-                },
-                "end": {
-                  "line": 17,
-                  "column": 16,
-                  "offset": 187
-                }
-              },
-              "type": "array",
-              "raw": "(array)",
-              "expr": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 17,
-                    "column": 14,
-                    "offset": 185
-                  },
-                  "end": {
-                    "line": 17,
-                    "column": 16,
-                    "offset": 187
-                  }
-                },
-                "name": "z",
-                "curly": false
-              }
-            },
-            "operator": "="
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
           }
         },
         "loc": {
@@ -3464,9 +1295,9 @@
           },
           "end": {
             "line": 17,
-            "column": 18
+            "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "_meta": {
@@ -3479,94 +1310,7 @@
             "line": 17,
             "column": 18
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-        },
-        "origin": {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 17,
-              "column": 0,
-              "offset": 171
-            },
-            "end": {
-              "line": 17,
-              "column": 17,
-              "offset": 188
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 17,
-                "column": 0,
-                "offset": 171
-              },
-              "end": {
-                "line": 17,
-                "column": 17,
-                "offset": 188
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 17,
-                  "column": 0,
-                  "offset": 171
-                },
-                "end": {
-                  "line": 17,
-                  "column": 4,
-                  "offset": 175
-                }
-              },
-              "name": "arr",
-              "curly": false
-            },
-            "right": {
-              "kind": "cast",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 17,
-                  "column": 7,
-                  "offset": 178
-                },
-                "end": {
-                  "line": 17,
-                  "column": 16,
-                  "offset": 187
-                }
-              },
-              "type": "array",
-              "raw": "(array)",
-              "expr": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 17,
-                    "column": 14,
-                    "offset": 185
-                  },
-                  "end": {
-                    "line": 17,
-                    "column": 16,
-                    "offset": 187
-                  }
-                },
-                "name": "z",
-                "curly": false
-              }
-            },
-            "operator": "="
-          }
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
         }
       },
       "loc": {
@@ -3578,13 +1322,13 @@
           "line": 17,
           "column": 18
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -3596,893 +1340,7 @@
         "line": 18,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
-    },
-    "origin": {
-      "kind": "program",
-      "loc": {
-        "source": null,
-        "start": {
-          "line": 1,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "line": 18,
-          "column": 0,
-          "offset": 189
-        }
-      },
-      "children": [
-        {
-          "kind": "class",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 7
-            },
-            "end": {
-              "line": 6,
-              "column": 1,
-              "offset": 46
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 6,
-                "offset": 13
-              },
-              "end": {
-                "line": 3,
-                "column": 10,
-                "offset": 17
-              }
-            },
-            "name": "Demo"
-          },
-          "isAnonymous": false,
-          "extends": null,
-          "implements": null,
-          "body": [
-            {
-              "kind": "classconstant",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 5,
-                  "column": 10,
-                  "offset": 30
-                },
-                "end": {
-                  "line": 5,
-                  "column": 23,
-                  "offset": 43
-                }
-              },
-              "constants": [
-                {
-                  "kind": "constant",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 10,
-                      "offset": 30
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 23,
-                      "offset": 43
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 10,
-                        "offset": 30
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 14,
-                        "offset": 34
-                      }
-                    },
-                    "name": "NAME"
-                  },
-                  "value": {
-                    "kind": "string",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 17,
-                        "offset": 37
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 23,
-                        "offset": 43
-                      }
-                    },
-                    "value": "demo",
-                    "raw": "'demo'",
-                    "unicode": false,
-                    "isDoubleQuote": false
-                  }
-                }
-              ],
-              "visibility": "",
-              "final": false,
-              "nullable": false,
-              "type": null,
-              "attrGroups": []
-            }
-          ],
-          "attrGroups": [],
-          "isAbstract": false,
-          "isFinal": false,
-          "isReadonly": false
-        },
-        {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 8,
-              "column": 0,
-              "offset": 48
-            },
-            "end": {
-              "line": 8,
-              "column": 19,
-              "offset": 67
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 8,
-                "column": 0,
-                "offset": 48
-              },
-              "end": {
-                "line": 8,
-                "column": 19,
-                "offset": 67
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 8,
-                  "column": 0,
-                  "offset": 48
-                },
-                "end": {
-                  "line": 8,
-                  "column": 2,
-                  "offset": 50
-                }
-              },
-              "name": "a",
-              "curly": false
-            },
-            "right": {
-              "kind": "encapsed",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 8,
-                  "column": 5,
-                  "offset": 53
-                },
-                "end": {
-                  "line": 8,
-                  "column": 18,
-                  "offset": 66
-                }
-              },
-              "value": [
-                {
-                  "kind": "encapsedpart",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 6,
-                      "offset": 54
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 12,
-                      "offset": 60
-                    }
-                  },
-                  "expression": {
-                    "kind": "string",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 8,
-                        "column": 6,
-                        "offset": 54
-                      },
-                      "end": {
-                        "line": 8,
-                        "column": 12,
-                        "offset": 60
-                      }
-                    },
-                    "value": "Hello ",
-                    "raw": "Hello ",
-                    "unicode": false,
-                    "isDoubleQuote": false
-                  },
-                  "syntax": null,
-                  "curly": false
-                },
-                {
-                  "kind": "encapsedpart",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 8,
-                      "column": 12,
-                      "offset": 60
-                    },
-                    "end": {
-                      "line": 8,
-                      "column": 17,
-                      "offset": 65
-                    }
-                  },
-                  "expression": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 8,
-                        "column": 12,
-                        "offset": 60
-                      },
-                      "end": {
-                        "line": 8,
-                        "column": 17,
-                        "offset": 65
-                      }
-                    },
-                    "name": "name",
-                    "curly": false
-                  },
-                  "syntax": "simple",
-                  "curly": false
-                }
-              ],
-              "raw": "\"Hello $name\"",
-              "type": "string"
-            },
-            "operator": "="
-          }
-        },
-        {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 9,
-              "column": 0,
-              "offset": 68
-            },
-            "end": {
-              "line": 11,
-              "column": 4,
-              "offset": 90
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 9,
-                "column": 0,
-                "offset": 68
-              },
-              "end": {
-                "line": 11,
-                "column": 4,
-                "offset": 90
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 9,
-                  "column": 0,
-                  "offset": 68
-                },
-                "end": {
-                  "line": 9,
-                  "column": 2,
-                  "offset": 70
-                }
-              },
-              "name": "b",
-              "curly": false
-            },
-            "right": {
-              "kind": "nowdoc",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 9,
-                  "column": 5,
-                  "offset": 73
-                },
-                "end": {
-                  "line": 11,
-                  "column": 3,
-                  "offset": 89
-                }
-              },
-              "value": "raw",
-              "raw": "<<<'TXT'\nraw\nTXT",
-              "label": "TXT"
-            },
-            "operator": "="
-          }
-        },
-        {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 12,
-              "column": 0,
-              "offset": 91
-            },
-            "end": {
-              "line": 12,
-              "column": 14,
-              "offset": 105
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 12,
-                "column": 0,
-                "offset": 91
-              },
-              "end": {
-                "line": 12,
-                "column": 14,
-                "offset": 105
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 12,
-                  "column": 0,
-                  "offset": 91
-                },
-                "end": {
-                  "line": 12,
-                  "column": 2,
-                  "offset": 93
-                }
-              },
-              "name": "c",
-              "curly": false
-            },
-            "right": {
-              "kind": "magic",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 12,
-                  "column": 5,
-                  "offset": 96
-                },
-                "end": {
-                  "line": 12,
-                  "column": 13,
-                  "offset": 104
-                }
-              },
-              "value": "__FILE__",
-              "raw": "__FILE__"
-            },
-            "operator": "="
-          }
-        },
-        {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 13,
-              "column": 0,
-              "offset": 106
-            },
-            "end": {
-              "line": 13,
-              "column": 16,
-              "offset": 122
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 13,
-                "column": 0,
-                "offset": 106
-              },
-              "end": {
-                "line": 13,
-                "column": 16,
-                "offset": 122
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 13,
-                  "column": 0,
-                  "offset": 106
-                },
-                "end": {
-                  "line": 13,
-                  "column": 2,
-                  "offset": 108
-                }
-              },
-              "name": "d",
-              "curly": false
-            },
-            "right": {
-              "kind": "staticlookup",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 13,
-                  "column": 5,
-                  "offset": 111
-                },
-                "end": {
-                  "line": 13,
-                  "column": 15,
-                  "offset": 121
-                }
-              },
-              "what": {
-                "kind": "name",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 13,
-                    "column": 5,
-                    "offset": 111
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 9,
-                    "offset": 115
-                  }
-                },
-                "name": "Demo",
-                "resolution": "uqn"
-              },
-              "offset": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 13,
-                    "column": 11,
-                    "offset": 117
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 15,
-                    "offset": 121
-                  }
-                },
-                "name": "NAME"
-              }
-            },
-            "operator": "="
-          }
-        },
-        {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 14,
-              "column": 0,
-              "offset": 123
-            },
-            "end": {
-              "line": 14,
-              "column": 16,
-              "offset": 139
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 14,
-                "column": 0,
-                "offset": 123
-              },
-              "end": {
-                "line": 14,
-                "column": 16,
-                "offset": 139
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 14,
-                  "column": 0,
-                  "offset": 123
-                },
-                "end": {
-                  "line": 14,
-                  "column": 2,
-                  "offset": 125
-                }
-              },
-              "name": "e",
-              "curly": false
-            },
-            "right": {
-              "kind": "staticlookup",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 14,
-                  "column": 5,
-                  "offset": 128
-                },
-                "end": {
-                  "line": 14,
-                  "column": 15,
-                  "offset": 138
-                }
-              },
-              "what": {
-                "kind": "selfreference",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 14,
-                    "column": 5,
-                    "offset": 128
-                  },
-                  "end": {
-                    "line": 14,
-                    "column": 9,
-                    "offset": 132
-                  }
-                },
-                "raw": "self"
-              },
-              "offset": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 14,
-                    "column": 11,
-                    "offset": 134
-                  },
-                  "end": {
-                    "line": 14,
-                    "column": 15,
-                    "offset": 138
-                  }
-                },
-                "name": "NAME"
-              }
-            },
-            "operator": "="
-          }
-        },
-        {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 15,
-              "column": 0,
-              "offset": 140
-            },
-            "end": {
-              "line": 15,
-              "column": 13,
-              "offset": 153
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 15,
-                "column": 0,
-                "offset": 140
-              },
-              "end": {
-                "line": 15,
-                "column": 13,
-                "offset": 153
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 15,
-                  "column": 0,
-                  "offset": 140
-                },
-                "end": {
-                  "line": 15,
-                  "column": 2,
-                  "offset": 142
-                }
-              },
-              "name": "i",
-              "curly": false
-            },
-            "right": {
-              "kind": "cast",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 15,
-                  "column": 5,
-                  "offset": 145
-                },
-                "end": {
-                  "line": 15,
-                  "column": 12,
-                  "offset": 152
-                }
-              },
-              "type": "int",
-              "raw": "(int)",
-              "expr": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 15,
-                    "column": 10,
-                    "offset": 150
-                  },
-                  "end": {
-                    "line": 15,
-                    "column": 12,
-                    "offset": 152
-                  }
-                },
-                "name": "x",
-                "curly": false
-              }
-            },
-            "operator": "="
-          }
-        },
-        {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 16,
-              "column": 0,
-              "offset": 154
-            },
-            "end": {
-              "line": 16,
-              "column": 16,
-              "offset": 170
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 16,
-                "column": 0,
-                "offset": 154
-              },
-              "end": {
-                "line": 16,
-                "column": 16,
-                "offset": 170
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 16,
-                  "column": 0,
-                  "offset": 154
-                },
-                "end": {
-                  "line": 16,
-                  "column": 2,
-                  "offset": 156
-                }
-              },
-              "name": "s",
-              "curly": false
-            },
-            "right": {
-              "kind": "cast",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 16,
-                  "column": 5,
-                  "offset": 159
-                },
-                "end": {
-                  "line": 16,
-                  "column": 15,
-                  "offset": 169
-                }
-              },
-              "type": "string",
-              "raw": "(string)",
-              "expr": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 16,
-                    "column": 13,
-                    "offset": 167
-                  },
-                  "end": {
-                    "line": 16,
-                    "column": 15,
-                    "offset": 169
-                  }
-                },
-                "name": "y",
-                "curly": false
-              }
-            },
-            "operator": "="
-          }
-        },
-        {
-          "kind": "expressionstatement",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 17,
-              "column": 0,
-              "offset": 171
-            },
-            "end": {
-              "line": 17,
-              "column": 17,
-              "offset": 188
-            }
-          },
-          "expression": {
-            "kind": "assign",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 17,
-                "column": 0,
-                "offset": 171
-              },
-              "end": {
-                "line": 17,
-                "column": 17,
-                "offset": 188
-              }
-            },
-            "left": {
-              "kind": "variable",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 17,
-                  "column": 0,
-                  "offset": 171
-                },
-                "end": {
-                  "line": 17,
-                  "column": 4,
-                  "offset": 175
-                }
-              },
-              "name": "arr",
-              "curly": false
-            },
-            "right": {
-              "kind": "cast",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 17,
-                  "column": 7,
-                  "offset": 178
-                },
-                "end": {
-                  "line": 17,
-                  "column": 16,
-                  "offset": 187
-                }
-              },
-              "type": "array",
-              "raw": "(array)",
-              "expr": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 17,
-                    "column": 14,
-                    "offset": 185
-                  },
-                  "end": {
-                    "line": 17,
-                    "column": 16,
-                    "offset": 187
-                  }
-                },
-                "name": "z",
-                "curly": false
-              }
-            },
-            "operator": "="
-          }
-        }
-      ],
-      "errors": [],
-      "comments": []
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
     }
   },
   "loc": {
@@ -4494,6 +1352,6 @@
       "line": 18,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/strings-casts.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/strings-casts.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/structures.php.json
+++ b/parser-PHP/tests/benchmark/base/structures.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+            "sourcefile": "structures.php"
           }
         },
         "loc": {
@@ -28,7 +28,7 @@
             "line": 3,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "structures.php"
         }
       },
       "body": [
@@ -47,7 +47,7 @@
                   "line": 5,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "structures.php"
               }
             },
             "loc": {
@@ -59,7 +59,7 @@
                 "line": 5,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "structures.php"
             }
           },
           "parameters": [
@@ -78,7 +78,7 @@
                       "line": 5,
                       "column": 27
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "structures.php"
                   }
                 },
                 "loc": {
@@ -90,7 +90,7 @@
                     "line": 5,
                     "column": 27
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "structures.php"
                 }
               },
               "init": null,
@@ -111,7 +111,7 @@
                     "line": 5,
                     "column": 27
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "structures.php"
                 }
               },
               "loc": {
@@ -123,7 +123,7 @@
                   "line": 5,
                   "column": 27
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "structures.php"
               }
             }
           ],
@@ -146,7 +146,7 @@
                   "line": 5,
                   "column": 29
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "structures.php"
               }
             },
             "loc": {
@@ -158,7 +158,7 @@
                 "line": 5,
                 "column": 29
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "structures.php"
             }
           },
           "modifiers": [
@@ -174,7 +174,7 @@
                 "line": 5,
                 "column": 29
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "structures.php"
             }
           },
           "loc": {
@@ -186,7 +186,7 @@
               "line": 5,
               "column": 29
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+            "sourcefile": "structures.php"
           }
         }
       ],
@@ -202,7 +202,7 @@
             "line": 6,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "structures.php"
         }
       },
       "loc": {
@@ -214,7 +214,7 @@
           "line": 6,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+        "sourcefile": "structures.php"
       }
     },
     {
@@ -232,7 +232,7 @@
               "line": 8,
               "column": 18
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+            "sourcefile": "structures.php"
           }
         },
         "loc": {
@@ -244,7 +244,7 @@
             "line": 8,
             "column": 18
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "structures.php"
         }
       },
       "body": [
@@ -263,7 +263,7 @@
                   "line": 10,
                   "column": 27
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "structures.php"
               }
             },
             "loc": {
@@ -275,7 +275,7 @@
                 "line": 10,
                 "column": 27
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "structures.php"
             }
           },
           "parameters": [],
@@ -303,7 +303,7 @@
                         "line": 12,
                         "column": 17
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "structures.php"
                     }
                   },
                   "loc": {
@@ -315,7 +315,7 @@
                       "line": 12,
                       "column": 17
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "structures.php"
                   }
                 },
                 "isYield": false,
@@ -329,7 +329,7 @@
                       "line": 12,
                       "column": 18
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "structures.php"
                   }
                 },
                 "loc": {
@@ -341,7 +341,7 @@
                     "line": 12,
                     "column": 18
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "structures.php"
                 }
               }
             ],
@@ -356,7 +356,7 @@
                   "line": 13,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "structures.php"
               }
             },
             "loc": {
@@ -368,7 +368,7 @@
                 "line": 13,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "structures.php"
             }
           },
           "modifiers": [
@@ -384,7 +384,7 @@
                 "line": 13,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "structures.php"
             }
           },
           "loc": {
@@ -396,7 +396,7 @@
               "line": 13,
               "column": 6
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+            "sourcefile": "structures.php"
           }
         }
       ],
@@ -412,7 +412,7 @@
             "line": 14,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "structures.php"
         }
       },
       "loc": {
@@ -424,7 +424,7 @@
           "line": 14,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+        "sourcefile": "structures.php"
       }
     },
     {
@@ -442,7 +442,7 @@
               "line": 16,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+            "sourcefile": "structures.php"
           }
         },
         "loc": {
@@ -454,7 +454,7 @@
             "line": 16,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "structures.php"
         }
       },
       "parameters": [],
@@ -481,7 +481,7 @@
                     "line": 18,
                     "column": 14
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "structures.php"
                 }
               },
               "loc": {
@@ -493,7 +493,7 @@
                   "line": 18,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "structures.php"
               }
             },
             "init": null,
@@ -514,7 +514,7 @@
                   "line": 18,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "structures.php"
               }
             },
             "loc": {
@@ -526,7 +526,7 @@
                 "line": 18,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "structures.php"
             }
           },
           {
@@ -544,7 +544,7 @@
                     "line": 18,
                     "column": 18
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "structures.php"
                 }
               },
               "loc": {
@@ -556,7 +556,7 @@
                   "line": 18,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "structures.php"
               }
             },
             "init": null,
@@ -577,7 +577,7 @@
                   "line": 18,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "structures.php"
               }
             },
             "loc": {
@@ -589,7 +589,7 @@
                 "line": 18,
                 "column": 18
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "structures.php"
             }
           },
           {
@@ -607,7 +607,7 @@
                     "line": 19,
                     "column": 18
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "structures.php"
                 }
               },
               "loc": {
@@ -619,7 +619,7 @@
                   "line": 19,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "structures.php"
               }
             },
             "init": {
@@ -636,7 +636,7 @@
                     "line": 19,
                     "column": 22
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "structures.php"
                 }
               },
               "loc": {
@@ -648,7 +648,7 @@
                   "line": 19,
                   "column": 22
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "structures.php"
               }
             },
             "cloned": false,
@@ -668,7 +668,7 @@
                   "line": 19,
                   "column": 22
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "structures.php"
               }
             },
             "loc": {
@@ -680,7 +680,7 @@
                 "line": 19,
                 "column": 22
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "structures.php"
             }
           },
           {
@@ -706,7 +706,7 @@
                         "line": 20,
                         "column": 13
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "structures.php"
                     }
                   },
                   "loc": {
@@ -718,7 +718,7 @@
                       "line": 20,
                       "column": 13
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "structures.php"
                   }
                 },
                 {
@@ -734,7 +734,7 @@
                         "line": 20,
                         "column": 17
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "structures.php"
                     }
                   },
                   "loc": {
@@ -746,7 +746,7 @@
                       "line": 20,
                       "column": 17
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "structures.php"
                   }
                 }
               ],
@@ -760,7 +760,7 @@
                     "line": 20,
                     "column": 19
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "structures.php"
                 }
               },
               "loc": {
@@ -772,7 +772,7 @@
                   "line": 20,
                   "column": 19
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "structures.php"
               }
             },
             "_meta": {
@@ -785,7 +785,7 @@
                   "line": 20,
                   "column": 19
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "structures.php"
               }
             },
             "loc": {
@@ -797,7 +797,7 @@
                 "line": 20,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "structures.php"
             }
           },
           {
@@ -820,7 +820,7 @@
                           "line": 22,
                           "column": 8
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "structures.php"
                       }
                     },
                     "loc": {
@@ -832,7 +832,7 @@
                         "line": 22,
                         "column": 8
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "structures.php"
                     }
                   },
                   {
@@ -848,7 +848,7 @@
                           "line": 22,
                           "column": 12
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "structures.php"
                       }
                     },
                     "loc": {
@@ -860,7 +860,7 @@
                         "line": 22,
                         "column": 12
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "structures.php"
                     }
                   }
                 ],
@@ -874,7 +874,7 @@
                       "line": 22,
                       "column": 13
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "structures.php"
                   }
                 },
                 "loc": {
@@ -886,7 +886,7 @@
                     "line": 22,
                     "column": 13
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "structures.php"
                 }
               },
               "right": {
@@ -904,7 +904,7 @@
                         "line": 22,
                         "column": 19
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "structures.php"
                     }
                   },
                   "loc": {
@@ -916,7 +916,7 @@
                       "line": 22,
                       "column": 19
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "structures.php"
                   }
                 },
                 "arguments": [],
@@ -930,7 +930,7 @@
                       "line": 22,
                       "column": 21
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "structures.php"
                   }
                 },
                 "loc": {
@@ -942,7 +942,7 @@
                     "line": 22,
                     "column": 21
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "structures.php"
                 }
               },
               "operator": "=",
@@ -957,7 +957,7 @@
                     "line": 22,
                     "column": 21
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "structures.php"
                 }
               },
               "loc": {
@@ -969,7 +969,7 @@
                   "line": 22,
                   "column": 21
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "structures.php"
               }
             },
             "_meta": {
@@ -982,7 +982,7 @@
                   "line": 22,
                   "column": 22
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "structures.php"
               }
             },
             "loc": {
@@ -994,7 +994,7 @@
                 "line": 22,
                 "column": 22
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "structures.php"
             }
           },
           {
@@ -1017,7 +1017,7 @@
                           "line": 23,
                           "column": 12
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "structures.php"
                       }
                     },
                     "loc": {
@@ -1029,7 +1029,7 @@
                         "line": 23,
                         "column": 12
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "structures.php"
                     }
                   },
                   {
@@ -1045,7 +1045,7 @@
                           "line": 23,
                           "column": 16
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "structures.php"
                       }
                     },
                     "loc": {
@@ -1057,7 +1057,7 @@
                         "line": 23,
                         "column": 16
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "structures.php"
                     }
                   }
                 ],
@@ -1071,7 +1071,7 @@
                       "line": 23,
                       "column": 17
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "structures.php"
                   }
                 },
                 "loc": {
@@ -1083,7 +1083,7 @@
                     "line": 23,
                     "column": 17
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "structures.php"
                 }
               },
               "right": {
@@ -1101,7 +1101,7 @@
                         "line": 23,
                         "column": 23
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "structures.php"
                     }
                   },
                   "loc": {
@@ -1113,7 +1113,7 @@
                       "line": 23,
                       "column": 23
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "structures.php"
                   }
                 },
                 "arguments": [],
@@ -1127,7 +1127,7 @@
                       "line": 23,
                       "column": 25
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "structures.php"
                   }
                 },
                 "loc": {
@@ -1139,7 +1139,7 @@
                     "line": 23,
                     "column": 25
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "structures.php"
                 }
               },
               "operator": "=",
@@ -1154,7 +1154,7 @@
                     "line": 23,
                     "column": 25
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "structures.php"
                 }
               },
               "loc": {
@@ -1166,7 +1166,7 @@
                   "line": 23,
                   "column": 25
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "structures.php"
               }
             },
             "_meta": {
@@ -1179,7 +1179,7 @@
                   "line": 23,
                   "column": 26
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "structures.php"
               }
             },
             "loc": {
@@ -1191,7 +1191,7 @@
                 "line": 23,
                 "column": 26
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "structures.php"
             }
           },
           {
@@ -1220,7 +1220,7 @@
                           "line": 25,
                           "column": 15
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "structures.php"
                       }
                     },
                     "loc": {
@@ -1232,7 +1232,7 @@
                         "line": 25,
                         "column": 15
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "structures.php"
                     }
                   },
                   "_meta": {
@@ -1245,7 +1245,7 @@
                         "line": 25,
                         "column": 15
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "structures.php"
                     }
                   },
                   "loc": {
@@ -1257,7 +1257,7 @@
                       "line": 25,
                       "column": 15
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "structures.php"
                   }
                 },
                 {
@@ -1281,7 +1281,7 @@
                           "line": 25,
                           "column": 19
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "structures.php"
                       }
                     },
                     "loc": {
@@ -1293,7 +1293,7 @@
                         "line": 25,
                         "column": 19
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "structures.php"
                     }
                   },
                   "_meta": {
@@ -1306,7 +1306,7 @@
                         "line": 25,
                         "column": 19
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "structures.php"
                     }
                   },
                   "loc": {
@@ -1318,7 +1318,7 @@
                       "line": 25,
                       "column": 19
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "structures.php"
                   }
                 },
                 {
@@ -1342,7 +1342,7 @@
                           "line": 25,
                           "column": 23
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "structures.php"
                       }
                     },
                     "loc": {
@@ -1354,7 +1354,7 @@
                         "line": 25,
                         "column": 23
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "structures.php"
                     }
                   },
                   "_meta": {
@@ -1367,7 +1367,7 @@
                         "line": 25,
                         "column": 23
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "structures.php"
                     }
                   },
                   "loc": {
@@ -1379,7 +1379,7 @@
                       "line": 25,
                       "column": 23
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "structures.php"
                   }
                 },
                 {
@@ -1403,7 +1403,7 @@
                           "line": 25,
                           "column": 27
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "structures.php"
                       }
                     },
                     "loc": {
@@ -1415,7 +1415,7 @@
                         "line": 25,
                         "column": 27
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "structures.php"
                     }
                   },
                   "_meta": {
@@ -1428,7 +1428,7 @@
                         "line": 25,
                         "column": 27
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "structures.php"
                     }
                   },
                   "loc": {
@@ -1440,7 +1440,7 @@
                       "line": 25,
                       "column": 27
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "structures.php"
                   }
                 }
               ],
@@ -1456,7 +1456,7 @@
                     "line": 25,
                     "column": 28
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "structures.php"
                 }
               },
               "loc": {
@@ -1468,7 +1468,7 @@
                   "line": 25,
                   "column": 28
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "structures.php"
               }
             },
             "isYield": false,
@@ -1482,7 +1482,7 @@
                   "line": 25,
                   "column": 29
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "structures.php"
               }
             },
             "loc": {
@@ -1494,7 +1494,7 @@
                 "line": 25,
                 "column": 29
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "structures.php"
             }
           }
         ],
@@ -1509,7 +1509,7 @@
               "line": 26,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+            "sourcefile": "structures.php"
           }
         },
         "loc": {
@@ -1521,7 +1521,7 @@
             "line": 26,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "structures.php"
         }
       },
       "modifiers": [],
@@ -1535,7 +1535,7 @@
             "line": 26,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "structures.php"
         }
       },
       "loc": {
@@ -1547,13 +1547,13 @@
           "line": 26,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+        "sourcefile": "structures.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php",
+  "uri": "structures.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -1565,7 +1565,7 @@
         "line": 27,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+      "sourcefile": "structures.php"
     }
   },
   "loc": {
@@ -1577,6 +1577,6 @@
       "line": 27,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+    "sourcefile": "structures.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/structures.php.json
+++ b/parser-PHP/tests/benchmark/base/structures.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
           }
         },
         "loc": {
@@ -28,7 +28,7 @@
             "line": 3,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
         }
       },
       "body": [
@@ -47,7 +47,7 @@
                   "line": 5,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "loc": {
@@ -59,7 +59,7 @@
                 "line": 5,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           "parameters": [
@@ -78,7 +78,7 @@
                       "line": 5,
                       "column": 27
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "loc": {
@@ -90,7 +90,7 @@
                     "line": 5,
                     "column": 27
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "init": null,
@@ -111,7 +111,7 @@
                     "line": 5,
                     "column": 27
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "loc": {
@@ -123,7 +123,7 @@
                   "line": 5,
                   "column": 27
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             }
           ],
@@ -146,7 +146,7 @@
                   "line": 5,
                   "column": 29
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "loc": {
@@ -158,7 +158,7 @@
                 "line": 5,
                 "column": 29
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           "modifiers": [
@@ -174,7 +174,7 @@
                 "line": 5,
                 "column": 29
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           "loc": {
@@ -186,7 +186,7 @@
               "line": 5,
               "column": 29
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
           }
         }
       ],
@@ -202,7 +202,7 @@
             "line": 6,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
         }
       },
       "loc": {
@@ -214,7 +214,7 @@
           "line": 6,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
       }
     },
     {
@@ -232,7 +232,7 @@
               "line": 8,
               "column": 18
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
           }
         },
         "loc": {
@@ -244,7 +244,7 @@
             "line": 8,
             "column": 18
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
         }
       },
       "body": [
@@ -263,7 +263,7 @@
                   "line": 10,
                   "column": 27
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "loc": {
@@ -275,7 +275,7 @@
                 "line": 10,
                 "column": 27
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           "parameters": [],
@@ -303,7 +303,7 @@
                         "line": 12,
                         "column": 17
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "loc": {
@@ -315,7 +315,7 @@
                       "line": 12,
                       "column": 17
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "isYield": false,
@@ -329,7 +329,7 @@
                       "line": 12,
                       "column": 18
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "loc": {
@@ -341,7 +341,7 @@
                     "line": 12,
                     "column": 18
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               }
             ],
@@ -356,7 +356,7 @@
                   "line": 13,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "loc": {
@@ -368,7 +368,7 @@
                 "line": 13,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           "modifiers": [
@@ -384,7 +384,7 @@
                 "line": 13,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           "loc": {
@@ -396,7 +396,7 @@
               "line": 13,
               "column": 6
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
           }
         }
       ],
@@ -412,7 +412,7 @@
             "line": 14,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
         }
       },
       "loc": {
@@ -424,7 +424,7 @@
           "line": 14,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
       }
     },
     {
@@ -442,7 +442,7 @@
               "line": 16,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
           }
         },
         "loc": {
@@ -454,7 +454,7 @@
             "line": 16,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
         }
       },
       "parameters": [],
@@ -481,7 +481,7 @@
                     "line": 18,
                     "column": 14
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "loc": {
@@ -493,7 +493,7 @@
                   "line": 18,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "init": null,
@@ -514,7 +514,7 @@
                   "line": 18,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "loc": {
@@ -526,7 +526,7 @@
                 "line": 18,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           {
@@ -544,7 +544,7 @@
                     "line": 18,
                     "column": 18
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "loc": {
@@ -556,7 +556,7 @@
                   "line": 18,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "init": null,
@@ -577,7 +577,7 @@
                   "line": 18,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "loc": {
@@ -589,7 +589,7 @@
                 "line": 18,
                 "column": 18
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           {
@@ -607,7 +607,7 @@
                     "line": 19,
                     "column": 18
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "loc": {
@@ -619,7 +619,7 @@
                   "line": 19,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "init": {
@@ -636,7 +636,7 @@
                     "line": 19,
                     "column": 22
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "loc": {
@@ -648,7 +648,7 @@
                   "line": 19,
                   "column": 22
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "cloned": false,
@@ -668,7 +668,7 @@
                   "line": 19,
                   "column": 22
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "loc": {
@@ -680,7 +680,7 @@
                 "line": 19,
                 "column": 22
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           {
@@ -706,7 +706,7 @@
                         "line": 20,
                         "column": 13
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "loc": {
@@ -718,7 +718,7 @@
                       "line": 20,
                       "column": 13
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 {
@@ -734,7 +734,7 @@
                         "line": 20,
                         "column": 17
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "loc": {
@@ -746,7 +746,7 @@
                       "line": 20,
                       "column": 17
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 }
               ],
@@ -760,7 +760,7 @@
                     "line": 20,
                     "column": 19
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "loc": {
@@ -772,7 +772,7 @@
                   "line": 20,
                   "column": 19
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "_meta": {
@@ -785,7 +785,7 @@
                   "line": 20,
                   "column": 19
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "loc": {
@@ -797,7 +797,7 @@
                 "line": 20,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           {
@@ -820,7 +820,7 @@
                           "line": 22,
                           "column": 8
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                       }
                     },
                     "loc": {
@@ -832,7 +832,7 @@
                         "line": 22,
                         "column": 8
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   {
@@ -848,7 +848,7 @@
                           "line": 22,
                           "column": 12
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                       }
                     },
                     "loc": {
@@ -860,7 +860,7 @@
                         "line": 22,
                         "column": 12
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   }
                 ],
@@ -874,7 +874,7 @@
                       "line": 22,
                       "column": 13
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "loc": {
@@ -886,7 +886,7 @@
                     "line": 22,
                     "column": 13
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "right": {
@@ -904,7 +904,7 @@
                         "line": 22,
                         "column": 19
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "loc": {
@@ -916,7 +916,7 @@
                       "line": 22,
                       "column": 19
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "arguments": [],
@@ -930,7 +930,7 @@
                       "line": 22,
                       "column": 21
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "loc": {
@@ -942,7 +942,7 @@
                     "line": 22,
                     "column": 21
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "operator": "=",
@@ -957,7 +957,7 @@
                     "line": 22,
                     "column": 21
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "loc": {
@@ -969,7 +969,7 @@
                   "line": 22,
                   "column": 21
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "_meta": {
@@ -982,7 +982,7 @@
                   "line": 22,
                   "column": 22
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "loc": {
@@ -994,7 +994,7 @@
                 "line": 22,
                 "column": 22
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           {
@@ -1017,7 +1017,7 @@
                           "line": 23,
                           "column": 12
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                       }
                     },
                     "loc": {
@@ -1029,7 +1029,7 @@
                         "line": 23,
                         "column": 12
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   {
@@ -1045,7 +1045,7 @@
                           "line": 23,
                           "column": 16
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                       }
                     },
                     "loc": {
@@ -1057,7 +1057,7 @@
                         "line": 23,
                         "column": 16
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   }
                 ],
@@ -1071,7 +1071,7 @@
                       "line": 23,
                       "column": 17
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "loc": {
@@ -1083,7 +1083,7 @@
                     "line": 23,
                     "column": 17
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "right": {
@@ -1101,7 +1101,7 @@
                         "line": 23,
                         "column": 23
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "loc": {
@@ -1113,7 +1113,7 @@
                       "line": 23,
                       "column": 23
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "arguments": [],
@@ -1127,7 +1127,7 @@
                       "line": 23,
                       "column": 25
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "loc": {
@@ -1139,7 +1139,7 @@
                     "line": 23,
                     "column": 25
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "operator": "=",
@@ -1154,7 +1154,7 @@
                     "line": 23,
                     "column": 25
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "loc": {
@@ -1166,7 +1166,7 @@
                   "line": 23,
                   "column": 25
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "_meta": {
@@ -1179,7 +1179,7 @@
                   "line": 23,
                   "column": 26
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "loc": {
@@ -1191,7 +1191,7 @@
                 "line": 23,
                 "column": 26
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           {
@@ -1220,7 +1220,7 @@
                           "line": 25,
                           "column": 15
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                       }
                     },
                     "loc": {
@@ -1232,7 +1232,7 @@
                         "line": 25,
                         "column": 15
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "_meta": {
@@ -1245,7 +1245,7 @@
                         "line": 25,
                         "column": 15
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "loc": {
@@ -1257,7 +1257,7 @@
                       "line": 25,
                       "column": 15
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 {
@@ -1281,7 +1281,7 @@
                           "line": 25,
                           "column": 19
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                       }
                     },
                     "loc": {
@@ -1293,7 +1293,7 @@
                         "line": 25,
                         "column": 19
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "_meta": {
@@ -1306,7 +1306,7 @@
                         "line": 25,
                         "column": 19
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "loc": {
@@ -1318,7 +1318,7 @@
                       "line": 25,
                       "column": 19
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 {
@@ -1342,7 +1342,7 @@
                           "line": 25,
                           "column": 23
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                       }
                     },
                     "loc": {
@@ -1354,7 +1354,7 @@
                         "line": 25,
                         "column": 23
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "_meta": {
@@ -1367,7 +1367,7 @@
                         "line": 25,
                         "column": 23
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "loc": {
@@ -1379,7 +1379,7 @@
                       "line": 25,
                       "column": 23
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 {
@@ -1403,7 +1403,7 @@
                           "line": 25,
                           "column": 27
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                       }
                     },
                     "loc": {
@@ -1415,7 +1415,7 @@
                         "line": 25,
                         "column": 27
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "_meta": {
@@ -1428,7 +1428,7 @@
                         "line": 25,
                         "column": 27
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "loc": {
@@ -1440,7 +1440,7 @@
                       "line": 25,
                       "column": 27
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 }
               ],
@@ -1456,7 +1456,7 @@
                     "line": 25,
                     "column": 28
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "loc": {
@@ -1468,7 +1468,7 @@
                   "line": 25,
                   "column": 28
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "isYield": false,
@@ -1482,7 +1482,7 @@
                   "line": 25,
                   "column": 29
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "loc": {
@@ -1494,7 +1494,7 @@
                 "line": 25,
                 "column": 29
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           }
         ],
@@ -1509,7 +1509,7 @@
               "line": 26,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
           }
         },
         "loc": {
@@ -1521,7 +1521,7 @@
             "line": 26,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
         }
       },
       "modifiers": [],
@@ -1535,7 +1535,7 @@
             "line": 26,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
         }
       },
       "loc": {
@@ -1547,13 +1547,13 @@
           "line": 26,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -1565,7 +1565,7 @@
         "line": 27,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
     }
   },
   "loc": {
@@ -1577,6 +1577,6 @@
       "line": 27,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/structures.php.json
+++ b/parser-PHP/tests/benchmark/base/structures.php.json
@@ -16,7 +16,7 @@
               "line": 3,
               "column": 17
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
           },
           "origin": {
             "kind": "identifier",
@@ -45,7 +45,7 @@
             "line": 3,
             "column": 17
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
         }
       },
       "body": [
@@ -64,7 +64,7 @@
                   "line": 5,
                   "column": 24
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -93,7 +93,7 @@
                 "line": 5,
                 "column": 24
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           "parameters": [
@@ -112,7 +112,7 @@
                       "line": 5,
                       "column": 27
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   },
                   "origin": {
                     "kind": "identifier",
@@ -141,7 +141,7 @@
                     "line": 5,
                     "column": 27
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "init": null,
@@ -164,7 +164,7 @@
                     "line": 5,
                     "column": 27
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 },
                 "origin": {
                   "kind": "parameter",
@@ -217,7 +217,7 @@
                   "line": 5,
                   "column": 27
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             }
           ],
@@ -240,7 +240,7 @@
                   "line": 5,
                   "column": 28
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               },
               "origin": {
                 "kind": "method",
@@ -338,7 +338,7 @@
                 "line": 5,
                 "column": 28
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           "modifiers": [
@@ -355,7 +355,7 @@
                 "line": 5,
                 "column": 28
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             },
             "origin": {
               "kind": "method",
@@ -453,7 +453,7 @@
               "line": 5,
               "column": 28
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
           }
         }
       ],
@@ -470,7 +470,7 @@
             "line": 6,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
         },
         "origin": {
           "kind": "interface",
@@ -605,7 +605,7 @@
           "line": 6,
           "column": 2
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
       }
     },
     {
@@ -623,7 +623,7 @@
               "line": 8,
               "column": 18
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
           },
           "origin": {
             "kind": "identifier",
@@ -652,7 +652,7 @@
             "line": 8,
             "column": 18
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
         }
       },
       "body": [
@@ -671,7 +671,7 @@
                   "line": 10,
                   "column": 27
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               },
               "origin": {
                 "kind": "identifier",
@@ -700,7 +700,7 @@
                 "line": 10,
                 "column": 27
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           "parameters": [],
@@ -728,7 +728,7 @@
                         "line": 12,
                         "column": 17
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     },
                     "origin": {
                       "kind": "number",
@@ -757,7 +757,7 @@
                       "line": 12,
                       "column": 17
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "isYield": false,
@@ -771,7 +771,7 @@
                       "line": 12,
                       "column": 18
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   },
                   "origin": {
                     "kind": "return",
@@ -816,7 +816,7 @@
                     "line": 12,
                     "column": 18
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               }
             ],
@@ -831,7 +831,7 @@
                   "line": 13,
                   "column": 6
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               },
               "origin": {
                 "kind": "block",
@@ -894,7 +894,7 @@
                 "line": 13,
                 "column": 6
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           "modifiers": [
@@ -911,7 +911,7 @@
                 "line": 13,
                 "column": 6
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             },
             "origin": {
               "kind": "method",
@@ -1017,7 +1017,7 @@
               "line": 13,
               "column": 6
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
           }
         }
       ],
@@ -1034,7 +1034,7 @@
             "line": 14,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
         },
         "origin": {
           "kind": "trait",
@@ -1175,7 +1175,7 @@
           "line": 14,
           "column": 2
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
       }
     },
     {
@@ -1193,7 +1193,7 @@
               "line": 16,
               "column": 14
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
           },
           "origin": {
             "kind": "identifier",
@@ -1222,7 +1222,7 @@
             "line": 16,
             "column": 14
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
         }
       },
       "parameters": [],
@@ -1249,7 +1249,7 @@
                     "line": 18,
                     "column": 14
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 },
                 "origin": {
                   "kind": "variable",
@@ -1279,7 +1279,7 @@
                   "line": 18,
                   "column": 14
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "init": null,
@@ -1299,7 +1299,7 @@
                   "line": 18,
                   "column": 14
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               },
               "origin": {
                 "kind": "variable",
@@ -1330,7 +1330,7 @@
                 "line": 18,
                 "column": 14
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           {
@@ -1348,7 +1348,7 @@
                     "line": 18,
                     "column": 18
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 },
                 "origin": {
                   "kind": "variable",
@@ -1378,7 +1378,7 @@
                   "line": 18,
                   "column": 18
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "init": null,
@@ -1398,7 +1398,7 @@
                   "line": 18,
                   "column": 18
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               },
               "origin": {
                 "kind": "variable",
@@ -1429,7 +1429,7 @@
                 "line": 18,
                 "column": 18
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           {
@@ -1447,7 +1447,7 @@
                     "line": 19,
                     "column": 18
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 },
                 "origin": {
                   "kind": "variable",
@@ -1477,7 +1477,7 @@
                   "line": 19,
                   "column": 18
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "init": {
@@ -1494,7 +1494,7 @@
                     "line": 19,
                     "column": 22
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 },
                 "origin": {
                   "kind": "number",
@@ -1523,7 +1523,7 @@
                   "line": 19,
                   "column": 22
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "cloned": false,
@@ -1542,7 +1542,7 @@
                   "line": 19,
                   "column": 22
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               },
               "origin": {
                 "kind": "staticvariable",
@@ -1606,7 +1606,7 @@
                 "line": 19,
                 "column": 22
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           {
@@ -1630,7 +1630,7 @@
                       "line": 20,
                       "column": 13
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   },
                   "origin": {
                     "kind": "variable",
@@ -1660,7 +1660,7 @@
                     "line": 20,
                     "column": 13
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               {
@@ -1676,7 +1676,7 @@
                       "line": 20,
                       "column": 17
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   },
                   "origin": {
                     "kind": "variable",
@@ -1706,7 +1706,7 @@
                     "line": 20,
                     "column": 17
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               }
             ],
@@ -1721,7 +1721,7 @@
                   "line": 20,
                   "column": 19
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               },
               "origin": {
                 "kind": "unset",
@@ -1787,7 +1787,7 @@
                 "line": 20,
                 "column": 19
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           {
@@ -1810,7 +1810,7 @@
                           "line": 22,
                           "column": 8
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                       },
                       "origin": {
                         "kind": "variable",
@@ -1840,7 +1840,7 @@
                         "line": 22,
                         "column": 8
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   {
@@ -1856,7 +1856,7 @@
                           "line": 22,
                           "column": 12
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                       },
                       "origin": {
                         "kind": "variable",
@@ -1886,7 +1886,7 @@
                         "line": 22,
                         "column": 12
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   }
                 ],
@@ -1901,7 +1901,7 @@
                       "line": 22,
                       "column": 13
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   },
                   "origin": {
                     "kind": "list",
@@ -2006,7 +2006,7 @@
                     "line": 22,
                     "column": 13
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "right": {
@@ -2024,7 +2024,7 @@
                         "line": 22,
                         "column": 19
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     },
                     "origin": {
                       "kind": "name",
@@ -2054,7 +2054,7 @@
                       "line": 22,
                       "column": 19
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "arguments": [],
@@ -2068,7 +2068,7 @@
                       "line": 22,
                       "column": 21
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   },
                   "origin": {
                     "kind": "call",
@@ -2115,7 +2115,7 @@
                     "line": 22,
                     "column": 21
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "operator": "=",
@@ -2130,7 +2130,7 @@
                     "line": 22,
                     "column": 22
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 },
                 "origin": {
                   "kind": "assign",
@@ -2287,7 +2287,7 @@
                   "line": 22,
                   "column": 22
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "_meta": {
@@ -2300,7 +2300,7 @@
                   "line": 22,
                   "column": 22
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               },
               "origin": {
                 "kind": "expressionstatement",
@@ -2473,7 +2473,7 @@
                 "line": 22,
                 "column": 22
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           {
@@ -2496,7 +2496,7 @@
                           "line": 23,
                           "column": 12
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                       },
                       "origin": {
                         "kind": "variable",
@@ -2526,7 +2526,7 @@
                         "line": 23,
                         "column": 12
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   {
@@ -2542,7 +2542,7 @@
                           "line": 23,
                           "column": 16
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                       },
                       "origin": {
                         "kind": "variable",
@@ -2572,7 +2572,7 @@
                         "line": 23,
                         "column": 16
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   }
                 ],
@@ -2587,7 +2587,7 @@
                       "line": 23,
                       "column": 17
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   },
                   "origin": {
                     "kind": "list",
@@ -2692,7 +2692,7 @@
                     "line": 23,
                     "column": 17
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "right": {
@@ -2710,7 +2710,7 @@
                         "line": 23,
                         "column": 23
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     },
                     "origin": {
                       "kind": "name",
@@ -2740,7 +2740,7 @@
                       "line": 23,
                       "column": 23
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "arguments": [],
@@ -2754,7 +2754,7 @@
                       "line": 23,
                       "column": 25
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   },
                   "origin": {
                     "kind": "call",
@@ -2801,7 +2801,7 @@
                     "line": 23,
                     "column": 25
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "operator": "=",
@@ -2816,7 +2816,7 @@
                     "line": 23,
                     "column": 26
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 },
                 "origin": {
                   "kind": "assign",
@@ -2973,7 +2973,7 @@
                   "line": 23,
                   "column": 26
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "_meta": {
@@ -2986,7 +2986,7 @@
                   "line": 23,
                   "column": 26
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               },
               "origin": {
                 "kind": "expressionstatement",
@@ -3159,7 +3159,7 @@
                 "line": 23,
                 "column": 26
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           {
@@ -3188,7 +3188,7 @@
                           "line": 25,
                           "column": 15
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                       },
                       "origin": {
                         "kind": "variable",
@@ -3218,7 +3218,7 @@
                         "line": 25,
                         "column": 15
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "_meta": {
@@ -3231,7 +3231,7 @@
                         "line": 25,
                         "column": 15
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     },
                     "origin": {
                       "kind": "entry",
@@ -3280,7 +3280,7 @@
                       "line": 25,
                       "column": 15
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 {
@@ -3304,7 +3304,7 @@
                           "line": 25,
                           "column": 19
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                       },
                       "origin": {
                         "kind": "variable",
@@ -3334,7 +3334,7 @@
                         "line": 25,
                         "column": 19
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "_meta": {
@@ -3347,7 +3347,7 @@
                         "line": 25,
                         "column": 19
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     },
                     "origin": {
                       "kind": "entry",
@@ -3396,7 +3396,7 @@
                       "line": 25,
                       "column": 19
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 {
@@ -3420,7 +3420,7 @@
                           "line": 25,
                           "column": 23
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                       },
                       "origin": {
                         "kind": "variable",
@@ -3450,7 +3450,7 @@
                         "line": 25,
                         "column": 23
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "_meta": {
@@ -3463,7 +3463,7 @@
                         "line": 25,
                         "column": 23
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     },
                     "origin": {
                       "kind": "entry",
@@ -3512,7 +3512,7 @@
                       "line": 25,
                       "column": 23
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 {
@@ -3536,7 +3536,7 @@
                           "line": 25,
                           "column": 27
                         },
-                        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                       },
                       "origin": {
                         "kind": "variable",
@@ -3566,7 +3566,7 @@
                         "line": 25,
                         "column": 27
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "_meta": {
@@ -3579,7 +3579,7 @@
                         "line": 25,
                         "column": 27
                       },
-                      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                     },
                     "origin": {
                       "kind": "entry",
@@ -3628,7 +3628,7 @@
                       "line": 25,
                       "column": 27
                     },
-                    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 }
               ],
@@ -3644,7 +3644,7 @@
                     "line": 25,
                     "column": 28
                   },
-                  "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
                 },
                 "origin": {
                   "kind": "array",
@@ -3823,7 +3823,7 @@
                   "line": 25,
                   "column": 28
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "isYield": false,
@@ -3837,7 +3837,7 @@
                   "line": 25,
                   "column": 29
                 },
-                "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
               },
               "origin": {
                 "kind": "return",
@@ -4032,7 +4032,7 @@
                 "line": 25,
                 "column": 29
               },
-              "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
             }
           }
         ],
@@ -4047,7 +4047,7 @@
               "line": 26,
               "column": 2
             },
-            "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
           },
           "origin": {
             "kind": "block",
@@ -4759,7 +4759,7 @@
             "line": 26,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
         }
       },
       "modifiers": [],
@@ -4774,7 +4774,7 @@
             "line": 26,
             "column": 2
           },
-          "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
         },
         "origin": {
           "kind": "function",
@@ -5524,13 +5524,13 @@
           "line": 26,
           "column": 2
         },
-        "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -5542,7 +5542,7 @@
         "line": 27,
         "column": 1
       },
-      "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
     },
     "origin": {
       "kind": "program",
@@ -6564,6 +6564,6 @@
       "line": 27,
       "column": 1
     },
-    "sourcefile": "/Users/chunpeng/Work/repo/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
   }
 }

--- a/parser-PHP/tests/benchmark/base/structures.php.json
+++ b/parser-PHP/tests/benchmark/base/structures.php.json
@@ -16,24 +16,7 @@
               "line": 3,
               "column": 17
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-          },
-          "origin": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 10,
-                "offset": 17
-              },
-              "end": {
-                "line": 3,
-                "column": 16,
-                "offset": 23
-              }
-            },
-            "name": "Runner"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
           }
         },
         "loc": {
@@ -45,7 +28,7 @@
             "line": 3,
             "column": 17
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
         }
       },
       "body": [
@@ -64,24 +47,7 @@
                   "line": 5,
                   "column": 24
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 20,
-                    "offset": 46
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 23,
-                    "offset": 49
-                  }
-                },
-                "name": "run"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "loc": {
@@ -93,7 +59,7 @@
                 "line": 5,
                 "column": 24
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           "parameters": [
@@ -112,24 +78,7 @@
                       "line": 5,
                       "column": 27
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                  },
-                  "origin": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 24,
-                        "offset": 50
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 26,
-                        "offset": 52
-                      }
-                    },
-                    "name": "x"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "loc": {
@@ -141,7 +90,7 @@
                     "line": 5,
                     "column": 27
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "init": null,
@@ -152,9 +101,7 @@
                 "_meta": {}
               },
               "_meta": {
-                "byref": false,
                 "variadic": false,
-                "attributes": [],
                 "loc": {
                   "start": {
                     "line": 5,
@@ -164,48 +111,7 @@
                     "line": 5,
                     "column": 27
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                },
-                "origin": {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 24,
-                      "offset": 50
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 26,
-                      "offset": 52
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 24,
-                        "offset": 50
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 26,
-                        "offset": 52
-                      }
-                    },
-                    "name": "x"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": []
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "loc": {
@@ -217,7 +123,7 @@
                   "line": 5,
                   "column": 27
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
               }
             }
           ],
@@ -238,95 +144,9 @@
                 },
                 "end": {
                   "line": 5,
-                  "column": 28
+                  "column": 29
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-              },
-              "origin": {
-                "kind": "method",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 4,
-                    "offset": 30
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 27,
-                    "offset": 53
-                  }
-                },
-                "name": {
-                  "kind": "identifier",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 20,
-                      "offset": 46
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 23,
-                      "offset": 49
-                    }
-                  },
-                  "name": "run"
-                },
-                "arguments": [
-                  {
-                    "kind": "parameter",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 24,
-                        "offset": 50
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 26,
-                        "offset": 52
-                      }
-                    },
-                    "name": {
-                      "kind": "identifier",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 5,
-                          "column": 24,
-                          "offset": 50
-                        },
-                        "end": {
-                          "line": 5,
-                          "column": 26,
-                          "offset": 52
-                        }
-                      },
-                      "name": "x"
-                    },
-                    "value": null,
-                    "type": null,
-                    "byref": false,
-                    "variadic": false,
-                    "readonly": false,
-                    "nullable": false,
-                    "flags": 0,
-                    "attrGroups": []
-                  }
-                ],
-                "byref": false,
-                "type": null,
-                "nullable": false,
-                "body": null,
-                "attrGroups": [],
-                "isAbstract": false,
-                "isFinal": false,
-                "isReadonly": false,
-                "visibility": "public",
-                "isStatic": false
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "loc": {
@@ -336,16 +156,15 @@
               },
               "end": {
                 "line": 5,
-                "column": 28
+                "column": 29
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           "modifiers": [
             "public"
           ],
           "_meta": {
-            "attributes": [],
             "loc": {
               "start": {
                 "line": 5,
@@ -353,95 +172,9 @@
               },
               "end": {
                 "line": 5,
-                "column": 28
+                "column": 29
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-            },
-            "origin": {
-              "kind": "method",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 5,
-                  "column": 4,
-                  "offset": 30
-                },
-                "end": {
-                  "line": 5,
-                  "column": 27,
-                  "offset": 53
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 20,
-                    "offset": 46
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 23,
-                    "offset": 49
-                  }
-                },
-                "name": "run"
-              },
-              "arguments": [
-                {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 24,
-                      "offset": 50
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 26,
-                      "offset": 52
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 24,
-                        "offset": 50
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 26,
-                        "offset": 52
-                      }
-                    },
-                    "name": "x"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": []
-                }
-              ],
-              "byref": false,
-              "type": null,
-              "nullable": false,
-              "body": null,
-              "attrGroups": [],
-              "isAbstract": false,
-              "isFinal": false,
-              "isReadonly": false,
-              "visibility": "public",
-              "isStatic": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           "loc": {
@@ -451,16 +184,15 @@
             },
             "end": {
               "line": 5,
-              "column": 28
+              "column": 29
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
           }
         }
       ],
       "supers": [],
       "_meta": {
-        "structureKind": "interface",
-        "attributes": [],
+        "kind": "interface",
         "loc": {
           "start": {
             "line": 3,
@@ -470,130 +202,7 @@
             "line": 6,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-        },
-        "origin": {
-          "kind": "interface",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 7
-            },
-            "end": {
-              "line": 6,
-              "column": 1,
-              "offset": 56
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 10,
-                "offset": 17
-              },
-              "end": {
-                "line": 3,
-                "column": 16,
-                "offset": 23
-              }
-            },
-            "name": "Runner"
-          },
-          "extends": null,
-          "body": [
-            {
-              "kind": "method",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 5,
-                  "column": 4,
-                  "offset": 30
-                },
-                "end": {
-                  "line": 5,
-                  "column": 27,
-                  "offset": 53
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 20,
-                    "offset": 46
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 23,
-                    "offset": 49
-                  }
-                },
-                "name": "run"
-              },
-              "arguments": [
-                {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 24,
-                      "offset": 50
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 26,
-                      "offset": 52
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 24,
-                        "offset": 50
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 26,
-                        "offset": 52
-                      }
-                    },
-                    "name": "x"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": []
-                }
-              ],
-              "byref": false,
-              "type": null,
-              "nullable": false,
-              "body": null,
-              "attrGroups": [],
-              "isAbstract": false,
-              "isFinal": false,
-              "isReadonly": false,
-              "visibility": "public",
-              "isStatic": false
-            }
-          ],
-          "attrGroups": []
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
         }
       },
       "loc": {
@@ -605,7 +214,7 @@
           "line": 6,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
       }
     },
     {
@@ -623,24 +232,7 @@
               "line": 8,
               "column": 18
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-          },
-          "origin": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 8,
-                "column": 6,
-                "offset": 64
-              },
-              "end": {
-                "line": 8,
-                "column": 17,
-                "offset": 75
-              }
-            },
-            "name": "HelperTrait"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
           }
         },
         "loc": {
@@ -652,7 +244,7 @@
             "line": 8,
             "column": 18
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
         }
       },
       "body": [
@@ -671,24 +263,7 @@
                   "line": 10,
                   "column": 27
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-              },
-              "origin": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 10,
-                    "column": 20,
-                    "offset": 98
-                  },
-                  "end": {
-                    "line": 10,
-                    "column": 26,
-                    "offset": 104
-                  }
-                },
-                "name": "helper"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "loc": {
@@ -700,7 +275,7 @@
                 "line": 10,
                 "column": 27
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           "parameters": [],
@@ -728,24 +303,7 @@
                         "line": 12,
                         "column": 17
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                    },
-                    "origin": {
-                      "kind": "number",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 12,
-                          "column": 15,
-                          "offset": 128
-                        },
-                        "end": {
-                          "line": 12,
-                          "column": 16,
-                          "offset": 129
-                        }
-                      },
-                      "value": "1"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "loc": {
@@ -757,7 +315,7 @@
                       "line": 12,
                       "column": 17
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "isYield": false,
@@ -771,40 +329,7 @@
                       "line": 12,
                       "column": 18
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                  },
-                  "origin": {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 12,
-                        "column": 8,
-                        "offset": 121
-                      },
-                      "end": {
-                        "line": 12,
-                        "column": 17,
-                        "offset": 130
-                      }
-                    },
-                    "expr": {
-                      "kind": "number",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 12,
-                          "column": 15,
-                          "offset": 128
-                        },
-                        "end": {
-                          "line": 12,
-                          "column": 16,
-                          "offset": 129
-                        }
-                      },
-                      "value": "1"
-                    }
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "loc": {
@@ -816,7 +341,7 @@
                     "line": 12,
                     "column": 18
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                 }
               }
             ],
@@ -831,58 +356,7 @@
                   "line": 13,
                   "column": 6
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-              },
-              "origin": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 11,
-                    "column": 4,
-                    "offset": 111
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 5,
-                    "offset": 136
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 12,
-                        "column": 8,
-                        "offset": 121
-                      },
-                      "end": {
-                        "line": 12,
-                        "column": 17,
-                        "offset": 130
-                      }
-                    },
-                    "expr": {
-                      "kind": "number",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 12,
-                          "column": 15,
-                          "offset": 128
-                        },
-                        "end": {
-                          "line": 12,
-                          "column": 16,
-                          "offset": 129
-                        }
-                      },
-                      "value": "1"
-                    }
-                  }
-                ]
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "loc": {
@@ -894,14 +368,13 @@
                 "line": 13,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           "modifiers": [
             "public"
           ],
           "_meta": {
-            "attributes": [],
             "loc": {
               "start": {
                 "line": 10,
@@ -911,101 +384,7 @@
                 "line": 13,
                 "column": 6
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-            },
-            "origin": {
-              "kind": "method",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 10,
-                  "column": 4,
-                  "offset": 82
-                },
-                "end": {
-                  "line": 13,
-                  "column": 5,
-                  "offset": 136
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 10,
-                    "column": 20,
-                    "offset": 98
-                  },
-                  "end": {
-                    "line": 10,
-                    "column": 26,
-                    "offset": 104
-                  }
-                },
-                "name": "helper"
-              },
-              "arguments": [],
-              "byref": false,
-              "type": null,
-              "nullable": false,
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 11,
-                    "column": 4,
-                    "offset": 111
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 5,
-                    "offset": 136
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 12,
-                        "column": 8,
-                        "offset": 121
-                      },
-                      "end": {
-                        "line": 12,
-                        "column": 17,
-                        "offset": 130
-                      }
-                    },
-                    "expr": {
-                      "kind": "number",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 12,
-                          "column": 15,
-                          "offset": 128
-                        },
-                        "end": {
-                          "line": 12,
-                          "column": 16,
-                          "offset": 129
-                        }
-                      },
-                      "value": "1"
-                    }
-                  }
-                ]
-              },
-              "attrGroups": [],
-              "isAbstract": false,
-              "isFinal": false,
-              "isReadonly": false,
-              "visibility": "public",
-              "isStatic": false
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           "loc": {
@@ -1017,14 +396,13 @@
               "line": 13,
               "column": 6
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
           }
         }
       ],
       "supers": [],
       "_meta": {
-        "structureKind": "trait",
-        "attributes": [],
+        "kind": "trait",
         "loc": {
           "start": {
             "line": 8,
@@ -1034,136 +412,7 @@
             "line": 14,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-        },
-        "origin": {
-          "kind": "trait",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 8,
-              "column": 0,
-              "offset": 58
-            },
-            "end": {
-              "line": 14,
-              "column": 1,
-              "offset": 138
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 8,
-                "column": 6,
-                "offset": 64
-              },
-              "end": {
-                "line": 8,
-                "column": 17,
-                "offset": 75
-              }
-            },
-            "name": "HelperTrait"
-          },
-          "body": [
-            {
-              "kind": "method",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 10,
-                  "column": 4,
-                  "offset": 82
-                },
-                "end": {
-                  "line": 13,
-                  "column": 5,
-                  "offset": 136
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 10,
-                    "column": 20,
-                    "offset": 98
-                  },
-                  "end": {
-                    "line": 10,
-                    "column": 26,
-                    "offset": 104
-                  }
-                },
-                "name": "helper"
-              },
-              "arguments": [],
-              "byref": false,
-              "type": null,
-              "nullable": false,
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 11,
-                    "column": 4,
-                    "offset": 111
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 5,
-                    "offset": 136
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 12,
-                        "column": 8,
-                        "offset": 121
-                      },
-                      "end": {
-                        "line": 12,
-                        "column": 17,
-                        "offset": 130
-                      }
-                    },
-                    "expr": {
-                      "kind": "number",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 12,
-                          "column": 15,
-                          "offset": 128
-                        },
-                        "end": {
-                          "line": 12,
-                          "column": 16,
-                          "offset": 129
-                        }
-                      },
-                      "value": "1"
-                    }
-                  }
-                ]
-              },
-              "attrGroups": [],
-              "isAbstract": false,
-              "isFinal": false,
-              "isReadonly": false,
-              "visibility": "public",
-              "isStatic": false
-            }
-          ]
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
         }
       },
       "loc": {
@@ -1175,7 +424,7 @@
           "line": 14,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
       }
     },
     {
@@ -1193,24 +442,7 @@
               "line": 16,
               "column": 14
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-          },
-          "origin": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 16,
-                "column": 9,
-                "offset": 149
-              },
-              "end": {
-                "line": 16,
-                "column": 13,
-                "offset": 153
-              }
-            },
-            "name": "demo"
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
           }
         },
         "loc": {
@@ -1222,7 +454,7 @@
             "line": 16,
             "column": 14
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
         }
       },
       "parameters": [],
@@ -1249,25 +481,7 @@
                     "line": 18,
                     "column": 14
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                },
-                "origin": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 18,
-                      "column": 11,
-                      "offset": 169
-                    },
-                    "end": {
-                      "line": 18,
-                      "column": 13,
-                      "offset": 171
-                    }
-                  },
-                  "name": "a",
-                  "curly": false
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "loc": {
@@ -1279,7 +493,7 @@
                   "line": 18,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "init": null,
@@ -1290,6 +504,7 @@
               "_meta": {}
             },
             "_meta": {
+              "storage": "global",
               "loc": {
                 "start": {
                   "line": 18,
@@ -1299,27 +514,8 @@
                   "line": 18,
                   "column": 14
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-              },
-              "origin": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 18,
-                    "column": 11,
-                    "offset": 169
-                  },
-                  "end": {
-                    "line": 18,
-                    "column": 13,
-                    "offset": 171
-                  }
-                },
-                "name": "a",
-                "curly": false
-              },
-              "storage": "global"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+              }
             },
             "loc": {
               "start": {
@@ -1330,7 +526,7 @@
                 "line": 18,
                 "column": 14
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           {
@@ -1348,25 +544,7 @@
                     "line": 18,
                     "column": 18
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                },
-                "origin": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 18,
-                      "column": 15,
-                      "offset": 173
-                    },
-                    "end": {
-                      "line": 18,
-                      "column": 17,
-                      "offset": 175
-                    }
-                  },
-                  "name": "b",
-                  "curly": false
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "loc": {
@@ -1378,7 +556,7 @@
                   "line": 18,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "init": null,
@@ -1389,6 +567,7 @@
               "_meta": {}
             },
             "_meta": {
+              "storage": "global",
               "loc": {
                 "start": {
                   "line": 18,
@@ -1398,27 +577,8 @@
                   "line": 18,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-              },
-              "origin": {
-                "kind": "variable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 18,
-                    "column": 15,
-                    "offset": 173
-                  },
-                  "end": {
-                    "line": 18,
-                    "column": 17,
-                    "offset": 175
-                  }
-                },
-                "name": "b",
-                "curly": false
-              },
-              "storage": "global"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+              }
             },
             "loc": {
               "start": {
@@ -1429,7 +589,7 @@
                 "line": 18,
                 "column": 18
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           {
@@ -1447,25 +607,7 @@
                     "line": 19,
                     "column": 18
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                },
-                "origin": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 19,
-                      "column": 11,
-                      "offset": 188
-                    },
-                    "end": {
-                      "line": 19,
-                      "column": 17,
-                      "offset": 194
-                    }
-                  },
-                  "name": "cache",
-                  "curly": false
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "loc": {
@@ -1477,7 +619,7 @@
                   "line": 19,
                   "column": 18
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "init": {
@@ -1494,24 +636,7 @@
                     "line": 19,
                     "column": 22
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                },
-                "origin": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 19,
-                      "column": 20,
-                      "offset": 197
-                    },
-                    "end": {
-                      "line": 19,
-                      "column": 21,
-                      "offset": 198
-                    }
-                  },
-                  "value": "1"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "loc": {
@@ -1523,7 +648,7 @@
                   "line": 19,
                   "column": 22
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "cloned": false,
@@ -1533,6 +658,7 @@
               "_meta": {}
             },
             "_meta": {
+              "storage": "static",
               "loc": {
                 "start": {
                   "line": 19,
@@ -1542,60 +668,8 @@
                   "line": 19,
                   "column": 22
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-              },
-              "origin": {
-                "kind": "staticvariable",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 19,
-                    "column": 11,
-                    "offset": 188
-                  },
-                  "end": {
-                    "line": 19,
-                    "column": 21,
-                    "offset": 198
-                  }
-                },
-                "variable": {
-                  "kind": "variable",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 19,
-                      "column": 11,
-                      "offset": 188
-                    },
-                    "end": {
-                      "line": 19,
-                      "column": 17,
-                      "offset": 194
-                    }
-                  },
-                  "name": "cache",
-                  "curly": false
-                },
-                "defaultValue": {
-                  "kind": "number",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 19,
-                      "column": 20,
-                      "offset": 197
-                    },
-                    "end": {
-                      "line": 19,
-                      "column": 21,
-                      "offset": 198
-                    }
-                  },
-                  "value": "1"
-                }
-              },
-              "storage": "static"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+              }
             },
             "loc": {
               "start": {
@@ -1606,21 +680,35 @@
                 "line": 19,
                 "column": 22
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           {
-            "type": "CallExpression",
-            "callee": {
-              "type": "Identifier",
-              "name": "unset",
-              "_meta": {}
-            },
-            "arguments": [
-              {
+            "type": "ExpressionStatement",
+            "expression": {
+              "type": "CallExpression",
+              "callee": {
                 "type": "Identifier",
-                "name": "a",
-                "_meta": {
+                "name": "unset",
+                "_meta": {}
+              },
+              "arguments": [
+                {
+                  "type": "Identifier",
+                  "name": "a",
+                  "_meta": {
+                    "loc": {
+                      "start": {
+                        "line": 20,
+                        "column": 11
+                      },
+                      "end": {
+                        "line": 20,
+                        "column": 13
+                      },
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                    }
+                  },
                   "loc": {
                     "start": {
                       "line": 20,
@@ -1630,43 +718,25 @@
                       "line": 20,
                       "column": 13
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                  },
-                  "origin": {
-                    "kind": "variable",
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                  }
+                },
+                {
+                  "type": "Identifier",
+                  "name": "b",
+                  "_meta": {
                     "loc": {
-                      "source": null,
                       "start": {
                         "line": 20,
-                        "column": 10,
-                        "offset": 210
+                        "column": 15
                       },
                       "end": {
                         "line": 20,
-                        "column": 12,
-                        "offset": 212
-                      }
-                    },
-                    "name": "a",
-                    "curly": false
-                  }
-                },
-                "loc": {
-                  "start": {
-                    "line": 20,
-                    "column": 11
+                        "column": 17
+                      },
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+                    }
                   },
-                  "end": {
-                    "line": 20,
-                    "column": 13
-                  },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                }
-              },
-              {
-                "type": "Identifier",
-                "name": "b",
-                "_meta": {
                   "loc": {
                     "start": {
                       "line": 20,
@@ -1676,42 +746,23 @@
                       "line": 20,
                       "column": 17
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                  },
-                  "origin": {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 14,
-                        "offset": 214
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 16,
-                        "offset": 216
-                      }
-                    },
-                    "name": "b",
-                    "curly": false
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                   }
-                },
+                }
+              ],
+              "_meta": {
                 "loc": {
                   "start": {
                     "line": 20,
-                    "column": 15
+                    "column": 5
                   },
                   "end": {
                     "line": 20,
-                    "column": 17
+                    "column": 19
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                 }
-              }
-            ],
-            "_meta": {
-              "synthetic": true,
+              },
               "loc": {
                 "start": {
                   "line": 20,
@@ -1721,61 +772,20 @@
                   "line": 20,
                   "column": 19
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-              },
-              "origin": {
-                "kind": "unset",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 20,
-                    "column": 4,
-                    "offset": 204
-                  },
-                  "end": {
-                    "line": 20,
-                    "column": 18,
-                    "offset": 218
-                  }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
+              }
+            },
+            "_meta": {
+              "loc": {
+                "start": {
+                  "line": 20,
+                  "column": 5
                 },
-                "variables": [
-                  {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 10,
-                        "offset": 210
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 12,
-                        "offset": 212
-                      }
-                    },
-                    "name": "a",
-                    "curly": false
-                  },
-                  {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 14,
-                        "offset": 214
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 16,
-                        "offset": 216
-                      }
-                    },
-                    "name": "b",
-                    "curly": false
-                  }
-                ]
+                "end": {
+                  "line": 20,
+                  "column": 19
+                },
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "loc": {
@@ -1787,7 +797,7 @@
                 "line": 20,
                 "column": 19
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           {
@@ -1810,25 +820,7 @@
                           "line": 22,
                           "column": 8
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                      },
-                      "origin": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 22,
-                            "column": 5,
-                            "offset": 225
-                          },
-                          "end": {
-                            "line": 22,
-                            "column": 7,
-                            "offset": 227
-                          }
-                        },
-                        "name": "x",
-                        "curly": false
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                       }
                     },
                     "loc": {
@@ -1840,7 +832,7 @@
                         "line": 22,
                         "column": 8
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   {
@@ -1856,25 +848,7 @@
                           "line": 22,
                           "column": 12
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                      },
-                      "origin": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 22,
-                            "column": 9,
-                            "offset": 229
-                          },
-                          "end": {
-                            "line": 22,
-                            "column": 11,
-                            "offset": 231
-                          }
-                        },
-                        "name": "y",
-                        "curly": false
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                       }
                     },
                     "loc": {
@@ -1886,12 +860,11 @@
                         "line": 22,
                         "column": 12
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   }
                 ],
                 "_meta": {
-                  "shortForm": true,
                   "loc": {
                     "start": {
                       "line": 22,
@@ -1901,100 +874,7 @@
                       "line": 22,
                       "column": 13
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                  },
-                  "origin": {
-                    "kind": "list",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 4,
-                        "offset": 224
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 12,
-                        "offset": 232
-                      }
-                    },
-                    "items": [
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 22,
-                            "column": 5,
-                            "offset": 225
-                          },
-                          "end": {
-                            "line": 22,
-                            "column": 7,
-                            "offset": 227
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 22,
-                              "column": 5,
-                              "offset": 225
-                            },
-                            "end": {
-                              "line": 22,
-                              "column": 7,
-                              "offset": 227
-                            }
-                          },
-                          "name": "x",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      },
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 22,
-                            "column": 9,
-                            "offset": 229
-                          },
-                          "end": {
-                            "line": 22,
-                            "column": 11,
-                            "offset": 231
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 22,
-                              "column": 9,
-                              "offset": 229
-                            },
-                            "end": {
-                              "line": 22,
-                              "column": 11,
-                              "offset": 231
-                            }
-                          },
-                          "name": "y",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      }
-                    ],
-                    "shortForm": true
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "loc": {
@@ -2006,7 +886,7 @@
                     "line": 22,
                     "column": 13
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "right": {
@@ -2024,25 +904,7 @@
                         "line": 22,
                         "column": 19
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                    },
-                    "origin": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 22,
-                          "column": 15,
-                          "offset": 235
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 18,
-                          "offset": 238
-                        }
-                      },
-                      "name": "foo",
-                      "resolution": "uqn"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "loc": {
@@ -2054,7 +916,7 @@
                       "line": 22,
                       "column": 19
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "arguments": [],
@@ -2068,42 +930,7 @@
                       "line": 22,
                       "column": 21
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                  },
-                  "origin": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 15,
-                        "offset": 235
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 20,
-                        "offset": 240
-                      }
-                    },
-                    "what": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 22,
-                          "column": 15,
-                          "offset": 235
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 18,
-                          "offset": 238
-                        }
-                      },
-                      "name": "foo",
-                      "resolution": "uqn"
-                    },
-                    "arguments": []
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "loc": {
@@ -2115,7 +942,7 @@
                     "line": 22,
                     "column": 21
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "operator": "=",
@@ -2128,154 +955,9 @@
                   },
                   "end": {
                     "line": 22,
-                    "column": 22
+                    "column": 21
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                },
-                "origin": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 22,
-                      "column": 4,
-                      "offset": 224
-                    },
-                    "end": {
-                      "line": 22,
-                      "column": 21,
-                      "offset": 241
-                    }
-                  },
-                  "left": {
-                    "kind": "list",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 4,
-                        "offset": 224
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 12,
-                        "offset": 232
-                      }
-                    },
-                    "items": [
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 22,
-                            "column": 5,
-                            "offset": 225
-                          },
-                          "end": {
-                            "line": 22,
-                            "column": 7,
-                            "offset": 227
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 22,
-                              "column": 5,
-                              "offset": 225
-                            },
-                            "end": {
-                              "line": 22,
-                              "column": 7,
-                              "offset": 227
-                            }
-                          },
-                          "name": "x",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      },
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 22,
-                            "column": 9,
-                            "offset": 229
-                          },
-                          "end": {
-                            "line": 22,
-                            "column": 11,
-                            "offset": 231
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 22,
-                              "column": 9,
-                              "offset": 229
-                            },
-                            "end": {
-                              "line": 22,
-                              "column": 11,
-                              "offset": 231
-                            }
-                          },
-                          "name": "y",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      }
-                    ],
-                    "shortForm": true
-                  },
-                  "right": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 15,
-                        "offset": 235
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 20,
-                        "offset": 240
-                      }
-                    },
-                    "what": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 22,
-                          "column": 15,
-                          "offset": 235
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 18,
-                          "offset": 238
-                        }
-                      },
-                      "name": "foo",
-                      "resolution": "uqn"
-                    },
-                    "arguments": []
-                  },
-                  "operator": "="
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "loc": {
@@ -2285,9 +967,9 @@
                 },
                 "end": {
                   "line": 22,
-                  "column": 22
+                  "column": 21
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "_meta": {
@@ -2300,168 +982,7 @@
                   "line": 22,
                   "column": 22
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-              },
-              "origin": {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 22,
-                    "column": 4,
-                    "offset": 224
-                  },
-                  "end": {
-                    "line": 22,
-                    "column": 21,
-                    "offset": 241
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 22,
-                      "column": 4,
-                      "offset": 224
-                    },
-                    "end": {
-                      "line": 22,
-                      "column": 21,
-                      "offset": 241
-                    }
-                  },
-                  "left": {
-                    "kind": "list",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 4,
-                        "offset": 224
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 12,
-                        "offset": 232
-                      }
-                    },
-                    "items": [
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 22,
-                            "column": 5,
-                            "offset": 225
-                          },
-                          "end": {
-                            "line": 22,
-                            "column": 7,
-                            "offset": 227
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 22,
-                              "column": 5,
-                              "offset": 225
-                            },
-                            "end": {
-                              "line": 22,
-                              "column": 7,
-                              "offset": 227
-                            }
-                          },
-                          "name": "x",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      },
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 22,
-                            "column": 9,
-                            "offset": 229
-                          },
-                          "end": {
-                            "line": 22,
-                            "column": 11,
-                            "offset": 231
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 22,
-                              "column": 9,
-                              "offset": 229
-                            },
-                            "end": {
-                              "line": 22,
-                              "column": 11,
-                              "offset": 231
-                            }
-                          },
-                          "name": "y",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      }
-                    ],
-                    "shortForm": true
-                  },
-                  "right": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 15,
-                        "offset": 235
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 20,
-                        "offset": 240
-                      }
-                    },
-                    "what": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 22,
-                          "column": 15,
-                          "offset": 235
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 18,
-                          "offset": 238
-                        }
-                      },
-                      "name": "foo",
-                      "resolution": "uqn"
-                    },
-                    "arguments": []
-                  },
-                  "operator": "="
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "loc": {
@@ -2473,7 +994,7 @@
                 "line": 22,
                 "column": 22
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           {
@@ -2496,25 +1017,7 @@
                           "line": 23,
                           "column": 12
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                      },
-                      "origin": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 23,
-                            "column": 9,
-                            "offset": 251
-                          },
-                          "end": {
-                            "line": 23,
-                            "column": 11,
-                            "offset": 253
-                          }
-                        },
-                        "name": "m",
-                        "curly": false
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                       }
                     },
                     "loc": {
@@ -2526,7 +1029,7 @@
                         "line": 23,
                         "column": 12
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   {
@@ -2542,25 +1045,7 @@
                           "line": 23,
                           "column": 16
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                      },
-                      "origin": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 23,
-                            "column": 13,
-                            "offset": 255
-                          },
-                          "end": {
-                            "line": 23,
-                            "column": 15,
-                            "offset": 257
-                          }
-                        },
-                        "name": "n",
-                        "curly": false
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                       }
                     },
                     "loc": {
@@ -2572,12 +1057,11 @@
                         "line": 23,
                         "column": 16
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   }
                 ],
                 "_meta": {
-                  "shortForm": false,
                   "loc": {
                     "start": {
                       "line": 23,
@@ -2587,100 +1071,7 @@
                       "line": 23,
                       "column": 17
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                  },
-                  "origin": {
-                    "kind": "list",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 4,
-                        "offset": 246
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 16,
-                        "offset": 258
-                      }
-                    },
-                    "items": [
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 23,
-                            "column": 9,
-                            "offset": 251
-                          },
-                          "end": {
-                            "line": 23,
-                            "column": 11,
-                            "offset": 253
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 23,
-                              "column": 9,
-                              "offset": 251
-                            },
-                            "end": {
-                              "line": 23,
-                              "column": 11,
-                              "offset": 253
-                            }
-                          },
-                          "name": "m",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      },
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 23,
-                            "column": 13,
-                            "offset": 255
-                          },
-                          "end": {
-                            "line": 23,
-                            "column": 15,
-                            "offset": 257
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 23,
-                              "column": 13,
-                              "offset": 255
-                            },
-                            "end": {
-                              "line": 23,
-                              "column": 15,
-                              "offset": 257
-                            }
-                          },
-                          "name": "n",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      }
-                    ],
-                    "shortForm": false
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "loc": {
@@ -2692,7 +1083,7 @@
                     "line": 23,
                     "column": 17
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "right": {
@@ -2710,25 +1101,7 @@
                         "line": 23,
                         "column": 23
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                    },
-                    "origin": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 23,
-                          "column": 19,
-                          "offset": 261
-                        },
-                        "end": {
-                          "line": 23,
-                          "column": 22,
-                          "offset": 264
-                        }
-                      },
-                      "name": "bar",
-                      "resolution": "uqn"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "loc": {
@@ -2740,7 +1113,7 @@
                       "line": 23,
                       "column": 23
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "arguments": [],
@@ -2754,42 +1127,7 @@
                       "line": 23,
                       "column": 25
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                  },
-                  "origin": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 19,
-                        "offset": 261
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 24,
-                        "offset": 266
-                      }
-                    },
-                    "what": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 23,
-                          "column": 19,
-                          "offset": 261
-                        },
-                        "end": {
-                          "line": 23,
-                          "column": 22,
-                          "offset": 264
-                        }
-                      },
-                      "name": "bar",
-                      "resolution": "uqn"
-                    },
-                    "arguments": []
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 "loc": {
@@ -2801,7 +1139,7 @@
                     "line": 23,
                     "column": 25
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "operator": "=",
@@ -2814,154 +1152,9 @@
                   },
                   "end": {
                     "line": 23,
-                    "column": 26
+                    "column": 25
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                },
-                "origin": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 23,
-                      "column": 4,
-                      "offset": 246
-                    },
-                    "end": {
-                      "line": 23,
-                      "column": 25,
-                      "offset": 267
-                    }
-                  },
-                  "left": {
-                    "kind": "list",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 4,
-                        "offset": 246
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 16,
-                        "offset": 258
-                      }
-                    },
-                    "items": [
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 23,
-                            "column": 9,
-                            "offset": 251
-                          },
-                          "end": {
-                            "line": 23,
-                            "column": 11,
-                            "offset": 253
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 23,
-                              "column": 9,
-                              "offset": 251
-                            },
-                            "end": {
-                              "line": 23,
-                              "column": 11,
-                              "offset": 253
-                            }
-                          },
-                          "name": "m",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      },
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 23,
-                            "column": 13,
-                            "offset": 255
-                          },
-                          "end": {
-                            "line": 23,
-                            "column": 15,
-                            "offset": 257
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 23,
-                              "column": 13,
-                              "offset": 255
-                            },
-                            "end": {
-                              "line": 23,
-                              "column": 15,
-                              "offset": 257
-                            }
-                          },
-                          "name": "n",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      }
-                    ],
-                    "shortForm": false
-                  },
-                  "right": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 19,
-                        "offset": 261
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 24,
-                        "offset": 266
-                      }
-                    },
-                    "what": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 23,
-                          "column": 19,
-                          "offset": 261
-                        },
-                        "end": {
-                          "line": 23,
-                          "column": 22,
-                          "offset": 264
-                        }
-                      },
-                      "name": "bar",
-                      "resolution": "uqn"
-                    },
-                    "arguments": []
-                  },
-                  "operator": "="
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "loc": {
@@ -2971,9 +1164,9 @@
                 },
                 "end": {
                   "line": 23,
-                  "column": 26
+                  "column": 25
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "_meta": {
@@ -2986,168 +1179,7 @@
                   "line": 23,
                   "column": 26
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-              },
-              "origin": {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 23,
-                    "column": 4,
-                    "offset": 246
-                  },
-                  "end": {
-                    "line": 23,
-                    "column": 25,
-                    "offset": 267
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 23,
-                      "column": 4,
-                      "offset": 246
-                    },
-                    "end": {
-                      "line": 23,
-                      "column": 25,
-                      "offset": 267
-                    }
-                  },
-                  "left": {
-                    "kind": "list",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 4,
-                        "offset": 246
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 16,
-                        "offset": 258
-                      }
-                    },
-                    "items": [
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 23,
-                            "column": 9,
-                            "offset": 251
-                          },
-                          "end": {
-                            "line": 23,
-                            "column": 11,
-                            "offset": 253
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 23,
-                              "column": 9,
-                              "offset": 251
-                            },
-                            "end": {
-                              "line": 23,
-                              "column": 11,
-                              "offset": 253
-                            }
-                          },
-                          "name": "m",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      },
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 23,
-                            "column": 13,
-                            "offset": 255
-                          },
-                          "end": {
-                            "line": 23,
-                            "column": 15,
-                            "offset": 257
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 23,
-                              "column": 13,
-                              "offset": 255
-                            },
-                            "end": {
-                              "line": 23,
-                              "column": 15,
-                              "offset": 257
-                            }
-                          },
-                          "name": "n",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      }
-                    ],
-                    "shortForm": false
-                  },
-                  "right": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 19,
-                        "offset": 261
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 24,
-                        "offset": 266
-                      }
-                    },
-                    "what": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 23,
-                          "column": 19,
-                          "offset": 261
-                        },
-                        "end": {
-                          "line": 23,
-                          "column": 22,
-                          "offset": 264
-                        }
-                      },
-                      "name": "bar",
-                      "resolution": "uqn"
-                    },
-                    "arguments": []
-                  },
-                  "operator": "="
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "loc": {
@@ -3159,7 +1191,7 @@
                 "line": 23,
                 "column": 26
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
             }
           },
           {
@@ -3188,25 +1220,7 @@
                           "line": 25,
                           "column": 15
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                      },
-                      "origin": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 12,
-                            "offset": 281
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 14,
-                            "offset": 283
-                          }
-                        },
-                        "name": "x",
-                        "curly": false
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                       }
                     },
                     "loc": {
@@ -3218,7 +1232,7 @@
                         "line": 25,
                         "column": 15
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "_meta": {
@@ -3231,44 +1245,7 @@
                         "line": 25,
                         "column": 15
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                    },
-                    "origin": {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 12,
-                          "offset": 281
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 14,
-                          "offset": 283
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 12,
-                            "offset": 281
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 14,
-                            "offset": 283
-                          }
-                        },
-                        "name": "x",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "loc": {
@@ -3280,7 +1257,7 @@
                       "line": 25,
                       "column": 15
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 {
@@ -3304,25 +1281,7 @@
                           "line": 25,
                           "column": 19
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                      },
-                      "origin": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 16,
-                            "offset": 285
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 18,
-                            "offset": 287
-                          }
-                        },
-                        "name": "y",
-                        "curly": false
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                       }
                     },
                     "loc": {
@@ -3334,7 +1293,7 @@
                         "line": 25,
                         "column": 19
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "_meta": {
@@ -3347,44 +1306,7 @@
                         "line": 25,
                         "column": 19
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                    },
-                    "origin": {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 16,
-                          "offset": 285
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 18,
-                          "offset": 287
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 16,
-                            "offset": 285
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 18,
-                            "offset": 287
-                          }
-                        },
-                        "name": "y",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "loc": {
@@ -3396,7 +1318,7 @@
                       "line": 25,
                       "column": 19
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 {
@@ -3420,25 +1342,7 @@
                           "line": 25,
                           "column": 23
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                      },
-                      "origin": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 20,
-                            "offset": 289
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 22,
-                            "offset": 291
-                          }
-                        },
-                        "name": "m",
-                        "curly": false
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                       }
                     },
                     "loc": {
@@ -3450,7 +1354,7 @@
                         "line": 25,
                         "column": 23
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "_meta": {
@@ -3463,44 +1367,7 @@
                         "line": 25,
                         "column": 23
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                    },
-                    "origin": {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 20,
-                          "offset": 289
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 22,
-                          "offset": 291
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 20,
-                            "offset": 289
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 22,
-                            "offset": 291
-                          }
-                        },
-                        "name": "m",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "loc": {
@@ -3512,7 +1379,7 @@
                       "line": 25,
                       "column": 23
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 },
                 {
@@ -3536,25 +1403,7 @@
                           "line": 25,
                           "column": 27
                         },
-                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                      },
-                      "origin": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 24,
-                            "offset": 293
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 26,
-                            "offset": 295
-                          }
-                        },
-                        "name": "n",
-                        "curly": false
+                        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                       }
                     },
                     "loc": {
@@ -3566,7 +1415,7 @@
                         "line": 25,
                         "column": 27
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "_meta": {
@@ -3579,44 +1428,7 @@
                         "line": 25,
                         "column": 27
                       },
-                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                    },
-                    "origin": {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 24,
-                          "offset": 293
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 26,
-                          "offset": 295
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 24,
-                            "offset": 293
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 26,
-                            "offset": 295
-                          }
-                        },
-                        "name": "n",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
+                      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                     }
                   },
                   "loc": {
@@ -3628,7 +1440,7 @@
                       "line": 25,
                       "column": 27
                     },
-                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                   }
                 }
               ],
@@ -3644,174 +1456,7 @@
                     "line": 25,
                     "column": 28
                   },
-                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-                },
-                "origin": {
-                  "kind": "array",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 25,
-                      "column": 11,
-                      "offset": 280
-                    },
-                    "end": {
-                      "line": 25,
-                      "column": 27,
-                      "offset": 296
-                    }
-                  },
-                  "items": [
-                    {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 12,
-                          "offset": 281
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 14,
-                          "offset": 283
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 12,
-                            "offset": 281
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 14,
-                            "offset": 283
-                          }
-                        },
-                        "name": "x",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 16,
-                          "offset": 285
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 18,
-                          "offset": 287
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 16,
-                            "offset": 285
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 18,
-                            "offset": 287
-                          }
-                        },
-                        "name": "y",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 20,
-                          "offset": 289
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 22,
-                          "offset": 291
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 20,
-                            "offset": 289
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 22,
-                            "offset": 291
-                          }
-                        },
-                        "name": "m",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 24,
-                          "offset": 293
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 26,
-                          "offset": 295
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 24,
-                            "offset": 293
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 26,
-                            "offset": 295
-                          }
-                        },
-                        "name": "n",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    }
-                  ],
-                  "shortForm": true
+                  "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
                 }
               },
               "loc": {
@@ -3823,7 +1468,7 @@
                   "line": 25,
                   "column": 28
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "isYield": false,
@@ -3837,190 +1482,7 @@
                   "line": 25,
                   "column": 29
                 },
-                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-              },
-              "origin": {
-                "kind": "return",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 25,
-                    "column": 4,
-                    "offset": 273
-                  },
-                  "end": {
-                    "line": 25,
-                    "column": 28,
-                    "offset": 297
-                  }
-                },
-                "expr": {
-                  "kind": "array",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 25,
-                      "column": 11,
-                      "offset": 280
-                    },
-                    "end": {
-                      "line": 25,
-                      "column": 27,
-                      "offset": 296
-                    }
-                  },
-                  "items": [
-                    {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 12,
-                          "offset": 281
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 14,
-                          "offset": 283
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 12,
-                            "offset": 281
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 14,
-                            "offset": 283
-                          }
-                        },
-                        "name": "x",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 16,
-                          "offset": 285
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 18,
-                          "offset": 287
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 16,
-                            "offset": 285
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 18,
-                            "offset": 287
-                          }
-                        },
-                        "name": "y",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 20,
-                          "offset": 289
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 22,
-                          "offset": 291
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 20,
-                            "offset": 289
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 22,
-                            "offset": 291
-                          }
-                        },
-                        "name": "m",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 24,
-                          "offset": 293
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 26,
-                          "offset": 295
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 24,
-                            "offset": 293
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 26,
-                            "offset": 295
-                          }
-                        },
-                        "name": "n",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    }
-                  ],
-                  "shortForm": true
-                }
+                "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
               }
             },
             "loc": {
@@ -4032,7 +1494,7 @@
                 "line": 25,
                 "column": 29
               },
-              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+              "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
             }
           }
         ],
@@ -4047,707 +1509,7 @@
               "line": 26,
               "column": 2
             },
-            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-          },
-          "origin": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 17,
-                "column": 0,
-                "offset": 156
-              },
-              "end": {
-                "line": 26,
-                "column": 1,
-                "offset": 299
-              }
-            },
-            "children": [
-              {
-                "kind": "global",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 18,
-                    "column": 4,
-                    "offset": 162
-                  },
-                  "end": {
-                    "line": 18,
-                    "column": 18,
-                    "offset": 176
-                  }
-                },
-                "items": [
-                  {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 18,
-                        "column": 11,
-                        "offset": 169
-                      },
-                      "end": {
-                        "line": 18,
-                        "column": 13,
-                        "offset": 171
-                      }
-                    },
-                    "name": "a",
-                    "curly": false
-                  },
-                  {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 18,
-                        "column": 15,
-                        "offset": 173
-                      },
-                      "end": {
-                        "line": 18,
-                        "column": 17,
-                        "offset": 175
-                      }
-                    },
-                    "name": "b",
-                    "curly": false
-                  }
-                ]
-              },
-              {
-                "kind": "static",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 19,
-                    "column": 4,
-                    "offset": 181
-                  },
-                  "end": {
-                    "line": 19,
-                    "column": 22,
-                    "offset": 199
-                  }
-                },
-                "variables": [
-                  {
-                    "kind": "staticvariable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 19,
-                        "column": 11,
-                        "offset": 188
-                      },
-                      "end": {
-                        "line": 19,
-                        "column": 21,
-                        "offset": 198
-                      }
-                    },
-                    "variable": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 19,
-                          "column": 11,
-                          "offset": 188
-                        },
-                        "end": {
-                          "line": 19,
-                          "column": 17,
-                          "offset": 194
-                        }
-                      },
-                      "name": "cache",
-                      "curly": false
-                    },
-                    "defaultValue": {
-                      "kind": "number",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 19,
-                          "column": 20,
-                          "offset": 197
-                        },
-                        "end": {
-                          "line": 19,
-                          "column": 21,
-                          "offset": 198
-                        }
-                      },
-                      "value": "1"
-                    }
-                  }
-                ]
-              },
-              {
-                "kind": "unset",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 20,
-                    "column": 4,
-                    "offset": 204
-                  },
-                  "end": {
-                    "line": 20,
-                    "column": 18,
-                    "offset": 218
-                  }
-                },
-                "variables": [
-                  {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 10,
-                        "offset": 210
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 12,
-                        "offset": 212
-                      }
-                    },
-                    "name": "a",
-                    "curly": false
-                  },
-                  {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 14,
-                        "offset": 214
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 16,
-                        "offset": 216
-                      }
-                    },
-                    "name": "b",
-                    "curly": false
-                  }
-                ]
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 22,
-                    "column": 4,
-                    "offset": 224
-                  },
-                  "end": {
-                    "line": 22,
-                    "column": 21,
-                    "offset": 241
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 22,
-                      "column": 4,
-                      "offset": 224
-                    },
-                    "end": {
-                      "line": 22,
-                      "column": 21,
-                      "offset": 241
-                    }
-                  },
-                  "left": {
-                    "kind": "list",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 4,
-                        "offset": 224
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 12,
-                        "offset": 232
-                      }
-                    },
-                    "items": [
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 22,
-                            "column": 5,
-                            "offset": 225
-                          },
-                          "end": {
-                            "line": 22,
-                            "column": 7,
-                            "offset": 227
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 22,
-                              "column": 5,
-                              "offset": 225
-                            },
-                            "end": {
-                              "line": 22,
-                              "column": 7,
-                              "offset": 227
-                            }
-                          },
-                          "name": "x",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      },
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 22,
-                            "column": 9,
-                            "offset": 229
-                          },
-                          "end": {
-                            "line": 22,
-                            "column": 11,
-                            "offset": 231
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 22,
-                              "column": 9,
-                              "offset": 229
-                            },
-                            "end": {
-                              "line": 22,
-                              "column": 11,
-                              "offset": 231
-                            }
-                          },
-                          "name": "y",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      }
-                    ],
-                    "shortForm": true
-                  },
-                  "right": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 15,
-                        "offset": 235
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 20,
-                        "offset": 240
-                      }
-                    },
-                    "what": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 22,
-                          "column": 15,
-                          "offset": 235
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 18,
-                          "offset": 238
-                        }
-                      },
-                      "name": "foo",
-                      "resolution": "uqn"
-                    },
-                    "arguments": []
-                  },
-                  "operator": "="
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 23,
-                    "column": 4,
-                    "offset": 246
-                  },
-                  "end": {
-                    "line": 23,
-                    "column": 25,
-                    "offset": 267
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 23,
-                      "column": 4,
-                      "offset": 246
-                    },
-                    "end": {
-                      "line": 23,
-                      "column": 25,
-                      "offset": 267
-                    }
-                  },
-                  "left": {
-                    "kind": "list",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 4,
-                        "offset": 246
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 16,
-                        "offset": 258
-                      }
-                    },
-                    "items": [
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 23,
-                            "column": 9,
-                            "offset": 251
-                          },
-                          "end": {
-                            "line": 23,
-                            "column": 11,
-                            "offset": 253
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 23,
-                              "column": 9,
-                              "offset": 251
-                            },
-                            "end": {
-                              "line": 23,
-                              "column": 11,
-                              "offset": 253
-                            }
-                          },
-                          "name": "m",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      },
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 23,
-                            "column": 13,
-                            "offset": 255
-                          },
-                          "end": {
-                            "line": 23,
-                            "column": 15,
-                            "offset": 257
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 23,
-                              "column": 13,
-                              "offset": 255
-                            },
-                            "end": {
-                              "line": 23,
-                              "column": 15,
-                              "offset": 257
-                            }
-                          },
-                          "name": "n",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      }
-                    ],
-                    "shortForm": false
-                  },
-                  "right": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 19,
-                        "offset": 261
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 24,
-                        "offset": 266
-                      }
-                    },
-                    "what": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 23,
-                          "column": 19,
-                          "offset": 261
-                        },
-                        "end": {
-                          "line": 23,
-                          "column": 22,
-                          "offset": 264
-                        }
-                      },
-                      "name": "bar",
-                      "resolution": "uqn"
-                    },
-                    "arguments": []
-                  },
-                  "operator": "="
-                }
-              },
-              {
-                "kind": "return",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 25,
-                    "column": 4,
-                    "offset": 273
-                  },
-                  "end": {
-                    "line": 25,
-                    "column": 28,
-                    "offset": 297
-                  }
-                },
-                "expr": {
-                  "kind": "array",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 25,
-                      "column": 11,
-                      "offset": 280
-                    },
-                    "end": {
-                      "line": 25,
-                      "column": 27,
-                      "offset": 296
-                    }
-                  },
-                  "items": [
-                    {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 12,
-                          "offset": 281
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 14,
-                          "offset": 283
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 12,
-                            "offset": 281
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 14,
-                            "offset": 283
-                          }
-                        },
-                        "name": "x",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 16,
-                          "offset": 285
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 18,
-                          "offset": 287
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 16,
-                            "offset": 285
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 18,
-                            "offset": 287
-                          }
-                        },
-                        "name": "y",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 20,
-                          "offset": 289
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 22,
-                          "offset": 291
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 20,
-                            "offset": 289
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 22,
-                            "offset": 291
-                          }
-                        },
-                        "name": "m",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 24,
-                          "offset": 293
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 26,
-                          "offset": 295
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 24,
-                            "offset": 293
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 26,
-                            "offset": 295
-                          }
-                        },
-                        "name": "n",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    }
-                  ],
-                  "shortForm": true
-                }
-              }
-            ]
+            "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
           }
         },
         "loc": {
@@ -4759,12 +1521,11 @@
             "line": 26,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
         }
       },
       "modifiers": [],
       "_meta": {
-        "attributes": [],
         "loc": {
           "start": {
             "line": 16,
@@ -4774,745 +1535,7 @@
             "line": 26,
             "column": 2
           },
-          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-        },
-        "origin": {
-          "kind": "function",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 16,
-              "column": 0,
-              "offset": 140
-            },
-            "end": {
-              "line": 26,
-              "column": 1,
-              "offset": 299
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 16,
-                "column": 9,
-                "offset": 149
-              },
-              "end": {
-                "line": 16,
-                "column": 13,
-                "offset": 153
-              }
-            },
-            "name": "demo"
-          },
-          "arguments": [],
-          "byref": false,
-          "type": null,
-          "nullable": false,
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 17,
-                "column": 0,
-                "offset": 156
-              },
-              "end": {
-                "line": 26,
-                "column": 1,
-                "offset": 299
-              }
-            },
-            "children": [
-              {
-                "kind": "global",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 18,
-                    "column": 4,
-                    "offset": 162
-                  },
-                  "end": {
-                    "line": 18,
-                    "column": 18,
-                    "offset": 176
-                  }
-                },
-                "items": [
-                  {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 18,
-                        "column": 11,
-                        "offset": 169
-                      },
-                      "end": {
-                        "line": 18,
-                        "column": 13,
-                        "offset": 171
-                      }
-                    },
-                    "name": "a",
-                    "curly": false
-                  },
-                  {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 18,
-                        "column": 15,
-                        "offset": 173
-                      },
-                      "end": {
-                        "line": 18,
-                        "column": 17,
-                        "offset": 175
-                      }
-                    },
-                    "name": "b",
-                    "curly": false
-                  }
-                ]
-              },
-              {
-                "kind": "static",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 19,
-                    "column": 4,
-                    "offset": 181
-                  },
-                  "end": {
-                    "line": 19,
-                    "column": 22,
-                    "offset": 199
-                  }
-                },
-                "variables": [
-                  {
-                    "kind": "staticvariable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 19,
-                        "column": 11,
-                        "offset": 188
-                      },
-                      "end": {
-                        "line": 19,
-                        "column": 21,
-                        "offset": 198
-                      }
-                    },
-                    "variable": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 19,
-                          "column": 11,
-                          "offset": 188
-                        },
-                        "end": {
-                          "line": 19,
-                          "column": 17,
-                          "offset": 194
-                        }
-                      },
-                      "name": "cache",
-                      "curly": false
-                    },
-                    "defaultValue": {
-                      "kind": "number",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 19,
-                          "column": 20,
-                          "offset": 197
-                        },
-                        "end": {
-                          "line": 19,
-                          "column": 21,
-                          "offset": 198
-                        }
-                      },
-                      "value": "1"
-                    }
-                  }
-                ]
-              },
-              {
-                "kind": "unset",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 20,
-                    "column": 4,
-                    "offset": 204
-                  },
-                  "end": {
-                    "line": 20,
-                    "column": 18,
-                    "offset": 218
-                  }
-                },
-                "variables": [
-                  {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 10,
-                        "offset": 210
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 12,
-                        "offset": 212
-                      }
-                    },
-                    "name": "a",
-                    "curly": false
-                  },
-                  {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 14,
-                        "offset": 214
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 16,
-                        "offset": 216
-                      }
-                    },
-                    "name": "b",
-                    "curly": false
-                  }
-                ]
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 22,
-                    "column": 4,
-                    "offset": 224
-                  },
-                  "end": {
-                    "line": 22,
-                    "column": 21,
-                    "offset": 241
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 22,
-                      "column": 4,
-                      "offset": 224
-                    },
-                    "end": {
-                      "line": 22,
-                      "column": 21,
-                      "offset": 241
-                    }
-                  },
-                  "left": {
-                    "kind": "list",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 4,
-                        "offset": 224
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 12,
-                        "offset": 232
-                      }
-                    },
-                    "items": [
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 22,
-                            "column": 5,
-                            "offset": 225
-                          },
-                          "end": {
-                            "line": 22,
-                            "column": 7,
-                            "offset": 227
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 22,
-                              "column": 5,
-                              "offset": 225
-                            },
-                            "end": {
-                              "line": 22,
-                              "column": 7,
-                              "offset": 227
-                            }
-                          },
-                          "name": "x",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      },
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 22,
-                            "column": 9,
-                            "offset": 229
-                          },
-                          "end": {
-                            "line": 22,
-                            "column": 11,
-                            "offset": 231
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 22,
-                              "column": 9,
-                              "offset": 229
-                            },
-                            "end": {
-                              "line": 22,
-                              "column": 11,
-                              "offset": 231
-                            }
-                          },
-                          "name": "y",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      }
-                    ],
-                    "shortForm": true
-                  },
-                  "right": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 15,
-                        "offset": 235
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 20,
-                        "offset": 240
-                      }
-                    },
-                    "what": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 22,
-                          "column": 15,
-                          "offset": 235
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 18,
-                          "offset": 238
-                        }
-                      },
-                      "name": "foo",
-                      "resolution": "uqn"
-                    },
-                    "arguments": []
-                  },
-                  "operator": "="
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 23,
-                    "column": 4,
-                    "offset": 246
-                  },
-                  "end": {
-                    "line": 23,
-                    "column": 25,
-                    "offset": 267
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 23,
-                      "column": 4,
-                      "offset": 246
-                    },
-                    "end": {
-                      "line": 23,
-                      "column": 25,
-                      "offset": 267
-                    }
-                  },
-                  "left": {
-                    "kind": "list",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 4,
-                        "offset": 246
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 16,
-                        "offset": 258
-                      }
-                    },
-                    "items": [
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 23,
-                            "column": 9,
-                            "offset": 251
-                          },
-                          "end": {
-                            "line": 23,
-                            "column": 11,
-                            "offset": 253
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 23,
-                              "column": 9,
-                              "offset": 251
-                            },
-                            "end": {
-                              "line": 23,
-                              "column": 11,
-                              "offset": 253
-                            }
-                          },
-                          "name": "m",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      },
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 23,
-                            "column": 13,
-                            "offset": 255
-                          },
-                          "end": {
-                            "line": 23,
-                            "column": 15,
-                            "offset": 257
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 23,
-                              "column": 13,
-                              "offset": 255
-                            },
-                            "end": {
-                              "line": 23,
-                              "column": 15,
-                              "offset": 257
-                            }
-                          },
-                          "name": "n",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      }
-                    ],
-                    "shortForm": false
-                  },
-                  "right": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 19,
-                        "offset": 261
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 24,
-                        "offset": 266
-                      }
-                    },
-                    "what": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 23,
-                          "column": 19,
-                          "offset": 261
-                        },
-                        "end": {
-                          "line": 23,
-                          "column": 22,
-                          "offset": 264
-                        }
-                      },
-                      "name": "bar",
-                      "resolution": "uqn"
-                    },
-                    "arguments": []
-                  },
-                  "operator": "="
-                }
-              },
-              {
-                "kind": "return",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 25,
-                    "column": 4,
-                    "offset": 273
-                  },
-                  "end": {
-                    "line": 25,
-                    "column": 28,
-                    "offset": 297
-                  }
-                },
-                "expr": {
-                  "kind": "array",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 25,
-                      "column": 11,
-                      "offset": 280
-                    },
-                    "end": {
-                      "line": 25,
-                      "column": 27,
-                      "offset": 296
-                    }
-                  },
-                  "items": [
-                    {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 12,
-                          "offset": 281
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 14,
-                          "offset": 283
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 12,
-                            "offset": 281
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 14,
-                            "offset": 283
-                          }
-                        },
-                        "name": "x",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 16,
-                          "offset": 285
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 18,
-                          "offset": 287
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 16,
-                            "offset": 285
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 18,
-                            "offset": 287
-                          }
-                        },
-                        "name": "y",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 20,
-                          "offset": 289
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 22,
-                          "offset": 291
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 20,
-                            "offset": 289
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 22,
-                            "offset": 291
-                          }
-                        },
-                        "name": "m",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 24,
-                          "offset": 293
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 26,
-                          "offset": 295
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 24,
-                            "offset": 293
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 26,
-                            "offset": 295
-                          }
-                        },
-                        "name": "n",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    }
-                  ],
-                  "shortForm": true
-                }
-              }
-            ]
-          },
-          "attrGroups": []
+          "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
         }
       },
       "loc": {
@@ -5524,13 +1547,13 @@
           "line": 26,
           "column": 2
         },
-        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+        "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
       }
     }
   ],
   "language": "php",
   "languageVersion": null,
-  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php",
+  "uri": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php",
   "version": "0.0.0",
   "_meta": {
     "loc": {
@@ -5542,1017 +1565,7 @@
         "line": 27,
         "column": 1
       },
-      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
-    },
-    "origin": {
-      "kind": "program",
-      "loc": {
-        "source": null,
-        "start": {
-          "line": 1,
-          "column": 0,
-          "offset": 0
-        },
-        "end": {
-          "line": 27,
-          "column": 0,
-          "offset": 300
-        }
-      },
-      "children": [
-        {
-          "kind": "interface",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 3,
-              "column": 0,
-              "offset": 7
-            },
-            "end": {
-              "line": 6,
-              "column": 1,
-              "offset": 56
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 3,
-                "column": 10,
-                "offset": 17
-              },
-              "end": {
-                "line": 3,
-                "column": 16,
-                "offset": 23
-              }
-            },
-            "name": "Runner"
-          },
-          "extends": null,
-          "body": [
-            {
-              "kind": "method",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 5,
-                  "column": 4,
-                  "offset": 30
-                },
-                "end": {
-                  "line": 5,
-                  "column": 27,
-                  "offset": 53
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 5,
-                    "column": 20,
-                    "offset": 46
-                  },
-                  "end": {
-                    "line": 5,
-                    "column": 23,
-                    "offset": 49
-                  }
-                },
-                "name": "run"
-              },
-              "arguments": [
-                {
-                  "kind": "parameter",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 5,
-                      "column": 24,
-                      "offset": 50
-                    },
-                    "end": {
-                      "line": 5,
-                      "column": 26,
-                      "offset": 52
-                    }
-                  },
-                  "name": {
-                    "kind": "identifier",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 5,
-                        "column": 24,
-                        "offset": 50
-                      },
-                      "end": {
-                        "line": 5,
-                        "column": 26,
-                        "offset": 52
-                      }
-                    },
-                    "name": "x"
-                  },
-                  "value": null,
-                  "type": null,
-                  "byref": false,
-                  "variadic": false,
-                  "readonly": false,
-                  "nullable": false,
-                  "flags": 0,
-                  "attrGroups": []
-                }
-              ],
-              "byref": false,
-              "type": null,
-              "nullable": false,
-              "body": null,
-              "attrGroups": [],
-              "isAbstract": false,
-              "isFinal": false,
-              "isReadonly": false,
-              "visibility": "public",
-              "isStatic": false
-            }
-          ],
-          "attrGroups": []
-        },
-        {
-          "kind": "trait",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 8,
-              "column": 0,
-              "offset": 58
-            },
-            "end": {
-              "line": 14,
-              "column": 1,
-              "offset": 138
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 8,
-                "column": 6,
-                "offset": 64
-              },
-              "end": {
-                "line": 8,
-                "column": 17,
-                "offset": 75
-              }
-            },
-            "name": "HelperTrait"
-          },
-          "body": [
-            {
-              "kind": "method",
-              "loc": {
-                "source": null,
-                "start": {
-                  "line": 10,
-                  "column": 4,
-                  "offset": 82
-                },
-                "end": {
-                  "line": 13,
-                  "column": 5,
-                  "offset": 136
-                }
-              },
-              "name": {
-                "kind": "identifier",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 10,
-                    "column": 20,
-                    "offset": 98
-                  },
-                  "end": {
-                    "line": 10,
-                    "column": 26,
-                    "offset": 104
-                  }
-                },
-                "name": "helper"
-              },
-              "arguments": [],
-              "byref": false,
-              "type": null,
-              "nullable": false,
-              "body": {
-                "kind": "block",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 11,
-                    "column": 4,
-                    "offset": 111
-                  },
-                  "end": {
-                    "line": 13,
-                    "column": 5,
-                    "offset": 136
-                  }
-                },
-                "children": [
-                  {
-                    "kind": "return",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 12,
-                        "column": 8,
-                        "offset": 121
-                      },
-                      "end": {
-                        "line": 12,
-                        "column": 17,
-                        "offset": 130
-                      }
-                    },
-                    "expr": {
-                      "kind": "number",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 12,
-                          "column": 15,
-                          "offset": 128
-                        },
-                        "end": {
-                          "line": 12,
-                          "column": 16,
-                          "offset": 129
-                        }
-                      },
-                      "value": "1"
-                    }
-                  }
-                ]
-              },
-              "attrGroups": [],
-              "isAbstract": false,
-              "isFinal": false,
-              "isReadonly": false,
-              "visibility": "public",
-              "isStatic": false
-            }
-          ]
-        },
-        {
-          "kind": "function",
-          "loc": {
-            "source": null,
-            "start": {
-              "line": 16,
-              "column": 0,
-              "offset": 140
-            },
-            "end": {
-              "line": 26,
-              "column": 1,
-              "offset": 299
-            }
-          },
-          "name": {
-            "kind": "identifier",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 16,
-                "column": 9,
-                "offset": 149
-              },
-              "end": {
-                "line": 16,
-                "column": 13,
-                "offset": 153
-              }
-            },
-            "name": "demo"
-          },
-          "arguments": [],
-          "byref": false,
-          "type": null,
-          "nullable": false,
-          "body": {
-            "kind": "block",
-            "loc": {
-              "source": null,
-              "start": {
-                "line": 17,
-                "column": 0,
-                "offset": 156
-              },
-              "end": {
-                "line": 26,
-                "column": 1,
-                "offset": 299
-              }
-            },
-            "children": [
-              {
-                "kind": "global",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 18,
-                    "column": 4,
-                    "offset": 162
-                  },
-                  "end": {
-                    "line": 18,
-                    "column": 18,
-                    "offset": 176
-                  }
-                },
-                "items": [
-                  {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 18,
-                        "column": 11,
-                        "offset": 169
-                      },
-                      "end": {
-                        "line": 18,
-                        "column": 13,
-                        "offset": 171
-                      }
-                    },
-                    "name": "a",
-                    "curly": false
-                  },
-                  {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 18,
-                        "column": 15,
-                        "offset": 173
-                      },
-                      "end": {
-                        "line": 18,
-                        "column": 17,
-                        "offset": 175
-                      }
-                    },
-                    "name": "b",
-                    "curly": false
-                  }
-                ]
-              },
-              {
-                "kind": "static",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 19,
-                    "column": 4,
-                    "offset": 181
-                  },
-                  "end": {
-                    "line": 19,
-                    "column": 22,
-                    "offset": 199
-                  }
-                },
-                "variables": [
-                  {
-                    "kind": "staticvariable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 19,
-                        "column": 11,
-                        "offset": 188
-                      },
-                      "end": {
-                        "line": 19,
-                        "column": 21,
-                        "offset": 198
-                      }
-                    },
-                    "variable": {
-                      "kind": "variable",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 19,
-                          "column": 11,
-                          "offset": 188
-                        },
-                        "end": {
-                          "line": 19,
-                          "column": 17,
-                          "offset": 194
-                        }
-                      },
-                      "name": "cache",
-                      "curly": false
-                    },
-                    "defaultValue": {
-                      "kind": "number",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 19,
-                          "column": 20,
-                          "offset": 197
-                        },
-                        "end": {
-                          "line": 19,
-                          "column": 21,
-                          "offset": 198
-                        }
-                      },
-                      "value": "1"
-                    }
-                  }
-                ]
-              },
-              {
-                "kind": "unset",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 20,
-                    "column": 4,
-                    "offset": 204
-                  },
-                  "end": {
-                    "line": 20,
-                    "column": 18,
-                    "offset": 218
-                  }
-                },
-                "variables": [
-                  {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 10,
-                        "offset": 210
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 12,
-                        "offset": 212
-                      }
-                    },
-                    "name": "a",
-                    "curly": false
-                  },
-                  {
-                    "kind": "variable",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 20,
-                        "column": 14,
-                        "offset": 214
-                      },
-                      "end": {
-                        "line": 20,
-                        "column": 16,
-                        "offset": 216
-                      }
-                    },
-                    "name": "b",
-                    "curly": false
-                  }
-                ]
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 22,
-                    "column": 4,
-                    "offset": 224
-                  },
-                  "end": {
-                    "line": 22,
-                    "column": 21,
-                    "offset": 241
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 22,
-                      "column": 4,
-                      "offset": 224
-                    },
-                    "end": {
-                      "line": 22,
-                      "column": 21,
-                      "offset": 241
-                    }
-                  },
-                  "left": {
-                    "kind": "list",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 4,
-                        "offset": 224
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 12,
-                        "offset": 232
-                      }
-                    },
-                    "items": [
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 22,
-                            "column": 5,
-                            "offset": 225
-                          },
-                          "end": {
-                            "line": 22,
-                            "column": 7,
-                            "offset": 227
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 22,
-                              "column": 5,
-                              "offset": 225
-                            },
-                            "end": {
-                              "line": 22,
-                              "column": 7,
-                              "offset": 227
-                            }
-                          },
-                          "name": "x",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      },
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 22,
-                            "column": 9,
-                            "offset": 229
-                          },
-                          "end": {
-                            "line": 22,
-                            "column": 11,
-                            "offset": 231
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 22,
-                              "column": 9,
-                              "offset": 229
-                            },
-                            "end": {
-                              "line": 22,
-                              "column": 11,
-                              "offset": 231
-                            }
-                          },
-                          "name": "y",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      }
-                    ],
-                    "shortForm": true
-                  },
-                  "right": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 22,
-                        "column": 15,
-                        "offset": 235
-                      },
-                      "end": {
-                        "line": 22,
-                        "column": 20,
-                        "offset": 240
-                      }
-                    },
-                    "what": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 22,
-                          "column": 15,
-                          "offset": 235
-                        },
-                        "end": {
-                          "line": 22,
-                          "column": 18,
-                          "offset": 238
-                        }
-                      },
-                      "name": "foo",
-                      "resolution": "uqn"
-                    },
-                    "arguments": []
-                  },
-                  "operator": "="
-                }
-              },
-              {
-                "kind": "expressionstatement",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 23,
-                    "column": 4,
-                    "offset": 246
-                  },
-                  "end": {
-                    "line": 23,
-                    "column": 25,
-                    "offset": 267
-                  }
-                },
-                "expression": {
-                  "kind": "assign",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 23,
-                      "column": 4,
-                      "offset": 246
-                    },
-                    "end": {
-                      "line": 23,
-                      "column": 25,
-                      "offset": 267
-                    }
-                  },
-                  "left": {
-                    "kind": "list",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 4,
-                        "offset": 246
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 16,
-                        "offset": 258
-                      }
-                    },
-                    "items": [
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 23,
-                            "column": 9,
-                            "offset": 251
-                          },
-                          "end": {
-                            "line": 23,
-                            "column": 11,
-                            "offset": 253
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 23,
-                              "column": 9,
-                              "offset": 251
-                            },
-                            "end": {
-                              "line": 23,
-                              "column": 11,
-                              "offset": 253
-                            }
-                          },
-                          "name": "m",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      },
-                      {
-                        "kind": "entry",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 23,
-                            "column": 13,
-                            "offset": 255
-                          },
-                          "end": {
-                            "line": 23,
-                            "column": 15,
-                            "offset": 257
-                          }
-                        },
-                        "key": null,
-                        "value": {
-                          "kind": "variable",
-                          "loc": {
-                            "source": null,
-                            "start": {
-                              "line": 23,
-                              "column": 13,
-                              "offset": 255
-                            },
-                            "end": {
-                              "line": 23,
-                              "column": 15,
-                              "offset": 257
-                            }
-                          },
-                          "name": "n",
-                          "curly": false
-                        },
-                        "byRef": false,
-                        "unpack": false
-                      }
-                    ],
-                    "shortForm": false
-                  },
-                  "right": {
-                    "kind": "call",
-                    "loc": {
-                      "source": null,
-                      "start": {
-                        "line": 23,
-                        "column": 19,
-                        "offset": 261
-                      },
-                      "end": {
-                        "line": 23,
-                        "column": 24,
-                        "offset": 266
-                      }
-                    },
-                    "what": {
-                      "kind": "name",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 23,
-                          "column": 19,
-                          "offset": 261
-                        },
-                        "end": {
-                          "line": 23,
-                          "column": 22,
-                          "offset": 264
-                        }
-                      },
-                      "name": "bar",
-                      "resolution": "uqn"
-                    },
-                    "arguments": []
-                  },
-                  "operator": "="
-                }
-              },
-              {
-                "kind": "return",
-                "loc": {
-                  "source": null,
-                  "start": {
-                    "line": 25,
-                    "column": 4,
-                    "offset": 273
-                  },
-                  "end": {
-                    "line": 25,
-                    "column": 28,
-                    "offset": 297
-                  }
-                },
-                "expr": {
-                  "kind": "array",
-                  "loc": {
-                    "source": null,
-                    "start": {
-                      "line": 25,
-                      "column": 11,
-                      "offset": 280
-                    },
-                    "end": {
-                      "line": 25,
-                      "column": 27,
-                      "offset": 296
-                    }
-                  },
-                  "items": [
-                    {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 12,
-                          "offset": 281
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 14,
-                          "offset": 283
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 12,
-                            "offset": 281
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 14,
-                            "offset": 283
-                          }
-                        },
-                        "name": "x",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 16,
-                          "offset": 285
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 18,
-                          "offset": 287
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 16,
-                            "offset": 285
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 18,
-                            "offset": 287
-                          }
-                        },
-                        "name": "y",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 20,
-                          "offset": 289
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 22,
-                          "offset": 291
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 20,
-                            "offset": 289
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 22,
-                            "offset": 291
-                          }
-                        },
-                        "name": "m",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    },
-                    {
-                      "kind": "entry",
-                      "loc": {
-                        "source": null,
-                        "start": {
-                          "line": 25,
-                          "column": 24,
-                          "offset": 293
-                        },
-                        "end": {
-                          "line": 25,
-                          "column": 26,
-                          "offset": 295
-                        }
-                      },
-                      "key": null,
-                      "value": {
-                        "kind": "variable",
-                        "loc": {
-                          "source": null,
-                          "start": {
-                            "line": 25,
-                            "column": 24,
-                            "offset": 293
-                          },
-                          "end": {
-                            "line": 25,
-                            "column": 26,
-                            "offset": 295
-                          }
-                        },
-                        "name": "n",
-                        "curly": false
-                      },
-                      "byRef": false,
-                      "unpack": false
-                    }
-                  ],
-                  "shortForm": true
-                }
-              }
-            ]
-          },
-          "attrGroups": []
-        }
-      ],
-      "errors": [],
-      "comments": []
+      "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
     }
   },
   "loc": {
@@ -6564,6 +1577,6 @@
       "line": 27,
       "column": 1
     },
-    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST/parser-PHP/tests/benchmark/base/structures.php"
+    "sourcefile": "/Users/jiufo/yasaaaaa/ycrew/YASA-UAST-W1/parser-PHP/tests/benchmark/base/structures.php"
   }
 }

--- a/parser-PHP/tests/index.ts
+++ b/parser-PHP/tests/index.ts
@@ -3,7 +3,7 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import fastGlob from 'fast-glob';
-import { parse } from '../src/parser';
+import { init, parse } from '../src/parser';
 
 function getCurrentVersion(): string {
     return process.env.UAST_VERSION || require('../package.json').version;
@@ -52,14 +52,20 @@ function shouldRefresh(): boolean {
 }
 
 if (shouldRefresh()) {
-    refreshUastJson();
-    process.exit(0);
-}
+    init().then(() => {
+        refreshUastJson();
+        process.exit(0);
+    });
+} else {
 
 describe('benchmark for php', () => {
     const baseDir = path.join(__dirname, 'benchmark', 'base');
     const phpFiles = fastGlob.sync('*.php', { cwd: baseDir });
     const currentVersion = getCurrentVersion();
+
+    before(async () => {
+        await init();
+    });
 
     for (const phpFile of phpFiles) {
         it(phpFile, () => {
@@ -75,3 +81,5 @@ describe('benchmark for php', () => {
         });
     }
 });
+
+} // end else (not refresh)

--- a/parser-PHP/tests/index.ts
+++ b/parser-PHP/tests/index.ts
@@ -41,7 +41,7 @@ function refreshUastJson() {
     for (const file of phpFiles) {
         const fullPath = path.join(baseDir, file);
         const content = fs.readFileSync(fullPath, 'utf8');
-        const ast = parse(content, { sourcefile: fullPath });
+        const ast = parse(content, { sourcefile: file });
         ast.version = currentVersion;
         fs.writeFileSync(`${fullPath}.json`, JSON.stringify(ast, null, 2), 'utf8');
     }
@@ -71,11 +71,11 @@ describe('benchmark for php', () => {
         it(phpFile, () => {
             const fullPath = path.join(baseDir, phpFile);
             const content = fs.readFileSync(fullPath, 'utf8');
-            const actual = parse(content, { sourcefile: fullPath });
+            const actual = parse(content, { sourcefile: phpFile });
             const expected = JSON.parse(fs.readFileSync(`${fullPath}.json`, 'utf8'));
 
-            const actualStr = JSON.stringify(normalizeAst(actual, fullPath, currentVersion), null, 2);
-            const expectedStr = JSON.stringify(normalizeAst(expected, fullPath, currentVersion), null, 2);
+            const actualStr = JSON.stringify(normalizeAst(actual, phpFile, currentVersion), null, 2);
+            const expectedStr = JSON.stringify(normalizeAst(expected, phpFile, currentVersion), null, 2);
 
             assert.strictEqual(actualStr, expectedStr, `UAST mismatch in ${phpFile}`);
         });

--- a/parser-PHP/tests/index.ts
+++ b/parser-PHP/tests/index.ts
@@ -2,6 +2,7 @@ import 'mocha';
 import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
+// @ts-ignore
 import fastGlob from 'fast-glob';
 import { init, parse } from '../src/parser';
 
@@ -42,6 +43,7 @@ function refreshUastJson() {
         const fullPath = path.join(baseDir, file);
         const content = fs.readFileSync(fullPath, 'utf8');
         const ast = parse(content, { sourcefile: file });
+        // @ts-ignore
         ast.version = currentVersion;
         fs.writeFileSync(`${fullPath}.json`, JSON.stringify(ast, null, 2), 'utf8');
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it replaces the core PHP AST source (`php-parser` → `web-tree-sitter`/`tree-sitter-php`) and rewrites most node-to-UAST mapping logic; output shape/locations and runtime initialization/wasm loading may break existing consumers and CI environments.
> 
> **Overview**
> **Replaces the PHP parsing backend** by rewriting `src/parser.ts` to build UAST from `web-tree-sitter` using the `tree-sitter-php` WASM grammar, including new operator mapping and expanded handling for many PHP expressions/statements (calls, member access, nullsafe access, match, loops, try/catch, namespaces/uses, etc.).
> 
> **Adds explicit one-time initialization**: `Parser` now exposes async `init()` and `parser.ts` enforces initialization before `parse()` (throwing if not initialized), with tree cleanup via `tree.delete()`.
> 
> **Updates dependencies/lockfile** to include `web-tree-sitter` and `tree-sitter-php` (and native build deps), keeping `php-parser` listed but no longer used in code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e3597e3085f638399ffe836f1410ffdd4616644. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->