### PR TITLE
fix(spec): AssignmentExpression operator 增补 ES2021 逻辑赋值运算符

### DIFF
--- a/specification/specification.md
+++ b/specification/specification.md
@@ -361,7 +361,7 @@ Aliases: [`Standardized`](#standardized), [`Instruction`](#instruction), [`Expre
 | --- | --- | --- | --- |
 | `left` | LVal |  required | 
 | `right` | Expression |  required | 
-| `operator` | "=" &#124; "^=" &#124; "&=" &#124; "<<=" &#124; ">>=" &#124; ">>>=" &#124; "+=" &#124; "-=" &#124; "*=" &#124; "/=" &#124; "%=" &#124; "&#124;=" &#124; "**=" |  required | 
+| `operator` | "=" &#124; "^=" &#124; "&=" &#124; "<<=" &#124; ">>=" &#124; ">>>=" &#124; "+=" &#124; "-=" &#124; "*=" &#124; "/=" &#124; "%=" &#124; "&#124;=" &#124; "**=" &#124; "&#124;&#124;=" &#124; "&&=" &#124; "??=" |  required | 
 | `cloned` | boolean |  default: null | 
 
 Aliases: [`Standardized`](#standardized), [`Instruction`](#instruction), [`Expression`](#expression)

--- a/specification/src/ast-types/generated/index.ts
+++ b/specification/src/ast-types/generated/index.ts
@@ -296,6 +296,9 @@ export interface AssignmentExpression extends BaseNode {
     | '%='
     | '|='
     | '**='
+    | '||='
+    | '&&='
+    | '??='
   cloned?: boolean | null
 }
 

--- a/specification/src/builders/generated/index.ts
+++ b/specification/src/builders/generated/index.ts
@@ -184,7 +184,10 @@ export function assignmentExpression(
     | '/='
     | '%='
     | '|='
-    | '**=',
+    | '**='
+    | '||='
+    | '&&='
+    | '??=',
   cloned?: boolean | null
 ): t.AssignmentExpression {
   return builder.apply('AssignmentExpression', arguments)

--- a/specification/src/definitions/core.ts
+++ b/specification/src/definitions/core.ts
@@ -460,7 +460,11 @@ export const assignOpValues = [
     '/=',
     '%=',
     '|=',
-    '**='
+    '**=',
+    // ES2021 逻辑赋值运算符
+    '||=',
+    '&&=',
+    '??='
 ] as const
 
 defineType("AssignmentExpression", {


### PR DESCRIPTION
- assignOpValues 增补 ||= / &&= / ??=
- 同步 generated ast-types/builders 类型与 specification.md 文档
- 修复 JS parser 遇逻辑赋值运算符在 spec validate 阶段抛 TypeError 导致分析崩溃

验证: yasa2 验证路径下重跑 yuyanprovider --dumpAllCG exit 0; test-js 383/0; test-egg 239/0; JS 基线无退化