### PR TITLE
fix(uast): 修复 Python 类型节点 ID 序列化

### DIFF
--- a/parser-Python/test/test_compat_keywords.py
+++ b/parser-Python/test/test_compat_keywords.py
@@ -72,6 +72,24 @@ def test_normal_code_unaffected():
     print("  PASS: normal code unaffected")
 
 
+def test_type_node_ids_are_identifiers():
+    """类型节点 ID 应序列化为 Identifier 对象"""
+    code = """def primitive() -> int: pass\ndef array() -> list[str]: pass\ndef mapping() -> dict[str, int]: pass\n"""
+    success, result = _parse_code(code)
+    assert success, "类型注解应成功解析"
+
+    body = result["body"]
+    assert len(body) == 3
+    assert all(node["type"] == "FunctionDefinition" for node in body)
+    return_types = [function["returnType"] for function in body]
+    assert len(return_types) == 3
+    for return_type, expected_type in zip(return_types, ["PrimitiveType", "ArrayType", "MapType"]):
+        assert return_type["type"] == expected_type
+        assert return_type["id"]["type"] == "Identifier"
+        assert return_type["id"]["name"] == expected_type
+    print("  PASS: type node ids are identifiers")
+
+
 def test_real_syntax_error_still_fails():
     """真正的语法错误仍然失败"""
     code = """def foo(\n    pass\n"""
@@ -98,6 +116,7 @@ if __name__ == '__main__':
         test_async_as_function_name,
         test_normal_async_def_unaffected,
         test_normal_code_unaffected,
+        test_type_node_ids_are_identifiers,
         test_real_syntax_error_still_fails,
         test_async_for_with_preserved,
     ]

--- a/parser-Python/uast/asttype_generated.py
+++ b/parser-Python/uast/asttype_generated.py
@@ -55,7 +55,7 @@ class Identifier(BaseNode):
 @dataclass
 class CompileUnit(BaseNode):
     body: List['Instruction']
-    language: TypingLiteral["javascript", "typescript", "java", "golang", "python"]
+    language: TypingLiteral["javascript", "typescript", "java", "golang", "python", "php"]
     uri: str
     version: str
     languageVersion: Optional[Union[int, str, bool]] = None
@@ -178,7 +178,7 @@ class UnaryExpression(BaseNode):
 class AssignmentExpression(BaseNode):
     left: 'LVal'
     right: 'Expression'
-    operator: TypingLiteral["=", "^=", "&=", "<<=", ">>=", ">>>=", "+=", "-=", "*=", "/=", "%=", "|=", "**="]
+    operator: TypingLiteral["=", "^=", "&=", "<<=", ">>=", ">>>=", "+=", "-=", "*=", "/=", "%=", "|=", "**=", "||=", "&&=", "??="]
     cloned: Optional[bool] = None
 
 @dataclass_json
@@ -313,15 +313,15 @@ class PackageDeclaration(BaseNode):
 @dataclass_json
 @dataclass
 class PrimitiveType(BaseNode):
+    id: 'Identifier'
     kind: TypingLiteral["string", "number", "boolean", "null"]
-    id: Optional['Identifier'] = "PrimitiveType"
     typeArguments: Optional[List['Type']] = None
 
 @dataclass_json
 @dataclass
 class ArrayType(BaseNode):
+    id: 'Identifier'
     element: 'Type'
-    id: Optional['Identifier'] = "ArrayType"
     typeArguments: Optional[List['Type']] = None
     size: Optional['Expression'] = None
 
@@ -336,9 +336,9 @@ class PointerType(BaseNode):
 @dataclass_json
 @dataclass
 class MapType(BaseNode):
+    id: 'Identifier'
     keyType: 'Type'
     valueType: 'Type'
-    id: Optional['Identifier'] = "MapType"
     typeArguments: Optional[List['Type']] = None
 
 @dataclass_json

--- a/parser-Python/uast/visitor.py
+++ b/parser-Python/uast/visitor.py
@@ -11,16 +11,32 @@ class UASTTransformer(ast.NodeTransformer):
     def _dynamic_type(self, **kwargs):
         return UNode.DynamicType(UNode.SourceLocation(), UNode.Meta(), **kwargs)
 
+    def _type_identifier(self, name):
+        return UNode.Identifier(UNode.SourceLocation(), UNode.Meta(), name)
+
     def _primitive_type(self, kind, **kwargs):
-        return UNode.PrimitiveType(UNode.SourceLocation(), UNode.Meta(), kind=kind, **kwargs)
+        return UNode.PrimitiveType(
+            UNode.SourceLocation(),
+            UNode.Meta(),
+            id=self._type_identifier("PrimitiveType"),
+            kind=kind,
+            **kwargs,
+        )
 
     def _array_type(self, element=None, **kwargs):
-        return UNode.ArrayType(UNode.SourceLocation(), UNode.Meta(), element=element, **kwargs)
+        return UNode.ArrayType(
+            UNode.SourceLocation(),
+            UNode.Meta(),
+            id=self._type_identifier("ArrayType"),
+            element=element,
+            **kwargs,
+        )
 
     def _map_type(self, key_type=None, value_type=None, **kwargs):
         return UNode.MapType(
             UNode.SourceLocation(),
             UNode.Meta(),
+            id=self._type_identifier("MapType"),
             keyType=key_type,
             valueType=value_type,
             **kwargs,

--- a/specification/scripts/generators/ast-types-python.js
+++ b/specification/scripts/generators/ast-types-python.js
@@ -51,9 +51,9 @@ const LEGACY_DEFAULTS = {
   WhileStatement: { isPostTest: false },
   FunctionDefinition: { id: null, modifiers: null },
   VariableDeclaration: { variableParam: false },
-  PrimitiveType: { id: "PrimitiveType", typeArguments: null },
-  ArrayType: { id: "ArrayType", size: null, typeArguments: null },
-  MapType: { id: "MapType", typeArguments: null },
+  PrimitiveType: { typeArguments: null },
+  ArrayType: { size: null, typeArguments: null },
+  MapType: { typeArguments: null },
   DynamicType: { id: null, typeArguments: null },
   ScopedType: { id: null, scope: null, typeArguments: null },
 };


### PR DESCRIPTION
- 移除类型节点生成器中的字符串 ID 默认值，恢复必填 Identifier 契约
- 为 PrimitiveType、ArrayType 和 MapType 显式构造规范化 Identifier
- 重新生成 Python AST 类型，并覆盖类型注解的 JSON 回归场景